### PR TITLE
Better reporting for terms

### DIFF
--- a/ortac.opam
+++ b/ortac.opam
@@ -33,5 +33,5 @@ depends: [
   "ortac-runtime" {with-test}
 ]
 pin-depends: [
-  [ "gospel.dev" "git+https://github.com/ocaml-gospel/gospel#17b70f214d0334554246445ea325b979fd196c77" ]
+  [ "gospel.dev" "git+https://github.com/ocaml-gospel/gospel#c20197bf097ed777c2b01441fba48f362e9674aa" ]
 ]

--- a/src/core/failure.ml
+++ b/src/core/failure.ml
@@ -1,7 +1,7 @@
 open Ppxlib
 open Builder
 
-let eterm t = Fmt.str "%a" Gospel.Tterm.print_term t |> estring
+let eterm t = estring t
 
 let term_kind kind =
   (match kind with `Pre -> "Pre" | `Post -> "Post" | `XPost -> "XPost")

--- a/src/core/failure.mli
+++ b/src/core/failure.mli
@@ -1,15 +1,14 @@
 open Ppxlib
-open Gospel
 
 val violated :
   [ `Post | `Pre | `XPost ] ->
-  term:Tterm.term ->
+  term:string ->
   register_name:expression ->
   expression
 
 val spec_failure :
   [ `Post | `Pre | `XPost ] ->
-  term:Tterm.term ->
+  term:string ->
   exn:expression ->
   register_name:expression ->
   expression
@@ -20,9 +19,9 @@ val unexpected_exn :
   register_name:expression ->
   expression
 
-val uncaught_checks : term:Tterm.term -> register_name:expression -> expression
+val uncaught_checks : term:string -> register_name:expression -> expression
 
 val unexpected_checks :
-  terms:Tterm.term list -> register_name:expression -> expression
+  terms:string list -> register_name:expression -> expression
 
 val report : register_name:expression -> expression

--- a/src/core/translation.mli
+++ b/src/core/translation.mli
@@ -8,10 +8,15 @@ val returned_pattern : Tast.lb_arg list -> pattern * expression
 val mk_setup : location -> string -> (expression -> expression) * string
 
 val mk_pre_checks :
-  register_name:expression -> Tterm.term list -> expression -> expression
+  register_name:expression ->
+  term_printer:(Tterm.term -> string) ->
+  Tterm.term list ->
+  expression ->
+  expression
 
 val mk_call :
   register_name:expression ->
+  term_printer:(Tterm.term -> string) ->
   pattern ->
   location ->
   label ->
@@ -21,4 +26,8 @@ val mk_call :
   expression
 
 val mk_post_checks :
-  register_name:expression -> Tterm.term list -> expression -> expression
+  register_name:expression ->
+  term_printer:(Tterm.term -> string) ->
+  Tterm.term list ->
+  expression ->
+  expression


### PR DESCRIPTION
This uses the original text written in the specification to report errors.