### PR TITLE
Abstract types for monolith frontend

### DIFF
--- a/src/monolith/generators.ml
+++ b/src/monolith/generators.ml
@@ -53,20 +53,20 @@ let record_generator (rec_decl : Tast.rec_declaration) =
 
 let generator_expr (ty_kind : Tast.type_kind) =
   match ty_kind with
-  | Pty_abstract -> failwith "generator for abstract type not yet implemented"
-  | Pty_variant _constructors ->
-      failwith "generator for variant not yet implemented"
-  | Pty_record rec_decl -> record_generator rec_decl
-  | Pty_open -> failwith "generator for open not yet implemented"
+  | Pty_abstract -> None
+  | Pty_variant _constructors -> None
+  | Pty_record rec_decl -> Some (record_generator rec_decl)
+  | Pty_open -> None
 
 let generator_definition (type_decl : Tast.type_declaration) =
   let id = B.pvar type_decl.td_ts.ts_ident.id_str in
-  let generator = generator_expr type_decl.td_kind in
-  [%stri let [%p id] = [%e generator]]
+  match generator_expr type_decl.td_kind with
+  | None -> None
+  | Some generator -> Some [%stri let [%p id] = [%e generator]]
 
 let generator_option (sig_item : Tast.signature_item) =
   match sig_item.sig_desc with
-  | Tast.Sig_type (_, [ type_decl ], _) -> Some (generator_definition type_decl)
+  | Tast.Sig_type (_, [ type_decl ], _) -> generator_definition type_decl
   | _ -> None
 
 let generators s =

--- a/src/monolith/ortac_monolith.ml
+++ b/src/monolith/ortac_monolith.ml
@@ -80,7 +80,7 @@ let rec translate_ret s =
       [%expr list [%e translate_ret param]]
   | Ptyp_constr ({ txt = Lident "array"; _ }, [ param ]) ->
       [%expr M.deconstructible_array [%e find_printer param]]
-  | Ptyp_constr ({ txt = Lident s; _ }, _) -> B.evar (Printf.sprintf "S.%s" s)
+  | Ptyp_constr ({ txt = Lident ty; _ }, _) -> B.evar (Printf.sprintf "S.%s" ty)
   | _ -> failwith "monolith deconstructible spec not implemented yet"
 
 let rec translate s =
@@ -98,9 +98,7 @@ let rec translate s =
   | Ptyp_arrow (_, x, y) when is_arrow y.ptyp_desc ->
       [%expr [%e translate x] ^> [%e translate y]]
   | Ptyp_arrow (_, x, y) -> [%expr [%e translate x] ^!> [%e translate_ret y]]
-  | Ptyp_constr ({ txt = Lident ty; _ }, _params) ->
-      failwith
-        (Printf.sprintf "spec generator for %s is not yet implemented" ty)
+  | Ptyp_constr ({ txt = Lident ty; _ }, _) -> B.evar (Printf.sprintf "S.%s" ty)
   | _ ->
       failwith
         "monolith constructible spec not implemented yet (from translate)"

--- a/src/monolith/ortac_monolith.ml
+++ b/src/monolith/ortac_monolith.ml
@@ -55,7 +55,7 @@ let is_arrow = function Ptyp_arrow _ -> true | _ -> false
 
 let rec translate_ret s =
   match s.ptyp_desc with
-  | Ptyp_var s -> B.evar s
+  | Ptyp_var _s -> [%expr sequential ()]
   | Ptyp_constr ({ txt = Lident "unit"; _ }, _) -> [%expr unit]
   | Ptyp_constr ({ txt = Lident "int"; _ }, _) -> [%expr int]
   | Ptyp_constr ({ txt = Lident "bool"; _ }, _) -> [%expr bool]
@@ -68,7 +68,7 @@ let rec translate_ret s =
 
 let rec translate s =
   match s.ptyp_desc with
-  | Ptyp_var s -> B.evar s
+  | Ptyp_var _s -> [%expr sequential ()]
   | Ptyp_constr ({ txt = Lident "unit"; _ }, _params) -> [%expr unit]
   | Ptyp_constr ({ txt = Lident "bool"; _ }, _params) -> [%expr bool]
   | Ptyp_constr ({ txt = Lident "char"; _ }, _params) -> [%expr char]

--- a/src/monolith/printers.ml
+++ b/src/monolith/printers.ml
@@ -53,20 +53,20 @@ let record_printer (rec_decl : Tast.rec_declaration) =
 
 let printer_expr (ty_kind : Tast.type_kind) =
   match ty_kind with
-  | Pty_abstract -> failwith "printer for abstract type not yet implemented"
-  | Pty_variant _construtors ->
-      failwith "printer for variant not yet implemented"
-  | Pty_record rec_decl -> record_printer rec_decl
-  | Pty_open -> failwith "printer for open not yet implemented"
+  | Pty_abstract -> None
+  | Pty_variant _construtors -> None
+  | Pty_record rec_decl -> Some (record_printer rec_decl)
+  | Pty_open -> None
 
 let printer_definition (type_decl : Tast.type_declaration) =
   let id = B.pvar type_decl.td_ts.ts_ident.id_str in
-  let printer = printer_expr type_decl.td_kind in
-  [%stri let [%p id] = [%e printer]]
+  match printer_expr type_decl.td_kind with
+  | None -> None
+  | Some printer -> Some [%stri let [%p id] = [%e printer]]
 
 let printer_option (sig_item : Tast.signature_item) =
   match sig_item.sig_desc with
-  | Tast.Sig_type (_, [ type_decl ], _) -> Some (printer_definition type_decl)
+  | Tast.Sig_type (_, [ type_decl ], _) -> printer_definition type_decl
   | _ -> None
 
 let printers s =

--- a/src/monolith/runtime/ortac_runtime_monolith.ml
+++ b/src/monolith/runtime/ortac_runtime_monolith.ml
@@ -6,9 +6,7 @@ let int = ifpol constructible_int int
 
 let positive_int = int_within (Gen.int Int.max_int)
 
-let constructible_array g p =
-  easily_constructible
-    (Monolith.Gen.array (Gen.int Int.max_int) g)
-    (Monolith.Print.array p)
-
-let deconstructible_array p = deconstructible (Monolith.Print.array p)
+let array spec =
+  map_outof Array.of_list
+    (Array.of_list, constant "array froom list")
+    (list spec)

--- a/src/monolith/runtime/ortac_runtime_monolith.mli
+++ b/src/monolith/runtime/ortac_runtime_monolith.mli
@@ -4,10 +4,4 @@ val int : (int, int) Monolith.spec
 
 val positive_int : (int, int) Monolith.spec
 
-val constructible_array :
-  'a Monolith.Gen.gen ->
-  'a Monolith.printer ->
-  ('a array, 'a array) Monolith.spec
-
-val deconstructible_array :
-  'a Monolith.printer -> ('a array, 'a array) Monolith.spec
+val array : ('r, 'c) Monolith.spec -> ('r array, 'c array) Monolith.spec


### PR DESCRIPTION
In this PR, I add support for abstract types in the frontend for `monolith`.

- In presence of an abstract type, it will be declared to `monolith` in the generated file.
- Alpha types are constrained to `int`. This seems a reasonable choice in most of the cases.
- A better array generator is given.