### PR TITLE
Compute mutability of type before processing specifications

### DIFF
--- a/src/core/drv.ml
+++ b/src/core/drv.ml
@@ -62,7 +62,9 @@ let stdlib_types =
         ~mutable_:(Dependant (fun _ -> Mutable))
         ~ghost:false );
     ( [ "Gospelstdlib"; "array" ],
-      type_ ~name:"array" ~loc ~mutable_:Mutable ~ghost:false );
+      type_ ~name:"array" ~loc
+        ~mutable_:(Dependant (fun _ -> Mutable))
+        ~ghost:false );
     ( [ "Gospelstdlib"; "set" ],
       type_ ~name:"set" ~loc
         ~mutable_:(Dependant (function [ m ] -> m | _ -> assert false))

--- a/src/core/drv.ml
+++ b/src/core/drv.ml
@@ -20,6 +20,7 @@ let get_env get ns path =
         path)
 
 let get_ls_env = get_env ns_find_ls
+let get_ts_env = get_env ns_find_ts
 let translate_stdlib ls t = L.find_opt ls t.stdlib
 let add_translation i t = { t with translations = i :: t.translations }
 let add_type ts i t = { t with types = T.add ts i t.types }
@@ -29,6 +30,45 @@ let find_function ls t = L.find ls t.functions
 let is_function ls t = L.mem ls t.functions
 let get_ls t = get_ls_env t.env
 let get_ts t = get_env ns_find_ts t.env
+
+let stdlib_types =
+  let open Translated in
+  let loc = Ppxlib.Location.none in
+  [
+    ([ "unit" ], type_ ~name:"unit" ~loc ~mutable_:Immutable ~ghost:false);
+    ([ "string" ], type_ ~name:"string" ~loc ~mutable_:Immutable ~ghost:false);
+    ([ "char" ], type_ ~name:"char" ~loc ~mutable_:Immutable ~ghost:false);
+    ([ "float" ], type_ ~name:"float" ~loc ~mutable_:Immutable ~ghost:false);
+    ([ "bool" ], type_ ~name:"bool" ~loc ~mutable_:Immutable ~ghost:false);
+    ([ "integer" ], type_ ~name:"integer" ~loc ~mutable_:Immutable ~ghost:false);
+    ( [ "option" ],
+      type_ ~name:"option" ~loc
+        ~mutable_:(Dependant (function [ m ] -> m | _ -> assert false))
+        ~ghost:false );
+    ( [ "list" ],
+      type_ ~name:"list" ~loc
+        ~mutable_:(Dependant (function [ m ] -> m | _ -> assert false))
+        ~ghost:false );
+    ( [ "Gospelstdlib"; "seq" ],
+      type_ ~name:"seq" ~loc
+        ~mutable_:(Dependant (function [ m ] -> m | _ -> assert false))
+        ~ghost:false );
+    ( [ "Gospelstdlib"; "bag" ],
+      type_ ~name:"bag" ~loc
+        ~mutable_:(Dependant (function [ m ] -> m | _ -> assert false))
+        ~ghost:false );
+    ( [ "Gospelstdlib"; "ref" ],
+      type_ ~name:"ref" ~loc
+        ~mutable_:(Dependant (fun _ -> Mutable))
+        ~ghost:false );
+    ( [ "Gospelstdlib"; "array" ],
+      type_ ~name:"array" ~loc ~mutable_:Mutable ~ghost:false );
+    ( [ "Gospelstdlib"; "set" ],
+      type_ ~name:"set" ~loc
+        ~mutable_:(Dependant (function [ m ] -> m | _ -> assert false))
+        ~ghost:false );
+    ([ "int" ], type_ ~name:"int" ~loc ~mutable_:Immutable ~ghost:false);
+  ]
 
 let stdlib =
   [
@@ -69,14 +109,14 @@ let init module_name env =
         L.add ls ocaml acc)
       L.empty stdlib
   in
-  {
-    module_name;
-    stdlib;
-    env;
-    translations = [];
-    types = T.empty;
-    functions = L.empty;
-  }
+  let types =
+    List.fold_left
+      (fun acc (path, type_) ->
+        let ls = get_ts_env env path in
+        T.add ls type_ acc)
+      T.empty stdlib_types
+  in
+  { module_name; stdlib; env; translations = []; types; functions = L.empty }
 
 let map_translation ~f t = List.rev_map f t.translations
 let iter_translation ~f t = List.iter f (List.rev t.translations)

--- a/src/core/translate.ml
+++ b/src/core/translate.ml
@@ -37,12 +37,11 @@ module Mutability = struct
     || lsymbol ~driver rd.rd_cs
 
   let type_declaration ~driver (td : Tast.type_declaration) =
-    (* what about type t = int array ? what kind of type_decalration is it ?*)
+    Option.fold ~none:false ~some:(ty ~driver) td.td_ts.ts_alias
+    ||
     match td.td_kind with
     | Pty_abstract -> false
-    | Pty_variant cdl ->
-        List.exists (constructor_declaration ~driver) cdl
-        (* cdl is empty if defined through a tuple ??? *)
+    | Pty_variant cdl -> List.exists (constructor_declaration ~driver) cdl
     | Pty_record rd -> rec_declaration ~driver rd
     | Pty_open -> false
 end

--- a/src/core/translate.ml
+++ b/src/core/translate.ml
@@ -57,11 +57,7 @@ let type_ ~driver ~ghost (td : Tast.type_declaration) =
   let type_ = type_ ~name ~loc ~mutable_ ~ghost in
   let process ~type_ (spec : Tast.type_spec) =
     let term_printer = Fmt.str "%a" Tterm.print_term in
-    let mutable_ =
-      max
-        (if spec.ty_ephemeral then Translated.Mutable else type_.mutable_)
-        (Mutability.mutable_model ~driver spec.ty_fields)
-    in
+    let mutable_ = Mutability.(max type_.mutable_ (type_spec ~driver spec)) in
     let type_ =
       type_
       |> T.with_models ~driver spec.ty_fields

--- a/src/core/translate.ml
+++ b/src/core/translate.ml
@@ -18,7 +18,7 @@ let type_of_ty ~driver (ty : Ttypes.ty) =
   match ty.ty_node with
   | Tyvar a ->
       Translated.type_ ~name:a.tv_name.id_str ~loc:a.tv_name.id_loc
-        ~mutable_:false ~ghost:false
+        ~mutable_:Translated.Unknown ~ghost:false
   | Tyapp (ts, _tvs) -> (
       match Drv.get_type ts driver with
       | None ->
@@ -58,9 +58,9 @@ let type_ ~driver ~ghost (td : Tast.type_declaration) =
   let process ~type_ (spec : Tast.type_spec) =
     let term_printer = Fmt.str "%a" Tterm.print_term in
     let mutable_ =
-      type_.mutable_
-      || spec.ty_ephemeral
-      || Mutability.mutable_model ~driver spec.ty_fields
+      max
+        (if spec.ty_ephemeral then Translated.Mutable else type_.mutable_)
+        (Mutability.mutable_model ~driver spec.ty_fields)
     in
     let type_ =
       type_

--- a/src/core/translate.ml
+++ b/src/core/translate.ml
@@ -1,55 +1,9 @@
 module W = Warnings
+open Types
 open Ppxlib
 open Gospel
 open Translated
 module T = Translation
-
-module Mutability = struct
-  let known_tysymbol ~driver (ts : Ttypes.tysymbol) =
-    match Drv.get_type ts driver with
-    | None -> false
-    | Some type_ -> type_.mutable_
-
-  let rec ty ~driver (t : Ttypes.ty) =
-    match t.ty_node with
-    | Tyvar _ -> false
-    | Tyapp (ts, tyl) ->
-        (* already known as mutable, an array, a reference or a container of something mutable *)
-        known_tysymbol ~driver ts
-        || Ttypes.ts_equal ts (Drv.get_ts driver [ "Gospelstdlib"; "array" ])
-        || Ttypes.ts_equal ts (Drv.get_ts driver [ "Gospelstdlib"; "ref" ])
-        || List.exists (ty ~driver) tyl
-
-  let lsymbol ~driver (ls : Tterm.lsymbol) =
-    (match ls.ls_value with None -> false | Some t -> ty ~driver t)
-    || List.exists (ty ~driver) ls.ls_args
-
-  let constructor_declaration ~driver (cd : Tast.constructor_decl) =
-    List.exists
-      (fun (ld : (Identifier.Ident.t * Ttypes.ty) Tast.label_declaration) ->
-        ld.ld_mut = Mutable || ty ~driver (snd ld.ld_field))
-      cd.cd_ld
-    || lsymbol ~driver cd.cd_cs
-
-  let rec_declaration ~driver (rd : Tast.rec_declaration) =
-    List.exists
-      (fun (ld : Tterm.lsymbol Tast.label_declaration) ->
-        ld.ld_mut = Mutable || lsymbol ~driver ld.ld_field)
-      rd.rd_ldl
-    || lsymbol ~driver rd.rd_cs
-
-  let type_declaration ~driver (td : Tast.type_declaration) =
-    Option.fold ~none:false ~some:(ty ~driver) td.td_ts.ts_alias
-    ||
-    match td.td_kind with
-    | Pty_abstract -> false
-    | Pty_variant cdl -> List.exists (constructor_declaration ~driver) cdl
-    | Pty_record rd -> rec_declaration ~driver rd
-    | Pty_open -> false
-
-  let mutable_model ~driver (ty_fields : (Tterm.lsymbol * bool) list) =
-    List.exists (fun (ls, b) -> b || lsymbol ~driver ls) ty_fields
-end
 
 let register_name = gen_symbol ~prefix:"__error"
 

--- a/src/core/translated.ml
+++ b/src/core/translated.ml
@@ -1,6 +1,8 @@
 module W = Warnings
 open Ppxlib
 
+type mutability = Unknown | Immutable | Mutable
+
 type term = {
   txt : string;
   loc : Location.t;
@@ -24,7 +26,7 @@ type invariant = {
 type type_ = {
   name : string;
   loc : Location.t;
-  mutable_ : bool;
+  mutable_ : mutability;
   ghost : bool;
   models : (string * bool) list;
   invariants : invariant list;

--- a/src/core/translated.ml
+++ b/src/core/translated.ml
@@ -1,7 +1,11 @@
 module W = Warnings
 open Ppxlib
 
-type mutability = Unknown | Immutable | Mutable
+type mutability =
+  | Unknown
+  | Immutable
+  | Mutable
+  | Dependant of (mutability list -> mutability)
 
 type term = {
   txt : string;

--- a/src/core/types.ml
+++ b/src/core/types.ml
@@ -1,6 +1,13 @@
 open Gospel
 
 module Mutability = struct
+  let max m n =
+    let open Translated in
+    match m with
+    | Mutable -> Mutable
+    | Immutable -> ( match n with Mutable -> Mutable | _ -> Immutable)
+    | Unknown -> n
+
   let known_tysymbol ~driver (ts : Ttypes.tysymbol) =
     Option.fold ~none:Translated.Unknown
       ~some:(fun (t : Translated.type_) -> t.mutable_)

--- a/src/core/types.ml
+++ b/src/core/types.ml
@@ -2,47 +2,65 @@ open Gospel
 
 module Mutability = struct
   let known_tysymbol ~driver (ts : Ttypes.tysymbol) =
-    match Drv.get_type ts driver with
-    | None -> false
-    | Some type_ -> type_.mutable_
+    Option.fold ~none:Translated.Unknown
+      ~some:(fun (t : Translated.type_) -> t.mutable_)
+      (Drv.get_type ts driver)
+
+  let tysymbol ~driver (ts : Ttypes.tysymbol) =
+    max
+      (if
+       Ttypes.ts_equal ts (Drv.get_ts driver [ "Gospelstdlib"; "array" ])
+       || Ttypes.ts_equal ts (Drv.get_ts driver [ "Gospelstdlib"; "ref" ])
+      then Translated.Mutable
+      else Translated.Immutable)
+      (known_tysymbol ~driver ts)
 
   let rec ty ~driver (t : Ttypes.ty) =
     match t.ty_node with
-    | Tyvar _ -> false
+    | Tyvar _ -> Translated.Unknown
     | Tyapp (ts, tyl) ->
-        (* already known as mutable, an array, a reference or a container of something mutable *)
-        known_tysymbol ~driver ts
-        || Ttypes.ts_equal ts (Drv.get_ts driver [ "Gospelstdlib"; "array" ])
-        || Ttypes.ts_equal ts (Drv.get_ts driver [ "Gospelstdlib"; "ref" ])
-        || List.exists (ty ~driver) tyl
+        List.fold_left
+          (fun acc t -> max acc (ty ~driver t))
+          (tysymbol ~driver ts) tyl
 
   let lsymbol ~driver (ls : Tterm.lsymbol) =
-    (match ls.ls_value with None -> false | Some t -> ty ~driver t)
-    || List.exists (ty ~driver) ls.ls_args
+    Option.fold ~none:Translated.Unknown ~some:(ty ~driver) ls.ls_value
+    |> List.fold_right (fun t acc -> max acc (ty ~driver t)) ls.ls_args
+
+  let mutable_flag = function
+    | Tast.Immutable -> Translated.Immutable
+    | Tast.Mutable -> Translated.Mutable
 
   let constructor_declaration ~driver (cd : Tast.constructor_decl) =
-    List.exists
+    List.map
       (fun (ld : (Identifier.Ident.t * Ttypes.ty) Tast.label_declaration) ->
-        ld.ld_mut = Mutable || ty ~driver (snd ld.ld_field))
+        max (mutable_flag ld.ld_mut) (ty ~driver (snd ld.ld_field)))
       cd.cd_ld
-    || lsymbol ~driver cd.cd_cs
+    |> List.fold_left max (lsymbol ~driver cd.cd_cs)
 
   let rec_declaration ~driver (rd : Tast.rec_declaration) =
-    List.exists
+    List.map
       (fun (ld : Tterm.lsymbol Tast.label_declaration) ->
-        ld.ld_mut = Mutable || lsymbol ~driver ld.ld_field)
+        max (mutable_flag ld.ld_mut) (lsymbol ~driver ld.ld_field))
       rd.rd_ldl
-    || lsymbol ~driver rd.rd_cs
+    |> List.fold_left max (lsymbol ~driver rd.rd_cs)
 
   let type_declaration ~driver (td : Tast.type_declaration) =
-    Option.fold ~none:false ~some:(ty ~driver) td.td_ts.ts_alias
-    ||
-    match td.td_kind with
-    | Pty_abstract -> false
-    | Pty_variant cdl -> List.exists (constructor_declaration ~driver) cdl
-    | Pty_record rd -> rec_declaration ~driver rd
-    | Pty_open -> false
+    max
+      (Option.fold ~none:Translated.Unknown ~some:(ty ~driver) td.td_ts.ts_alias)
+      (match td.td_kind with
+      | Pty_abstract -> Translated.Unknown
+      | Pty_variant cdl ->
+          List.map (constructor_declaration ~driver) cdl
+          |> List.fold_left max Translated.Unknown
+      | Pty_record rd -> rec_declaration ~driver rd
+      | Pty_open -> Translated.Unknown)
+
+  let inject_bool = function
+    | true -> Translated.Mutable
+    | false -> Translated.Immutable
 
   let mutable_model ~driver (ty_fields : (Tterm.lsymbol * bool) list) =
-    List.exists (fun (ls, b) -> b || lsymbol ~driver ls) ty_fields
+    List.map (fun (ls, b) -> max (inject_bool b) (lsymbol ~driver ls)) ty_fields
+    |> List.fold_left max Translated.Unknown
 end

--- a/src/core/types.ml
+++ b/src/core/types.ml
@@ -1,0 +1,48 @@
+open Gospel
+
+module Mutability = struct
+  let known_tysymbol ~driver (ts : Ttypes.tysymbol) =
+    match Drv.get_type ts driver with
+    | None -> false
+    | Some type_ -> type_.mutable_
+
+  let rec ty ~driver (t : Ttypes.ty) =
+    match t.ty_node with
+    | Tyvar _ -> false
+    | Tyapp (ts, tyl) ->
+        (* already known as mutable, an array, a reference or a container of something mutable *)
+        known_tysymbol ~driver ts
+        || Ttypes.ts_equal ts (Drv.get_ts driver [ "Gospelstdlib"; "array" ])
+        || Ttypes.ts_equal ts (Drv.get_ts driver [ "Gospelstdlib"; "ref" ])
+        || List.exists (ty ~driver) tyl
+
+  let lsymbol ~driver (ls : Tterm.lsymbol) =
+    (match ls.ls_value with None -> false | Some t -> ty ~driver t)
+    || List.exists (ty ~driver) ls.ls_args
+
+  let constructor_declaration ~driver (cd : Tast.constructor_decl) =
+    List.exists
+      (fun (ld : (Identifier.Ident.t * Ttypes.ty) Tast.label_declaration) ->
+        ld.ld_mut = Mutable || ty ~driver (snd ld.ld_field))
+      cd.cd_ld
+    || lsymbol ~driver cd.cd_cs
+
+  let rec_declaration ~driver (rd : Tast.rec_declaration) =
+    List.exists
+      (fun (ld : Tterm.lsymbol Tast.label_declaration) ->
+        ld.ld_mut = Mutable || lsymbol ~driver ld.ld_field)
+      rd.rd_ldl
+    || lsymbol ~driver rd.rd_cs
+
+  let type_declaration ~driver (td : Tast.type_declaration) =
+    Option.fold ~none:false ~some:(ty ~driver) td.td_ts.ts_alias
+    ||
+    match td.td_kind with
+    | Pty_abstract -> false
+    | Pty_variant cdl -> List.exists (constructor_declaration ~driver) cdl
+    | Pty_record rd -> rec_declaration ~driver rd
+    | Pty_open -> false
+
+  let mutable_model ~driver (ty_fields : (Tterm.lsymbol * bool) list) =
+    List.exists (fun (ls, b) -> b || lsymbol ~driver ls) ty_fields
+end

--- a/src/core/types.ml
+++ b/src/core/types.ml
@@ -12,64 +12,91 @@ module Mutability = struct
   let min_mut = Translated.Immutable
 
   let tysymbol ~driver (ts : Ttypes.tysymbol) =
-    Option.fold ~none:Translated.Unknown
-      ~some:(fun (t : Translated.type_) -> t.mutable_)
-      (Drv.get_type ts driver)
+    (* To determine the mutability of a `tysymbol`, we look in the driver. *)
+    match Drv.get_type ts driver with
+    | None ->
+        (* If the driver doesn't know about this `tysymbol`, the mutability is `Unknown`.
+           Note that of the type is parametric we wait for the instantiation to deliver the
+           information *)
+        if List.length ts.ts_args > 0 then
+          Translated.Dependant (fun _ -> Unknown)
+        else Translated.Unknown
+    | Some t -> t.mutable_
 
   let alpha (ty : Ttypes.ty) =
     match ty.ty_node with Tyvar _ -> true | _ -> false
 
   let rec ty ~driver (t : Ttypes.ty) =
     match t.ty_node with
+    (* A `Tyvar` is an alpha *)
     | Tyvar _ -> Translated.Unknown
     | Tyapp (ts, tyl) when Ttypes.is_ts_tuple ts ->
+        (* The mutability of a tuple is the max of the mutability of its elements *)
         List.map (ty ~driver) tyl |> List.fold_left max min_mut
+    | Tyapp (ts, tyl) when List.length tyl = 0 ->
+        (* If `tyl` is empty, we just look at `ts`. The mutability can't be `Dependant` *)
+        tysymbol ~driver ts
     | Tyapp (ts, tyl) -> (
+        (* It the list is not empty, that means that `ts` is a parametric type and
+           its mutability is `Dependant` *)
         match tysymbol ~driver ts with
-        | Translated.Dependant f as m ->
-            if List.exists alpha tyl (* we still can't determine mutability *)
-            then m
-            else f (List.map (ty ~driver) tyl)
-        | m -> m)
+        | Translated.Dependant f as dep ->
+            (* It there is still an alpha in the parameters, the mutability is still `Dependant`,
+               otherwise, we apply the function embebed in the `Dependant` to the parameters *)
+            if List.exists alpha tyl then dep else f (List.map (ty ~driver) tyl)
+        | _ -> assert false)
 
   let lsymbol ~driver (ls : Tterm.lsymbol) =
+    (* To determine the mutability of a `lsymbol` we look at its `ls_value`
+       which is a `Ttypes.ty option`.
+       If there is none, the mutability is unknown *)
     Option.fold ~none:Translated.Unknown ~some:(ty ~driver) ls.ls_value
 
-  let mutable_flag = function
-    | Tast.Immutable -> Translated.Immutable
-    | Tast.Mutable -> Translated.Mutable
-
   let constructor_declaration ~driver (cd : Tast.constructor_decl) =
+    (* The mutability of a constructor is the max od the mutability of its argument *)
     List.map (ty ~driver) cd.cd_cs.ls_args |> List.fold_left max min_mut
 
-  let rec_declaration ~driver (rd : Tast.rec_declaration) =
-    List.map
-      (fun (ld : Tterm.lsymbol Tast.label_declaration) ->
-        max (mutable_flag ld.ld_mut) (lsymbol ~driver ld.ld_field))
-      rd.rd_ldl
-    |> List.fold_left max min_mut
+  let field_declaration ~driver (ld : Tterm.lsymbol Tast.label_declaration) =
+    (* A record field is mutable if it is annotated as mutable, if not we look
+       at the lsymbol it contains i.e. the field itself. *)
+    match ld.ld_mut with
+    | Tast.Mutable -> Translated.Mutable
+    | Tast.Immutable -> lsymbol ~driver ld.ld_field
 
   let type_declaration ~driver (td : Tast.type_declaration) =
+    (* To determine the mutability of a type declaration, we check
+       whether it is an alias. *)
     match td.td_ts.ts_alias with
     | Some alias ->
-        (* type t = int or type t = int array *)
+        (* An alias it a Ttypes.ty, e.g. `type t = int` *)
         ty ~driver alias
     | None -> (
         match td.td_kind with
-        | Pty_abstract -> Translated.Unknown (* type t *)
+        (* We don't have any information on an abstract type *)
+        | Pty_abstract -> Translated.Unknown
+        (* The mutability of a variant is the max of the mutability of its contructor *)
         | Pty_variant cdl ->
             List.map (constructor_declaration ~driver) cdl
             |> List.fold_left max min_mut
-        | Pty_record rd -> rec_declaration ~driver rd
+        | Pty_record rd ->
+            (* The mutability of a record is the max of the mutability of its fields *)
+            List.map (field_declaration ~driver) rd.rd_ldl
+            |> List.fold_left max min_mut
         | Pty_open -> Translated.Unknown (* ? *))
 
   let mutable_model ~driver (ty_fields : (Tterm.lsymbol * bool) list) =
     List.map
-      (fun (ls, b) -> if b then Translated.Mutable else lsymbol ~driver ls)
+      (* if a model is annotated as mutable, it is mutable, if not we look at
+         the type of the model *)
+        (fun (ls, b) -> if b then Translated.Mutable else lsymbol ~driver ls)
       ty_fields
+    (* the mutability of a type is here the max of the mutability of its models *)
     |> List.fold_left max min_mut
 
   let type_spec ~driver (spec : Tast.type_spec) =
+    (* To determine the mutability of a type according to its specification
+       we check whether it is annotated with an ephemeral, and if not we
+       look at its models *)
     if spec.ty_ephemeral then Translated.Mutable
     else mutable_model ~driver spec.ty_fields
 end

--- a/src/core/types.ml
+++ b/src/core/types.ml
@@ -3,71 +3,73 @@ open Gospel
 module Mutability = struct
   let max m n =
     let open Translated in
-    match m with
-    | Mutable -> Mutable
-    | Immutable -> ( match n with Mutable -> Mutable | _ -> Immutable)
-    | Unknown -> n
+    match (m, n) with
+    | Mutable, _ | _, Mutable -> Mutable
+    | Dependant f, _ | _, Dependant f -> Dependant f
+    | Unknown, _ | _, Unknown -> Unknown
+    | Immutable, Immutable -> Immutable
 
-  let known_tysymbol ~driver (ts : Ttypes.tysymbol) =
+  let min_mut = Translated.Immutable
+
+  let tysymbol ~driver (ts : Ttypes.tysymbol) =
     Option.fold ~none:Translated.Unknown
       ~some:(fun (t : Translated.type_) -> t.mutable_)
       (Drv.get_type ts driver)
 
-  let tysymbol ~driver (ts : Ttypes.tysymbol) =
-    max
-      (if
-       Ttypes.ts_equal ts (Drv.get_ts driver [ "Gospelstdlib"; "array" ])
-       || Ttypes.ts_equal ts (Drv.get_ts driver [ "Gospelstdlib"; "ref" ])
-      then Translated.Mutable
-      else Translated.Immutable)
-      (known_tysymbol ~driver ts)
+  let alpha (ty : Ttypes.ty) =
+    match ty.ty_node with Tyvar _ -> true | _ -> false
 
   let rec ty ~driver (t : Ttypes.ty) =
     match t.ty_node with
     | Tyvar _ -> Translated.Unknown
-    | Tyapp (ts, tyl) ->
-        List.fold_left
-          (fun acc t -> max acc (ty ~driver t))
-          (tysymbol ~driver ts) tyl
+    | Tyapp (ts, tyl) when Ttypes.is_ts_tuple ts ->
+        List.map (ty ~driver) tyl |> List.fold_left max min_mut
+    | Tyapp (ts, tyl) -> (
+        match tysymbol ~driver ts with
+        | Translated.Dependant f as m ->
+            if List.exists alpha tyl (* we still can't determine mutability *)
+            then m
+            else f (List.map (ty ~driver) tyl)
+        | m -> m)
 
   let lsymbol ~driver (ls : Tterm.lsymbol) =
     Option.fold ~none:Translated.Unknown ~some:(ty ~driver) ls.ls_value
-    |> List.fold_right (fun t acc -> max acc (ty ~driver t)) ls.ls_args
 
   let mutable_flag = function
     | Tast.Immutable -> Translated.Immutable
     | Tast.Mutable -> Translated.Mutable
 
   let constructor_declaration ~driver (cd : Tast.constructor_decl) =
-    List.map
-      (fun (ld : (Identifier.Ident.t * Ttypes.ty) Tast.label_declaration) ->
-        max (mutable_flag ld.ld_mut) (ty ~driver (snd ld.ld_field)))
-      cd.cd_ld
-    |> List.fold_left max (lsymbol ~driver cd.cd_cs)
+    List.map (ty ~driver) cd.cd_cs.ls_args |> List.fold_left max min_mut
 
   let rec_declaration ~driver (rd : Tast.rec_declaration) =
     List.map
       (fun (ld : Tterm.lsymbol Tast.label_declaration) ->
         max (mutable_flag ld.ld_mut) (lsymbol ~driver ld.ld_field))
       rd.rd_ldl
-    |> List.fold_left max (lsymbol ~driver rd.rd_cs)
+    |> List.fold_left max min_mut
 
   let type_declaration ~driver (td : Tast.type_declaration) =
-    max
-      (Option.fold ~none:Translated.Unknown ~some:(ty ~driver) td.td_ts.ts_alias)
-      (match td.td_kind with
-      | Pty_abstract -> Translated.Unknown
-      | Pty_variant cdl ->
-          List.map (constructor_declaration ~driver) cdl
-          |> List.fold_left max Translated.Unknown
-      | Pty_record rd -> rec_declaration ~driver rd
-      | Pty_open -> Translated.Unknown)
-
-  let inject_bool = function
-    | true -> Translated.Mutable
-    | false -> Translated.Immutable
+    match td.td_ts.ts_alias with
+    | Some alias ->
+        (* type t = int or type t = int array *)
+        ty ~driver alias
+    | None -> (
+        match td.td_kind with
+        | Pty_abstract -> Translated.Unknown (* type t *)
+        | Pty_variant cdl ->
+            List.map (constructor_declaration ~driver) cdl
+            |> List.fold_left max min_mut
+        | Pty_record rd -> rec_declaration ~driver rd
+        | Pty_open -> Translated.Unknown (* ? *))
 
   let mutable_model ~driver (ty_fields : (Tterm.lsymbol * bool) list) =
-    List.map (fun (ls, b) -> max (inject_bool b) (lsymbol ~driver ls)) ty_fields
-    |> List.fold_left max Translated.Unknown
+    List.map
+      (fun (ls, b) -> if b then Translated.Mutable else lsymbol ~driver ls)
+      ty_fields
+    |> List.fold_left max min_mut
+
+  let type_spec ~driver (spec : Tast.type_spec) =
+    if spec.ty_ephemeral then Translated.Mutable
+    else mutable_model ~driver spec.ty_fields
 end

--- a/src/core/types.mli
+++ b/src/core/types.mli
@@ -1,5 +1,9 @@
 module Mutability : sig
-  val ty : driver:Drv.t -> Gospel.Ttypes.ty -> bool
-  val type_declaration : driver:Drv.t -> Gospel.Tast.type_declaration -> bool
-  val mutable_model : driver:Drv.t -> (Gospel.Tterm.lsymbol * bool) list -> bool
+  val ty : driver:Drv.t -> Gospel.Ttypes.ty -> Translated.mutability
+
+  val type_declaration :
+    driver:Drv.t -> Gospel.Tast.type_declaration -> Translated.mutability
+
+  val mutable_model :
+    driver:Drv.t -> (Gospel.Tterm.lsymbol * bool) list -> Translated.mutability
 end

--- a/src/core/types.mli
+++ b/src/core/types.mli
@@ -1,0 +1,5 @@
+module Mutability : sig
+  val ty : driver:Drv.t -> Gospel.Ttypes.ty -> bool
+  val type_declaration : driver:Drv.t -> Gospel.Tast.type_declaration -> bool
+  val mutable_model : driver:Drv.t -> (Gospel.Tterm.lsymbol * bool) list -> bool
+end

--- a/src/core/types.mli
+++ b/src/core/types.mli
@@ -4,6 +4,5 @@ module Mutability : sig
   val type_declaration :
     driver:Drv.t -> Gospel.Tast.type_declaration -> Translated.mutability
 
-  val mutable_model :
-    driver:Drv.t -> (Gospel.Tterm.lsymbol * bool) list -> Translated.mutability
+  val type_spec : driver:Drv.t -> Gospel.Tast.type_spec -> Translated.mutability
 end

--- a/test/suite/dune
+++ b/test/suite/dune
@@ -1,5 +1,7 @@
 (test
  (name test)
  (package ortac)
+ (deps
+  (source_tree translation/))
  (libraries alcotest ortac-runtime ortac_core gospel fmt arrays arith
    exceptions terms ltypes))

--- a/test/suite/dune
+++ b/test/suite/dune
@@ -1,4 +1,5 @@
 (test
  (name test)
  (package ortac)
- (libraries alcotest ortac-runtime fmt arrays arith exceptions terms ltypes))
+ (libraries alcotest ortac-runtime ortac_core gospel fmt arrays arith
+   exceptions terms ltypes))

--- a/test/suite/test.ml
+++ b/test/suite/test.ml
@@ -1,4 +1,11 @@
 let () =
   Fmt.(set_style_renderer stderr `Ansi_tty);
   Alcotest.run "Gospel-rtac"
-    [ Arrays.suite; Arith.suite; Exceptions.suite; Terms.suite; Types.suite ]
+    [
+      Arrays.suite;
+      Arith.suite;
+      Exceptions.suite;
+      Terms.suite;
+      Types.suite;
+      Translation.suite;
+    ]

--- a/test/suite/translation.ml
+++ b/test/suite/translation.ml
@@ -30,6 +30,15 @@ let type_mutability () =
         true (is_mutable t))
     translations
 
+let type_immutability () =
+  let translations = translate "./translation/immutable.mli" in
+  Ortac_core.Drv.iter_translation
+    ~f:(fun t ->
+      Alcotest.(check bool)
+        (Fmt.str "%s is immutable" (type_name t))
+        false (is_mutable t))
+    translations
+
 let val_pure () =
   let translations = translate "./translation/pure.mli" in
   Ortac_core.Drv.iter_translation
@@ -41,5 +50,6 @@ let suite =
   ( "Translation",
     [
       ("type mutability", `Quick, type_mutability);
+      ("type immutability", `Quick, type_immutability);
       ("value purity", `Quick, val_pure);
     ] )

--- a/test/suite/translation.ml
+++ b/test/suite/translation.ml
@@ -7,36 +7,79 @@ let translate path =
   let driver = Ortac_core.Drv.init module_name (List.hd env) in
   Ortac_core.Translate.signature ~driver sigs
 
-let is_mutable = function
-  | Ortac_core.Translated.Type t -> t.mutable_ = Ortac_core.Translated.Mutable
-  | _ -> false
+let mutability =
+  let open Ortac_core.Translated in
+  let pp_mut ppf (m : mutability) =
+    match m with
+    | Unknown -> Fmt.pf ppf "Unknown"
+    | Immutable -> Fmt.pf ppf "Immutable"
+    | Mutable -> Fmt.pf ppf "Mutable"
+    | Dependant _ -> Fmt.pf ppf "Dependant"
+  in
+  let eq m n =
+    match (m, n) with
+    | Unknown, Unknown
+    | Immutable, Immutable
+    | Mutable, Mutable
+    | Dependant _, Dependant _ ->
+        true
+    | _ -> false
+  in
+  Alcotest.testable pp_mut eq
 
-let is_pure = function Ortac_core.Translated.Value v -> v.pure | _ -> false
+let get_mutability = function
+  | Ortac_core.Translated.Type t -> t.mutable_
+  | _ -> assert false
+
+let is_pure = function
+  | Ortac_core.Translated.Value v -> v.pure
+  | _ -> assert false
 
 let type_name = function
   | Ortac_core.Translated.Type t -> t.name
-  | _ -> "not found"
+  | _ -> assert false
 
 let val_name = function
   | Ortac_core.Translated.Value v -> v.name
-  | _ -> "not found"
+  | _ -> assert false
+
+let type_unknown () =
+  let translations = translate "./translation/unknown.mli" in
+  Ortac_core.Drv.iter_translation
+    ~f:(fun t ->
+      print_endline (type_name t);
+      Alcotest.(check mutability)
+        (Fmt.str "%s is unknown" (type_name t))
+        Ortac_core.Translated.Unknown (get_mutability t))
+    translations
 
 let type_mutability () =
   let translations = translate "./translation/mutable.mli" in
   Ortac_core.Drv.iter_translation
     ~f:(fun t ->
-      Alcotest.(check bool)
+      Alcotest.(check mutability)
         (Fmt.str "%s is mutable" (type_name t))
-        true (is_mutable t))
+        Ortac_core.Translated.Mutable (get_mutability t))
     translations
 
 let type_immutability () =
   let translations = translate "./translation/immutable.mli" in
   Ortac_core.Drv.iter_translation
     ~f:(fun t ->
-      Alcotest.(check bool)
+      Alcotest.(check mutability)
         (Fmt.str "%s is immutable" (type_name t))
-        false (is_mutable t))
+        Ortac_core.Translated.Immutable (get_mutability t))
+    translations
+
+let type_dependant () =
+  let translations = translate "./translation/dependant.mli" in
+  Ortac_core.Drv.iter_translation
+    ~f:(fun t ->
+      Alcotest.(check mutability)
+        (Fmt.str "%s is dependant" (type_name t))
+        (Ortac_core.Translated.Dependant
+           (fun _ -> Ortac_core.Translated.Unknown))
+        (get_mutability t))
     translations
 
 let val_pure () =
@@ -51,5 +94,6 @@ let suite =
     [
       ("type mutability", `Quick, type_mutability);
       ("type immutability", `Quick, type_immutability);
+      ("type unknown", `Quick, type_unknown);
       ("value purity", `Quick, val_pure);
     ] )

--- a/test/suite/translation.ml
+++ b/test/suite/translation.ml
@@ -8,7 +8,7 @@ let translate path =
   Ortac_core.Translate.signature ~driver sigs
 
 let is_mutable = function
-  | Ortac_core.Translated.Type t -> t.mutable_
+  | Ortac_core.Translated.Type t -> t.mutable_ = Ortac_core.Translated.Mutable
   | _ -> false
 
 let is_pure = function Ortac_core.Translated.Value v -> v.pure | _ -> false

--- a/test/suite/translation.ml
+++ b/test/suite/translation.ml
@@ -1,0 +1,45 @@
+let translate path =
+  let module_name = Ortac_core__Utils.module_name_of_path path in
+  Gospel.Parser_frontend.parse_ocaml_gospel path
+  |> Ortac_core__Utils.type_check [] path
+  |> fun (env, sigs) ->
+  assert (List.length env = 1);
+  let driver = Ortac_core.Drv.init module_name (List.hd env) in
+  Ortac_core.Translate.signature ~driver sigs
+
+let is_mutable = function
+  | Ortac_core.Translated.Type t -> t.mutable_
+  | _ -> false
+
+let is_pure = function Ortac_core.Translated.Value v -> v.pure | _ -> false
+
+let type_name = function
+  | Ortac_core.Translated.Type t -> t.name
+  | _ -> "not found"
+
+let val_name = function
+  | Ortac_core.Translated.Value v -> v.name
+  | _ -> "not found"
+
+let type_mutability () =
+  let translations = translate "./translation/mutable.mli" in
+  Ortac_core.Drv.iter_translation
+    ~f:(fun t ->
+      Alcotest.(check bool)
+        (Fmt.str "%s is mutable" (type_name t))
+        true (is_mutable t))
+    translations
+
+let val_pure () =
+  let translations = translate "./translation/pure.mli" in
+  Ortac_core.Drv.iter_translation
+    ~f:(fun v ->
+      Alcotest.(check bool) (Fmt.str "%s is pure" (val_name v)) true (is_pure v))
+    translations
+
+let suite =
+  ( "Translation",
+    [
+      ("type mutability", `Quick, type_mutability);
+      ("value purity", `Quick, val_pure);
+    ] )

--- a/test/suite/translation/dependant.ml
+++ b/test/suite/translation/dependant.ml
@@ -1,1 +1,0 @@
-type 'a alpha_list_is_dependant = 'a list

--- a/test/suite/translation/dependant.ml
+++ b/test/suite/translation/dependant.ml
@@ -1,0 +1,1 @@
+type 'a alpha_list_is_dependant = 'a list

--- a/test/suite/translation/dependant.mli
+++ b/test/suite/translation/dependant.mli
@@ -1,0 +1,1 @@
+type 'a alpha_list_is_dependant = 'a list

--- a/test/suite/translation/dependant.mli
+++ b/test/suite/translation/dependant.mli
@@ -1,1 +1,4 @@
+val start : unit -> unit
+
 type 'a alpha_list_is_dependant = 'a list
+type ('a, 'b) double_dependant = 'a * 'b

--- a/test/suite/translation/dune
+++ b/test/suite/translation/dune
@@ -1,3 +1,3 @@
 (library
  (name translation)
- (modules_without_implementation mutable immutable unknown pure))
+ (modules_without_implementation mutable immutable unknown dependant pure))

--- a/test/suite/translation/dune
+++ b/test/suite/translation/dune
@@ -1,0 +1,3 @@
+(library
+ (name translation)
+ (modules_without_implementation mutable pure))

--- a/test/suite/translation/dune
+++ b/test/suite/translation/dune
@@ -1,3 +1,3 @@
 (library
  (name translation)
- (modules_without_implementation mutable pure))
+ (modules_without_implementation mutable immutable pure))

--- a/test/suite/translation/dune
+++ b/test/suite/translation/dune
@@ -1,3 +1,3 @@
 (library
  (name translation)
- (modules_without_implementation mutable immutable pure))
+ (modules_without_implementation mutable immutable unknown dependant pure))

--- a/test/suite/translation/dune
+++ b/test/suite/translation/dune
@@ -1,3 +1,3 @@
 (library
  (name translation)
- (modules_without_implementation mutable immutable unknown dependant pure))
+ (modules_without_implementation mutable immutable unknown pure))

--- a/test/suite/translation/immutable.mli
+++ b/test/suite/translation/immutable.mli
@@ -1,6 +1,3 @@
 type int_list = int list
 type variant = C0 of int | C1 of string * int
 type record = { f0 : int; f1 : string }
-type abstract_type
-type 'a type_with_model
-(*@ model content : 'a set *)

--- a/test/suite/translation/immutable.mli
+++ b/test/suite/translation/immutable.mli
@@ -1,0 +1,6 @@
+type int_list = int list
+type variant = C0 of int | C1 of string * int
+type record = { f0 : int; f1 : string }
+type abstract_type
+type 'a type_with_model
+(*@ model content : 'a set *)

--- a/test/suite/translation/immutable.mli
+++ b/test/suite/translation/immutable.mli
@@ -1,3 +1,8 @@
+type ('a, 'b) t_dependant = 'a * 'b
+
+val start : unit -> unit
+
 type int_list = int list
 type variant = C0 of int | C1 of string * int
 type record = { f0 : int; f1 : string }
+type immutable_t_dependant = (int, char) t_dependant

--- a/test/suite/translation/mutable.mli
+++ b/test/suite/translation/mutable.mli
@@ -17,6 +17,4 @@ type int_array = int array
 type int_ref = int ref
 type list_of_mutable = int ref list
 type 'a abstract_and_mutable = 'a * int array
-
-type dependant_instanciated_with_int =
-  int Translation.Dependant.alpha_list_is_dependant
+type dependant_instanciated_with_int = int Dependant.alpha_list_is_dependant

--- a/test/suite/translation/mutable.mli
+++ b/test/suite/translation/mutable.mli
@@ -4,6 +4,9 @@ type t_ephemeral
 type 'a with_mutable_model
 (*@ mutable model content : 'a set *)
 
+type 'a with_deep_mutable_model
+(*@ model content : 'a array *)
+
 type record_with_mutable_flag = { mutable m : int }
 type record_with_known_mutable_field = { t : t_ephemeral }
 type variant_with_known_mutable_field = K of t_ephemeral

--- a/test/suite/translation/mutable.mli
+++ b/test/suite/translation/mutable.mli
@@ -1,3 +1,7 @@
+type 'a t_dependant = 'a list
+
+val start : unit -> unit
+
 type t_ephemeral
 (*@ ephemeral*)
 
@@ -5,7 +9,7 @@ type 'a with_mutable_model
 (*@ mutable model content : 'a set *)
 
 type 'a with_deep_mutable_model
-(*@ model content : 'a array *)
+(*@ model content : int array *)
 
 type record_with_mutable_flag = { mutable m : int }
 type record_with_known_mutable_field = { t : t_ephemeral }
@@ -17,4 +21,4 @@ type int_array = int array
 type int_ref = int ref
 type list_of_mutable = int ref list
 type 'a abstract_and_mutable = 'a * int array
-type dependant_instanciated_with_int = int Dependant.alpha_list_is_dependant
+type int_ref_dependant_list = int_ref t_dependant

--- a/test/suite/translation/mutable.mli
+++ b/test/suite/translation/mutable.mli
@@ -1,0 +1,13 @@
+type t_ephemeral
+(*@ ephemeral*)
+
+type 'a with_mutable_model
+(*@ mutable model content : 'a set *)
+
+type record_with_mutable_field = { mutable m : int }
+type variant_with_known_mutable_field = K of t_ephemeral
+type record_with_known_mutable_field = { t : t_ephemeral }
+type int_array = int array
+type int_ref = int ref
+type variant = C of int array
+type record = { f : int array }

--- a/test/suite/translation/mutable.mli
+++ b/test/suite/translation/mutable.mli
@@ -17,3 +17,6 @@ type int_array = int array
 type int_ref = int ref
 type list_of_mutable = int ref list
 type 'a abstract_and_mutable = 'a * int array
+
+type dependant_instanciated_with_int =
+  int Translation.Dependant.alpha_list_is_dependant

--- a/test/suite/translation/mutable.mli
+++ b/test/suite/translation/mutable.mli
@@ -7,8 +7,9 @@ type 'a with_mutable_model
 type record_with_mutable_flag = { mutable m : int }
 type record_with_known_mutable_field = { t : t_ephemeral }
 type variant_with_known_mutable_field = K of t_ephemeral
+type variant_with_int_array = C0 of int array | C1 of int
+type record_with_int_array = { f0 : int array; f1 : int }
+type record_with_list_of_known_mutable = { f : t_ephemeral list }
 type int_array = int array
 type int_ref = int ref
 type list_of_mutable = int ref list
-type variant = C of int array
-type record = { f : int array }

--- a/test/suite/translation/mutable.mli
+++ b/test/suite/translation/mutable.mli
@@ -4,10 +4,11 @@ type t_ephemeral
 type 'a with_mutable_model
 (*@ mutable model content : 'a set *)
 
-type record_with_mutable_field = { mutable m : int }
-type variant_with_known_mutable_field = K of t_ephemeral
+type record_with_mutable_flag = { mutable m : int }
 type record_with_known_mutable_field = { t : t_ephemeral }
+type variant_with_known_mutable_field = K of t_ephemeral
 type int_array = int array
 type int_ref = int ref
+type list_of_mutable = int ref list
 type variant = C of int array
 type record = { f : int array }

--- a/test/suite/translation/mutable.mli
+++ b/test/suite/translation/mutable.mli
@@ -16,3 +16,4 @@ type record_with_list_of_known_mutable = { f : t_ephemeral list }
 type int_array = int array
 type int_ref = int ref
 type list_of_mutable = int ref list
+type 'a abstract_and_mutable = 'a * int array

--- a/test/suite/translation/pure.mli
+++ b/test/suite/translation/pure.mli
@@ -1,0 +1,3 @@
+val f : int -> int
+(*@ y = f x
+    pure *)

--- a/test/suite/translation/unknown.mli
+++ b/test/suite/translation/unknown.mli
@@ -1,0 +1,1 @@
+type abstract_type_is_unknown

--- a/test/suite/translation/unknown.mli
+++ b/test/suite/translation/unknown.mli
@@ -1,1 +1,3 @@
+val start : unit -> unit
+
 type abstract_type_is_unknown


### PR DESCRIPTION
Traverse a type definition to compute whether it is an OCaml mutable type. 
This allows to have information even in the absence of specifications.

I also add some tests.