### PR TITLE
Invariants in known containers

### DIFF
--- a/ortac-runtime.opam
+++ b/ortac-runtime.opam
@@ -10,6 +10,15 @@ homepage: "https://github.com/ocaml-gospel/ortac"
 dev-repo: "git+https://github.com/ocaml-gospel/ortac.git"
 doc: "https://pascutto.github.io/ortac/"
 bug-reports: "https://github.com/ocaml-gospel/ortac/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "2.7"}
+  "fmt"
+  "ppxlib" {>= "0.20.0"}
+  "zarith"
+  "monolith" {>= "20201026" & with-test}
+  "pprint" {>= "20200410" & with-test}
+]
 build: [
   ["dune" "subst"] {dev}
   [
@@ -23,13 +32,4 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-]
-
-depends: [
-  "ocaml"
-  "dune" {>= "2.7"}
-  "fmt"
-  "ppxlib" {>= "0.20.0"}
-  "zarith"
-  "monolith" {>= "20201026"}
 ]

--- a/src/core/drv.ml
+++ b/src/core/drv.ml
@@ -35,41 +35,47 @@ let stdlib_types =
   let open Translated in
   let loc = Ppxlib.Location.none in
   [
-    ([ "unit" ], type_ ~name:"unit" ~loc ~mutable_:Immutable ~ghost:false);
-    ([ "string" ], type_ ~name:"string" ~loc ~mutable_:Immutable ~ghost:false);
-    ([ "char" ], type_ ~name:"char" ~loc ~mutable_:Immutable ~ghost:false);
-    ([ "float" ], type_ ~name:"float" ~loc ~mutable_:Immutable ~ghost:false);
-    ([ "bool" ], type_ ~name:"bool" ~loc ~mutable_:Immutable ~ghost:false);
-    ([ "integer" ], type_ ~name:"integer" ~loc ~mutable_:Immutable ~ghost:false);
+    ( [ "unit" ],
+      type_ ~name:"unit" ~args:[] ~loc ~mutable_:Immutable ~ghost:false );
+    ( [ "string" ],
+      type_ ~name:"string" ~args:[] ~loc ~mutable_:Immutable ~ghost:false );
+    ( [ "char" ],
+      type_ ~name:"char" ~args:[] ~loc ~mutable_:Immutable ~ghost:false );
+    ( [ "float" ],
+      type_ ~name:"float" ~args:[] ~loc ~mutable_:Immutable ~ghost:false );
+    ( [ "bool" ],
+      type_ ~name:"bool" ~args:[] ~loc ~mutable_:Immutable ~ghost:false );
+    ( [ "integer" ],
+      type_ ~name:"integer" ~args:[] ~loc ~mutable_:Immutable ~ghost:false );
     ( [ "option" ],
-      type_ ~name:"option" ~loc
+      type_ ~name:"option" ~args:[ alpha ] ~loc
         ~mutable_:(Dependant (function [ m ] -> m | _ -> assert false))
         ~ghost:false );
     ( [ "list" ],
-      type_ ~name:"list" ~loc
+      type_ ~name:"list" ~args:[ alpha ] ~loc
         ~mutable_:(Dependant (function [ m ] -> m | _ -> assert false))
         ~ghost:false );
     ( [ "Gospelstdlib"; "seq" ],
-      type_ ~name:"seq" ~loc
+      type_ ~name:"seq" ~args:[ alpha ] ~loc
         ~mutable_:(Dependant (function [ m ] -> m | _ -> assert false))
         ~ghost:false );
     ( [ "Gospelstdlib"; "bag" ],
-      type_ ~name:"bag" ~loc
+      type_ ~name:"bag" ~args:[ alpha ] ~loc
         ~mutable_:(Dependant (function [ m ] -> m | _ -> assert false))
         ~ghost:false );
     ( [ "Gospelstdlib"; "ref" ],
-      type_ ~name:"ref" ~loc
+      type_ ~name:"ref" ~args:[ alpha ] ~loc
         ~mutable_:(Dependant (fun _ -> Mutable))
         ~ghost:false );
     ( [ "Gospelstdlib"; "array" ],
-      type_ ~name:"array" ~loc
+      type_ ~name:"array" ~args:[ alpha ] ~loc
         ~mutable_:(Dependant (fun _ -> Mutable))
         ~ghost:false );
     ( [ "Gospelstdlib"; "set" ],
-      type_ ~name:"set" ~loc
+      type_ ~name:"set" ~args:[ alpha ] ~loc
         ~mutable_:(Dependant (function [ m ] -> m | _ -> assert false))
         ~ghost:false );
-    ([ "int" ], type_ ~name:"int" ~loc ~mutable_:Immutable ~ghost:false);
+    ([ "int" ], type_ ~name:"int" ~args:[] ~loc ~mutable_:Immutable ~ghost:false);
   ]
 
 let stdlib =

--- a/src/core/translate.ml
+++ b/src/core/translate.ml
@@ -26,7 +26,7 @@ let rec type_of_ty ~driver (ty : Ttypes.ty) =
           let mutable_ = Mutability.ty ~driver ty in
           Translated.type_ ~name:ts.ts_ident.id_str ~args
             ~loc:ts.ts_ident.id_loc ~mutable_ ~ghost:false
-      | Some type_ -> type_)
+      | Some type_ -> { type_ with args })
 
 let vsname (vs : Tterm.vsymbol) = Fmt.str "%a" Tast.Ident.pp vs.vs_name
 

--- a/src/core/translated.ml
+++ b/src/core/translated.ml
@@ -29,6 +29,7 @@ type invariant = {
 
 type type_ = {
   name : string;
+  args : type_ list;
   loc : Location.t;
   mutable_ : mutability;
   ghost : bool;
@@ -39,9 +40,10 @@ type type_ = {
   copy : (expression, W.t) result;
 }
 
-let type_ ~name ~loc ~mutable_ ~ghost =
+let type_ ~name ~args ~loc ~mutable_ ~ghost =
   {
     name;
+    args;
     loc;
     mutable_;
     ghost;
@@ -51,6 +53,9 @@ let type_ ~name ~loc ~mutable_ ~ghost =
     comparison = Error (W.Unsupported "comparison", loc);
     copy = Error (W.Unsupported "copy", loc);
   }
+
+let alpha =
+  type_ ~name:"alpha" ~args:[] ~loc:Location.none ~mutable_:Unknown ~ghost:false
 
 type ocaml_var = {
   name : string;

--- a/src/default/dune
+++ b/src/default/dune
@@ -2,4 +2,4 @@
  (name ortac_default)
  (preprocess
   (pps ppxlib.metaquot))
- (libraries ortac_core fmt gospel ppxlib ppxlib.ast))
+ (libraries ortac_core fmt gospel ppxlib ppxlib.astlib))

--- a/src/monolith/dune
+++ b/src/monolith/dune
@@ -2,4 +2,4 @@
  (name ortac_monolith)
  (preprocess
   (pps ppxlib.metaquot))
- (libraries ortac_core monolith fmt gospel ppxlib ppxlib.ast))
+ (libraries ortac_core monolith fmt gospel ppxlib ppxlib.astlib))

--- a/test/suite/types.ml
+++ b/test/suite/types.ml
@@ -1,8 +1,22 @@
 open Ltypes__Lib_rtac
 open Common
 
-let get_x () =
+let get_x_ok () =
   let t = { x = 10; y = false } in
-  check_success "get_x" (fun () -> get_x t |> ignore)
+  check_success "get_x is ok" (fun () -> get_x t |> ignore)
 
-let suite = ("Types", [ ("simple field access", `Quick, get_x) ])
+let get_x_wrong_invariant () =
+  let t = { x = 10; y = true } in
+  check_raises_ortac "get_x with wrong invariant" (fun () -> get_x t |> ignore)
+
+let in_list () =
+  let l = [ { x = 10; y = true } ] in
+  check_raises_ortac "in_list" (fun () -> in_list l |> ignore)
+
+let suite =
+  ( "Types",
+    [
+      ("simple field access", `Quick, get_x_ok);
+      ("invariant check", `Quick, get_x_wrong_invariant);
+      ("invariant in list", `Quick, in_list);
+    ] )

--- a/test/suite/types/lib.ml
+++ b/test/suite/types/lib.ml
@@ -2,3 +2,4 @@ type t = { x : int; y : bool }
 
 let e = { x = 0; y = false }
 let get_x t = t.x
+let in_list _ = true

--- a/test/suite/types/lib.mli
+++ b/test/suite/types/lib.mli
@@ -7,3 +7,7 @@ val e : t
 val get_x : t -> int
 (*@ r = get_x t
     ensures r = t.x *)
+
+val in_list : t list -> bool
+(*@ b = in_list l
+    ensures true *)


### PR DESCRIPTION
Check type invariants for what is inside:
- a list
- an array
- an option
- a ref

I had to add a field in Translation.type_ in order to have access to the argument of the type constructors.

This PR is incompatible with PR #51.