### PR TITLE
derive

### DIFF
--- a/ortac-runtime.opam
+++ b/ortac-runtime.opam
@@ -7,9 +7,17 @@ authors: [
   "Nicolas Osborne <nicolas.osborne@tarides.fr>"
 ]
 homepage: "https://github.com/ocaml-gospel/ortac"
-dev-repo: "git+https://github.com/ocaml-gospel/ortac.git"
 doc: "https://pascutto.github.io/ortac/"
 bug-reports: "https://github.com/ocaml-gospel/ortac/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "2.7"}
+  "fmt"
+  "ppxlib" {>= "0.20.0"}
+  "zarith"
+  "monolith" {>= "20201026" & with-test}
+  "pprint" {>= "20211129" & with-test}
+]
 build: [
   ["dune" "subst"] {dev}
   [
@@ -24,12 +32,4 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-
-depends: [
-  "ocaml"
-  "dune" {>= "2.7"}
-  "fmt"
-  "ppxlib" {>= "0.20.0"}
-  "zarith"
-  "monolith" {>= "20201026"}
-]
+dev-repo: "git+https://github.com/ocaml-gospel/ortac.git"

--- a/ortac.opam
+++ b/ortac.opam
@@ -1,15 +1,28 @@
 opam-version: "2.0"
 synopsis: "OCaml Runtime Assertion Checking based on Gospel"
 description: "OCaml Runtime Assertion Checking based on Gospel"
-maintainer: ["Clément Pascutto <clement@pascutto.fr>"]
+maintainer: "Clément Pascutto <clement@pascutto.fr>"
 authors: [
   "Clément Pascutto <clement@pascutto.fr>"
   "Nicolas Osborne <nicolas.osborne@tarides.fr>"
 ]
 homepage: "https://github.com/ocaml-gospel/ortac"
-dev-repo: "git+https://github.com/ocaml-gospel/ortac.git"
 doc: "https://ocaml-gospel.github.io/ortac/"
 bug-reports: "https://github.com/ocaml-gospel/ortac/issues"
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.7"}
+  "cmdliner"
+  "fmt"
+  "ppxlib" {>= "0.20.0"}
+  "gospel"
+  "alcotest" {with-test}
+  "pprint" {with-test}
+  "ortac-runtime" {with-test}
+  "ortac-runtime-monolith" {with-test}
+  "monolith" {>= "20201026"}
+  "ortac_runtime" {>= "0" & with-test}
+]
 build: [
   ["dune" "subst"] {dev}
   [
@@ -24,17 +37,4 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-
-depends: [
-  "ocaml" {>= "4.10.0"}
-  "dune" {>= "2.7"}
-  "cmdliner"
-  "fmt"
-  "ppxlib" {>= "0.20.0"}
-  "gospel"
-  "alcotest" {with-test}
-  "pprint" {with-test}
-  "ortac-runtime" {with-test}
-  "ortac-runtime-monolith" {with-test}
-  "monolith" {>= "20201026"}
-]
+dev-repo: "git+https://github.com/ocaml-gospel/ortac.git"

--- a/ortac.opam
+++ b/ortac.opam
@@ -21,7 +21,6 @@ depends: [
   "ortac-runtime" {with-test}
   "ortac-runtime-monolith" {with-test}
   "monolith" {>= "20201026"}
-  "ortac_runtime" {>= "0" & with-test}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/src/core/drv.ml
+++ b/src/core/drv.ml
@@ -31,45 +31,77 @@ let is_function ls t = L.mem ls t.functions
 let get_ls t = get_ls_env t.env
 let get_ts t = get_env ns_find_ts t.env
 
+let alpha =
+  let open Translated in
+  type_ ~name:"alpha" ~kind:Alpha ~loc:Ppxlib.Location.none ~mutable_:Unknown
+    ~ghost:false
+
 let stdlib_types =
   let open Translated in
   let loc = Ppxlib.Location.none in
   [
-    ([ "unit" ], type_ ~name:"unit" ~loc ~mutable_:Immutable ~ghost:false);
-    ([ "string" ], type_ ~name:"string" ~loc ~mutable_:Immutable ~ghost:false);
-    ([ "char" ], type_ ~name:"char" ~loc ~mutable_:Immutable ~ghost:false);
-    ([ "float" ], type_ ~name:"float" ~loc ~mutable_:Immutable ~ghost:false);
-    ([ "bool" ], type_ ~name:"bool" ~loc ~mutable_:Immutable ~ghost:false);
-    ([ "integer" ], type_ ~name:"integer" ~loc ~mutable_:Immutable ~ghost:false);
+    ( [ "unit" ],
+      type_ ~name:"unit" ~kind:(Core []) ~loc ~mutable_:Immutable ~ghost:false
+    );
+    ( [ "string" ],
+      type_ ~name:"string" ~kind:(Core []) ~loc ~mutable_:Immutable ~ghost:false
+    );
+    ( [ "char" ],
+      type_ ~name:"char" ~kind:(Core []) ~loc ~mutable_:Immutable ~ghost:false
+    );
+    ( [ "float" ],
+      type_ ~name:"float" ~kind:(Core []) ~loc ~mutable_:Immutable ~ghost:false
+    );
+    ( [ "bool" ],
+      type_ ~name:"bool" ~kind:(Core []) ~loc ~mutable_:Immutable ~ghost:false
+    );
+    ( [ "integer" ],
+      type_ ~name:"integer" ~kind:(Core []) ~loc ~mutable_:Immutable
+        ~ghost:false );
     ( [ "option" ],
-      type_ ~name:"option" ~loc
+      type_ ~name:"option"
+        ~kind:(Core [ alpha ])
+        ~loc
         ~mutable_:(Dependant (function [ m ] -> m | _ -> assert false))
         ~ghost:false );
     ( [ "list" ],
-      type_ ~name:"list" ~loc
+      type_ ~name:"list"
+        ~kind:(Core [ alpha ])
+        ~loc
         ~mutable_:(Dependant (function [ m ] -> m | _ -> assert false))
         ~ghost:false );
     ( [ "Gospelstdlib"; "seq" ],
-      type_ ~name:"seq" ~loc
+      type_ ~name:"seq"
+        ~kind:(Core [ alpha ])
+        ~loc
         ~mutable_:(Dependant (function [ m ] -> m | _ -> assert false))
         ~ghost:false );
     ( [ "Gospelstdlib"; "bag" ],
-      type_ ~name:"bag" ~loc
+      type_ ~name:"bag"
+        ~kind:(Core [ alpha ])
+        ~loc
         ~mutable_:(Dependant (function [ m ] -> m | _ -> assert false))
         ~ghost:false );
     ( [ "Gospelstdlib"; "ref" ],
-      type_ ~name:"ref" ~loc
+      type_ ~name:"ref"
+        ~kind:(Core [ alpha ])
+        ~loc
         ~mutable_:(Dependant (fun _ -> Mutable))
         ~ghost:false );
     ( [ "Gospelstdlib"; "array" ],
-      type_ ~name:"array" ~loc
+      type_ ~name:"array"
+        ~kind:(Core [ alpha ])
+        ~loc
         ~mutable_:(Dependant (fun _ -> Mutable))
         ~ghost:false );
     ( [ "Gospelstdlib"; "set" ],
-      type_ ~name:"set" ~loc
+      type_ ~name:"set"
+        ~kind:(Core [ alpha ])
+        ~loc
         ~mutable_:(Dependant (function [ m ] -> m | _ -> assert false))
         ~ghost:false );
-    ([ "int" ], type_ ~name:"int" ~loc ~mutable_:Immutable ~ghost:false);
+    ( [ "int" ],
+      type_ ~name:"int" ~kind:(Core []) ~loc ~mutable_:Immutable ~ghost:false );
   ]
 
 let stdlib =

--- a/src/core/translate.ml
+++ b/src/core/translate.ml
@@ -92,7 +92,7 @@ let rec kind ~driver (td : Tast.type_declaration) =
             match Drv.get_type ts driver with
             | None ->
                 Translated.type_ ~name:ts.ts_ident.id_str ~kind:Abstract
-                  ~loc:Location.none ~mutable_:Unknown ~ghost:false
+                  ~loc:td.td_loc ~mutable_:Unknown ~ghost:false
             | Some t -> t
           in
           Synonyms (t, List.map (type_of_ty ~driver) tvs))

--- a/src/core/translated.ml
+++ b/src/core/translated.ml
@@ -29,6 +29,7 @@ type invariant = {
 
 type type_ = {
   name : string;
+  kind : kind;
   loc : Location.t;
   mutable_ : mutability;
   ghost : bool;
@@ -39,9 +40,24 @@ type type_ = {
   copy : (expression, W.t) result;
 }
 
-let type_ ~name ~loc ~mutable_ ~ghost =
+and kind =
+  | Abstract (* type t *)
+  | Alpha (* 'a for polymorphic types *)
+  | Core of type_ list (* core types are the ones defined in the stdlib *)
+  | Synonyms of type_ * type_ list (* synonymes with the name of the type constructors and its arguments *)
+  | Variant of constructor (* variant with the list of contructors *)
+  | Record of (string * type_) list (* record with the list of of fields *)
+  | Tuple of type_ list
+(* tuples with the type_s of the elements *)
+
+and constructor =
+  | Unnamed of (string * type_) list
+  | Named of (string * type_ list) list
+
+let type_ ~name ~kind ~loc ~mutable_ ~ghost =
   {
     name;
+    kind;
     loc;
     mutable_;
     ghost;

--- a/src/core/translated.ml
+++ b/src/core/translated.ml
@@ -45,14 +45,12 @@ and kind =
   | Alpha (* 'a for polymorphic types *)
   | Core of type_ list (* core types are the ones defined in the stdlib *)
   | Synonyms of type_ * type_ list (* synonymes with the name of the type constructors and its arguments *)
-  | Variant of constructor (* variant with the list of contructors *)
+  | Variant of (string * constructor) list (* variant with the list of contructors *)
   | Record of (string * type_) list (* record with the list of of fields *)
   | Tuple of type_ list
 (* tuples with the type_s of the elements *)
 
-and constructor =
-  | Unnamed of (string * type_) list
-  | Named of (string * type_ list) list
+and constructor = Unnamed of type_ list | Named of (string * type_) list
 
 let type_ ~name ~kind ~loc ~mutable_ ~ghost =
   {

--- a/src/core/translated.ml
+++ b/src/core/translated.ml
@@ -48,8 +48,8 @@ and kind =
   | Variant of (string * constructor) list (* variant with the list of contructors *)
   | Record of (string * type_) list (* record with the list of of fields *)
   | Tuple of type_ list
-(* tuples with the type_s of the elements *)
 
+(* tuples with the type_s of the elements *)
 and constructor = Unnamed of type_ list | Named of (string * type_) list
 
 let type_ ~name ~kind ~loc ~mutable_ ~ghost =

--- a/src/core/types.ml
+++ b/src/core/types.ml
@@ -109,3 +109,246 @@ module Mutability = struct
     if spec.ty_ephemeral then Translated.Mutable
     else mutable_model ~driver spec.ty_fields
 end
+
+module W = Warnings
+open Ppxlib
+
+let result_of_list f l =
+  let rec aux = function
+    | [] -> Ok []
+    | x :: t -> (
+        match f x with
+        | Error _ as e -> e
+        | Ok x ->
+            let t = aux t in
+            Result.map (fun t -> x :: t) t)
+  in
+  aux l
+
+module Comparison = struct
+  let core_type =
+    [
+      "unit";
+      "bool";
+      "char";
+      "string";
+      "float";
+      "integer";
+      "option";
+      "list";
+      "array";
+      "ref";
+      "seq";
+      "bag";
+      "set";
+    ]
+
+  module Common = struct
+    let var_i ~prefix l () =
+      List.mapi (fun i _ -> gen_symbol ~prefix:(prefix ^ Int.to_string i) ()) l
+
+    let vars ~prefix l () =
+      List.map (fun s -> gen_symbol ~prefix:(prefix ^ s) ()) l
+
+    let item ~loc cmp elt_a elt_b next =
+      let open Ast_builder.Make (struct
+        let loc = loc
+      end) in
+      let res = gen_symbol ~prefix:"__res" () in
+      [%expr
+        let [%e pvar res] = [%e cmp] [%e evar elt_a] [%e evar elt_b] in
+        if [%e evar res] <> 0 then [%e evar res] else [%e next]]
+
+    let rec fold ~loc cmps elts_a elts_b =
+      match (cmps, elts_a, elts_b) with
+      | [], [], [] -> [%expr 0]
+      | c :: cs, elt_a :: elts_a, elt_b :: elts_b ->
+          item ~loc c elt_a elt_b (fold ~loc cs elts_a elts_b)
+      | _, _, _ -> assert false
+  end
+
+  module Variant = struct
+    (** In this module we define some auxiliary functions for generating
+        comparison about variants *)
+
+    let constructor_pattern ~loc (name, constructor) =
+      (* build the pattern corresponding to the constructor and return it along
+         with the list of variable names occuring in it *)
+      let open Ast_builder.Make (struct
+        let loc = loc
+      end) in
+      let cstr = Builder.lident name in
+      let names, rec_pat =
+        match constructor with
+        | Translated.Named fields ->
+            let fields = List.map fst fields in
+            let names = Common.vars ~prefix:"__" fields () in
+            let fields_pat =
+              List.map2 (fun f n -> (Builder.lident f, pvar n)) fields names
+            in
+            (names, Some (ppat_record fields_pat Closed))
+        | Translated.Unnamed args ->
+            let names = Common.var_i ~prefix:"__elt" args () in
+            (names, ppat_tuple_opt (List.map pvar names))
+      in
+      (names, ppat_construct cstr rec_pat)
+
+    let lhs ~loc (c0, arg0) (c1, args1) =
+      let open Ast_builder.Make (struct
+        let loc = loc
+      end) in
+      (* we need to name the arguments od the constructors only if they are the same *)
+      if c0 = c1 then
+        let var0, pat0 = constructor_pattern ~loc (c0, arg0) in
+        let var1, pat1 = constructor_pattern ~loc (c1, args1) in
+        (ppat_tuple [ pat0; pat1 ], var0, var1)
+      else
+        let pat0 = ppat_construct (Builder.lident c0) None in
+        let pat1 = ppat_construct (Builder.lident c1) None in
+        (ppat_tuple [ pat0; pat1 ], [], [])
+
+    let rhs ~loc cmps var0 var1 =
+      (* As we will check the first argument against the second, we know that if
+         we don't have any names for the arguments the constructor [var0] if less
+         than the constructor [var1] *)
+      if List.length var0 = 0 then [%expr -1]
+      else Common.fold ~loc cmps var0 var1
+
+    let case ~loc cmps c0 c1 =
+      let open Ast_builder.Make (struct
+        let loc = loc
+      end) in
+      let lhs, var0, var1 = lhs ~loc c0 c1 in
+      let rhs = rhs ~loc cmps var0 var1 in
+      case ~lhs ~guard:None ~rhs
+
+    let cmp_cases ~loc = List.map2 (fun cmp c -> case ~loc cmp c c)
+
+    let inf_cases ~loc constructors =
+      (* check a.(i) against b.(j) for all i < j *)
+      let a = Array.of_list constructors in
+      let b = Array.of_list constructors in
+      let stop = Array.length a in
+      let rec loop i j =
+        if i = stop then []
+        else if j = stop then loop (succ i) (i + 2)
+        else case ~loc [] a.(i) b.(j) :: loop i (succ j)
+      in
+      loop 0 1
+
+    let catch_all ~loc =
+      let open Ast_builder.Make (struct
+        let loc = loc
+      end) in
+      [
+        case ~lhs:(ppat_tuple [ ppat_any; ppat_any ]) ~guard:None ~rhs:[%expr 1];
+      ]
+  end
+
+  let rec core ~loc name args =
+    let open Ast_builder.Make (struct
+      let loc = loc
+    end) in
+    match name with
+    | "unit" | "bool" | "int" | "char" | "string" | "float" | "integer" ->
+        Ok [%expr compare]
+    | "option" ->
+        let build cmp = [%expr Option.compare [%e cmp]] in
+        Result.map build (derive (List.hd args))
+    | "list" ->
+        let build cmp = [%expr List.compare [%e cmp]] in
+        Result.map build (derive (List.hd args))
+    | "array" ->
+        let build cmp = [%expr Ortac_runtime.Array.compare [%e cmp]] in
+        Result.map build (derive (List.hd args))
+    | "ref" ->
+        let a = gen_symbol ~prefix:"__a" () in
+        let b = gen_symbol ~prefix:"__b" () in
+        let build cmp =
+          [%expr
+            fun [%p pvar a] [%p pvar b] -> [%e cmp] ![%e evar a] ![%e evar b]]
+        in
+        Result.map build (derive (List.hd args))
+    | "seq" -> Error (W.Unsupported_comparison "seq")
+    | "bag" -> Error (W.Unsupported_comparison "bag")
+    | "set" -> Error (W.Unsupported_comparison "set")
+    | _ -> assert false
+
+  and synonyms ~loc (constructor : Translated.type_) args =
+    if List.mem constructor.name core_type then core ~loc constructor.name args
+    else
+      match args with
+      | [] -> derive constructor
+      | _ -> Error (W.Unsupported_comparison constructor.name)
+  (* XXX we don't know yet how to do it *)
+
+  and constructor = function
+    | Translated.Named fields -> result_of_list (fun (_, t) -> derive t) fields
+    | Translated.Unnamed args -> result_of_list derive args
+
+  and variant ~loc constructors =
+    let open Ast_builder.Make (struct
+      let loc = loc
+    end) in
+    match result_of_list (fun (_, c) -> constructor c) constructors with
+    | Error e -> Error e
+    | Ok cmps ->
+        let a, b = (gen_symbol ~prefix:"__a" (), gen_symbol ~prefix:"__b" ()) in
+        let cases =
+          Variant.(
+            cmp_cases ~loc cmps constructors
+            @ inf_cases ~loc constructors
+            @ catch_all ~loc)
+        in
+        let case_split = pexp_match (pexp_tuple [ evar a; evar b ]) cases in
+        Ok [%expr fun [%p pvar a] [%p pvar b] -> [%e case_split]]
+
+  and tuple ~loc types =
+    let open Ast_builder.Make (struct
+      let loc = loc
+    end) in
+    match result_of_list derive types with
+    | Error e -> Error e
+    | Ok cmps ->
+        let vars_a = Common.var_i ~prefix:"__elt_a" cmps () in
+        let vars_b = Common.var_i ~prefix:"__elt_b" cmps () in
+        let body = Common.fold ~loc cmps vars_a vars_b in
+        let pat_a = ppat_tuple (List.map pvar vars_a) in
+        let pat_b = ppat_tuple (List.map pvar vars_b) in
+        Ok [%expr fun [%p pat_a] [%p pat_b] -> [%e body]]
+
+  and record ~loc fields =
+    let open Ast_builder.Make (struct
+      let loc = loc
+    end) in
+    match result_of_list (fun (_, t) -> derive t) fields with
+    | Error e -> Error e
+    | Ok cmps ->
+        let fields = List.map fst fields in
+        let fields_lidents = List.map Builder.lident fields in
+        let names_a = Common.vars ~prefix:"__field_a" fields () in
+        let names_b = Common.vars ~prefix:"__field_b" fields () in
+        let pat_a =
+          ppat_record
+            (List.combine fields_lidents (List.map pvar names_a))
+            Closed
+        in
+        let pat_b =
+          ppat_record
+            (List.combine fields_lidents (List.map pvar names_b))
+            Closed
+        in
+        let body = Common.fold ~loc cmps names_a names_b in
+        Ok [%expr fun [%p pat_a] [%p pat_b] -> [%e body]]
+
+  and derive (t : Translated.type_) =
+    let loc = t.loc in
+    match t.kind with
+    | Translated.Abstract -> Error (W.Unsupported_comparison "abstract")
+    | Translated.Alpha -> Error (W.Unsupported_comparison "polymorphic")
+    | Translated.Core args -> core ~loc t.name args
+    | Translated.Synonyms (c, a) -> synonyms ~loc c a
+    | Translated.Variant cstrs -> variant ~loc cstrs
+    | Translated.Record fields -> record ~loc fields
+    | Translated.Tuple elts -> tuple ~loc elts
+end

--- a/src/core/types.ml
+++ b/src/core/types.ml
@@ -113,19 +113,7 @@ end
 module W = Warnings
 open Ppxlib
 
-let result_of_list f l =
-  let rec aux = function
-    | [] -> Ok []
-    | x :: t -> (
-        match f x with
-        | Error _ as e -> e
-        | Ok x ->
-            let t = aux t in
-            Result.map (fun t -> x :: t) t)
-  in
-  aux l
-
-module Comparison = struct
+module Common = struct
   let core_type =
     [
       "unit";
@@ -143,103 +131,180 @@ module Comparison = struct
       "set";
     ]
 
-  module Common = struct
-    let var_i ~prefix l () =
-      List.mapi (fun i _ -> gen_symbol ~prefix:(prefix ^ Int.to_string i) ()) l
+  let result_of_list f l =
+    let rec aux = function
+      | [] -> Ok []
+      | x :: t -> (
+          match f x with
+          | Error _ as e -> e
+          | Ok x ->
+              let t = aux t in
+              Result.map (fun t -> x :: t) t)
+    in
+    aux l
 
-    let vars ~prefix l () =
-      List.map (fun s -> gen_symbol ~prefix:(prefix ^ s) ()) l
+  let var_i ~prefix l () =
+    List.mapi (fun i _ -> gen_symbol ~prefix:(prefix ^ Int.to_string i) ()) l
 
-    let item ~loc cmp elt_a elt_b next =
-      let open Ast_builder.Make (struct
-        let loc = loc
-      end) in
-      let res = gen_symbol ~prefix:"__res" () in
-      [%expr
-        let [%p pvar res] = [%e cmp] [%e evar elt_a] [%e evar elt_b] in
-        if [%e evar res] <> 0 then [%e evar res] else [%e next]]
+  let vars ~prefix l () =
+    List.map (fun s -> gen_symbol ~prefix:(prefix ^ s) ()) l
 
-    let rec fold ~loc cmps elts_a elts_b =
-      match (cmps, elts_a, elts_b) with
-      | [], [], [] -> [%expr 0]
-      | c :: cs, elt_a :: elts_a, elt_b :: elts_b ->
-          item ~loc c elt_a elt_b (fold ~loc cs elts_a elts_b)
-      | _, _, _ -> assert false
-  end
+  let rec fold ~loc ~combinator ~operators elts_a elts_b =
+    let open Ast_builder.Make (struct
+      let loc = loc
+    end) in
+    match (operators, elts_a, elts_b) with
+    | [ c ], [ elt_a ], [ elt_b ] ->
+        pexp_apply c [ (Nolabel, evar elt_a); (Nolabel, evar elt_b) ]
+    | c :: cs, elt_a :: elts_a, elt_b :: elts_b ->
+        combinator ~loc c elt_a elt_b
+          (fold ~loc ~combinator ~operators:cs elts_a elts_b)
+    | _, _, _ -> assert false
+
+  let synonyms ~loc ~derive ~core (constructor : Translated.type_) args =
+    if List.mem constructor.name core_type then core ~loc constructor.name args
+    else
+      match args with
+      | [] -> derive constructor
+      | _ -> Error (W.Unsupported_equality constructor.name)
+  (* XXX we don't know yet how to do it *)
+
+  let record_pattern ~loc ~fields ~vars =
+    let open Ast_builder.Make (struct
+      let loc = loc
+    end) in
+    let fields = List.map Builder.lident fields in
+    let vars = List.map pvar vars in
+    ppat_record (List.combine fields vars) Closed
+
+  let record_aux ~loc ~combinator ~fields operators =
+    let open Ast_builder.Make (struct
+      let loc = loc
+    end) in
+    let fields = List.map fst fields in
+    let names_a = vars ~prefix:"__field_a" fields () in
+    let names_b = vars ~prefix:"__field_b" fields () in
+    let pat_a = record_pattern ~loc ~fields ~vars:names_a in
+    let pat_b = record_pattern ~loc ~fields ~vars:names_b in
+    let body = fold ~loc ~combinator ~operators names_a names_b in
+    [%expr fun [%p pat_a] [%p pat_b] -> [%e body]]
+
+  let record ~loc ~derive ~combinator fields =
+    result_of_list (fun (_, t) -> derive t) fields
+    |> Result.map (record_aux ~loc ~combinator ~fields)
+
+  let tuple_aux ~loc ~combinator operators =
+    let open Ast_builder.Make (struct
+      let loc = loc
+    end) in
+    let vars_a = var_i ~prefix:"__elt_a" operators () in
+    let vars_b = var_i ~prefix:"__elt_b" operators () in
+    let body = fold ~loc ~combinator ~operators vars_a vars_b in
+    let pat_a = ppat_tuple (List.map pvar vars_a) in
+    let pat_b = ppat_tuple (List.map pvar vars_b) in
+    [%expr fun [%p pat_a] [%p pat_b] -> [%e body]]
+
+  let tuple ~loc ~derive ~combinator types =
+    result_of_list derive types |> Result.map (tuple_aux ~loc ~combinator)
+
+  let constructor fct = function
+    | Translated.Named fields -> result_of_list (fun (_, t) -> fct t) fields
+    | Translated.Unnamed args -> result_of_list fct args
+
+  let constructor_pattern ~loc (name, constructor) =
+    (* build the pattern corresponding to the constructor and return it along
+       with the list of variable names occuring in it *)
+    let open Ast_builder.Make (struct
+      let loc = loc
+    end) in
+    let cstr = Builder.lident name in
+    let names, rec_pat =
+      match constructor with
+      | Translated.Named fields ->
+          let fields = List.map fst fields in
+          let names = vars ~prefix:"__" fields () in
+          let fields_pat =
+            List.map2 (fun f n -> (Builder.lident f, pvar n)) fields names
+          in
+          (names, Some (ppat_record fields_pat Closed))
+      | Translated.Unnamed args ->
+          let names = var_i ~prefix:"__elt" args () in
+          (names, ppat_tuple_opt (List.map pvar names))
+    in
+    (names, ppat_construct cstr rec_pat)
+
+  let constructor_any_pattern ~loc (name, constructor) =
+    (* build the pattern corresponding to the constructor when we don't
+       need to have variable for its arguments *)
+    let open Ast_builder.Make (struct
+      let loc = loc
+    end) in
+    let cstr = Builder.lident name in
+    let rec_pat =
+      match constructor with
+      | Translated.Named _fields -> Some ppat_any
+      | Translated.Unnamed args ->
+          if List.length args = 0 then None
+          else Some (ppat_tuple (List.map (fun _ -> ppat_any) args))
+    in
+    ppat_construct cstr rec_pat
+
+  let lhs ~loc (c0, arg0) (c1, args1) =
+    let open Ast_builder.Make (struct
+      let loc = loc
+    end) in
+    (* we need to name the arguments of the constructors only if they are the same *)
+    if c0 = c1 then
+      let var0, pat0 = constructor_pattern ~loc (c0, arg0) in
+      let var1, pat1 = constructor_pattern ~loc (c1, args1) in
+      (ppat_tuple [ pat0; pat1 ], var0, var1)
+    else
+      let pat0 = constructor_any_pattern ~loc (c0, arg0) in
+      let pat1 = constructor_any_pattern ~loc (c1, args1) in
+      (ppat_tuple [ pat0; pat1 ], [], [])
+
+  let rhs ~loc ~combinator ~default ~operators var0 var1 =
+    if List.length var0 = 0 then default
+    else fold ~loc ~combinator ~operators var0 var1
+
+  let case ~loc ~combinator ~default ~operators c0 c1 =
+    let lhs, var0, var1 = lhs ~loc c0 c1 in
+    let rhs = rhs ~loc ~combinator ~default ~operators var0 var1 in
+    Ast_builder.Default.case ~lhs ~guard:None ~rhs
+
+  let same_constructor_cases ~loc ~combinator ~default =
+    List.map2 (fun operators c -> case ~loc ~combinator ~default ~operators c c)
+
+  let catch_all ~loc ~default =
+    let open Ast_builder.Make (struct
+      let loc = loc
+    end) in
+    [ case ~lhs:(ppat_tuple [ ppat_any; ppat_any ]) ~guard:None ~rhs:default ]
+
+  let variant ~loc ~cases =
+    let open Ast_builder.Make (struct
+      let loc = loc
+    end) in
+    let a, b = (gen_symbol ~prefix:"__a" (), gen_symbol ~prefix:"__b" ()) in
+    let case_split = pexp_match (pexp_tuple [ evar a; evar b ]) cases in
+    [%expr fun [%p pvar a] [%p pvar b] -> [%e case_split]]
+end
+
+module Comparison = struct
+  let if_then_else ~loc cmp elt_a elt_b next =
+    let open Ast_builder.Make (struct
+      let loc = loc
+    end) in
+    let res = gen_symbol ~prefix:"__res" () in
+    [%expr
+      let [%p pvar res] = [%e cmp] [%e evar elt_a] [%e evar elt_b] in
+      if [%e evar res] <> 0 then [%e evar res] else [%e next]]
 
   module Variant = struct
     (** In this module we define some auxiliary functions for generating
         comparison about variants *)
 
-    let constructor_pattern ~loc (name, constructor) =
-      (* build the pattern corresponding to the constructor and return it along
-         with the list of variable names occuring in it *)
-      let open Ast_builder.Make (struct
-        let loc = loc
-      end) in
-      let cstr = Builder.lident name in
-      let names, rec_pat =
-        match constructor with
-        | Translated.Named fields ->
-            let fields = List.map fst fields in
-            let names = Common.vars ~prefix:"__" fields () in
-            let fields_pat =
-              List.map2 (fun f n -> (Builder.lident f, pvar n)) fields names
-            in
-            (names, Some (ppat_record fields_pat Closed))
-        | Translated.Unnamed args ->
-            let names = Common.var_i ~prefix:"__elt" args () in
-            (names, ppat_tuple_opt (List.map pvar names))
-      in
-      (names, ppat_construct cstr rec_pat)
-
-    let constructor_any_pattern ~loc (name, constructor) =
-      (* build the pattern corresponding to the constructor when we don't
-         need to have variable for its arguments *)
-      let open Ast_builder.Make (struct
-        let loc = loc
-      end) in
-      let cstr = Builder.lident name in
-      let rec_pat =
-        match constructor with
-        | Translated.Named _fields -> Some ppat_any
-        | Translated.Unnamed args ->
-            if List.length args = 0 then None
-            else Some (ppat_tuple (List.map (fun _ -> ppat_any) args))
-      in
-      ppat_construct cstr rec_pat
-
-    let lhs ~loc (c0, arg0) (c1, args1) =
-      let open Ast_builder.Make (struct
-        let loc = loc
-      end) in
-      (* we need to name the arguments od the constructors only if they are the same *)
-      if c0 = c1 then
-        let var0, pat0 = constructor_pattern ~loc (c0, arg0) in
-        let var1, pat1 = constructor_pattern ~loc (c1, args1) in
-        (ppat_tuple [ pat0; pat1 ], var0, var1)
-      else
-        let pat0 = constructor_any_pattern ~loc (c0, arg0) in
-        let pat1 = constructor_any_pattern ~loc (c1, args1) in
-        (ppat_tuple [ pat0; pat1 ], [], [])
-
-    let rhs ~loc cmps var0 var1 =
-      (* As we will check the first argument against the second, we know that if
-         we don't have any names for the arguments the constructor [var0] if less
-         than the constructor [var1] *)
-      if List.length var0 = 0 then [%expr -1]
-      else Common.fold ~loc cmps var0 var1
-
-    let case ~loc cmps c0 c1 =
-      let open Ast_builder.Make (struct
-        let loc = loc
-      end) in
-      let lhs, var0, var1 = lhs ~loc c0 c1 in
-      let rhs = rhs ~loc cmps var0 var1 in
-      case ~lhs ~guard:None ~rhs
-
-    let cmp_cases ~loc = List.map2 (fun cmp c -> case ~loc cmp c c)
-
+    (* specific to comparison *)
     let inf_cases ~loc constructors =
       (* check a.(i) against b.(j) for all i < j *)
       let a = Array.of_list constructors in
@@ -248,17 +313,12 @@ module Comparison = struct
       let rec loop i j =
         if i = stop then []
         else if j = stop then loop (succ i) (i + 2)
-        else case ~loc [] a.(i) b.(j) :: loop i (succ j)
+        else
+          Common.case ~loc ~combinator:if_then_else ~default:[%expr -1]
+            ~operators:[] a.(i) b.(j)
+          :: loop i (succ j)
       in
       loop 0 1
-
-    let catch_all ~loc =
-      let open Ast_builder.Make (struct
-        let loc = loc
-      end) in
-      [
-        case ~lhs:(ppat_tuple [ ppat_any; ppat_any ]) ~guard:None ~rhs:[%expr 1];
-      ]
   end
 
   let rec core ~loc name args =
@@ -285,77 +345,31 @@ module Comparison = struct
             fun [%p pvar a] [%p pvar b] -> [%e cmp] ![%e evar a] ![%e evar b]]
         in
         Result.map build (derive (List.hd args))
-    | "seq" -> Error (W.Unsupported_comparison "seq")
+    | "seq" ->
+        Error (W.Unsupported_comparison "seq")
+        (* XXX How seq are implemented ? *)
     | "bag" -> Error (W.Unsupported_comparison "bag")
     | "set" -> Error (W.Unsupported_comparison "set")
     | _ -> assert false
 
   and synonyms ~loc (constructor : Translated.type_) args =
-    if List.mem constructor.name core_type then core ~loc constructor.name args
-    else
-      match args with
-      | [] -> derive constructor
-      | _ -> Error (W.Unsupported_comparison constructor.name)
-  (* XXX we don't know yet how to do it *)
-
-  and constructor = function
-    | Translated.Named fields -> result_of_list (fun (_, t) -> derive t) fields
-    | Translated.Unnamed args -> result_of_list derive args
+    Common.synonyms ~loc ~derive ~core constructor args
 
   and variant ~loc constructors =
-    let open Ast_builder.Make (struct
-      let loc = loc
-    end) in
-    match result_of_list (fun (_, c) -> constructor c) constructors with
-    | Error e -> Error e
-    | Ok cmps ->
-        let a, b = (gen_symbol ~prefix:"__a" (), gen_symbol ~prefix:"__b" ()) in
-        let cases =
-          Variant.(
-            cmp_cases ~loc cmps constructors
-            @ inf_cases ~loc constructors
-            @ catch_all ~loc)
-        in
-        let case_split = pexp_match (pexp_tuple [ evar a; evar b ]) cases in
-        Ok [%expr fun [%p pvar a] [%p pvar b] -> [%e case_split]]
+    Common.result_of_list
+      (fun (_, c) -> Common.constructor derive c)
+      constructors
+    |> Result.map (fun operators ->
+           let cases =
+             Common.same_constructor_cases ~loc ~combinator:if_then_else
+               ~default:[%expr 0] operators constructors
+             @ Variant.inf_cases ~loc constructors
+             @ Common.catch_all ~loc ~default:[%expr 1]
+           in
+           Common.variant ~loc ~cases)
 
-  and tuple ~loc types =
-    let open Ast_builder.Make (struct
-      let loc = loc
-    end) in
-    match result_of_list derive types with
-    | Error e -> Error e
-    | Ok cmps ->
-        let vars_a = Common.var_i ~prefix:"__elt_a" cmps () in
-        let vars_b = Common.var_i ~prefix:"__elt_b" cmps () in
-        let body = Common.fold ~loc cmps vars_a vars_b in
-        let pat_a = ppat_tuple (List.map pvar vars_a) in
-        let pat_b = ppat_tuple (List.map pvar vars_b) in
-        Ok [%expr fun [%p pat_a] [%p pat_b] -> [%e body]]
-
-  and record ~loc fields =
-    let open Ast_builder.Make (struct
-      let loc = loc
-    end) in
-    match result_of_list (fun (_, t) -> derive t) fields with
-    | Error e -> Error e
-    | Ok cmps ->
-        let fields = List.map fst fields in
-        let fields_lidents = List.map Builder.lident fields in
-        let names_a = Common.vars ~prefix:"__field_a" fields () in
-        let names_b = Common.vars ~prefix:"__field_b" fields () in
-        let pat_a =
-          ppat_record
-            (List.combine fields_lidents (List.map pvar names_a))
-            Closed
-        in
-        let pat_b =
-          ppat_record
-            (List.combine fields_lidents (List.map pvar names_b))
-            Closed
-        in
-        let body = Common.fold ~loc cmps names_a names_b in
-        Ok [%expr fun [%p pat_a] [%p pat_b] -> [%e body]]
+  and tuple ~loc = Common.tuple ~loc ~derive ~combinator:if_then_else
+  and record ~loc = Common.record ~loc ~derive ~combinator:if_then_else
 
   and derive (t : Translated.type_) =
     let loc = t.loc in
@@ -366,5 +380,77 @@ module Comparison = struct
     | Translated.Synonyms (c, a) -> synonyms ~loc c a
     | Translated.Variant cstrs -> variant ~loc cstrs
     | Translated.Record fields -> record ~loc fields
-    | Translated.Tuple elts -> tuple ~loc elts
+    | Translated.Tuple types -> tuple ~loc types
+end
+
+module Equality = struct
+  let conjunction ~loc eq elt_a elt_b next =
+    let open Ast_builder.Make (struct
+      let loc = loc
+    end) in
+    [%expr [%e eq] [%e evar elt_a] [%e evar elt_b] && [%e next]]
+
+  let rec core ~loc name args =
+    let open Ast_builder.Make (struct
+      let loc = loc
+    end) in
+    match name with
+    | "unit" | "bool" | "int" | "char" | "string" | "float" | "integer" ->
+        Ok [%expr ( = )]
+    | "option" ->
+        let build eq = [%expr Option.equal [%e eq]] in
+        Result.map build (derive (List.hd args))
+    | "list" ->
+        let build eq =
+          [%expr
+            fun a b ->
+              try List.for_all2 [%e eq] a b with Invalid_argument _ -> false]
+        in
+        Result.map build (derive (List.hd args))
+    | "array" ->
+        let build eq = [%expr Ortac_runtime.Array.equal [%e eq]] in
+        Result.map build (derive (List.hd args))
+    | "ref" ->
+        let a = gen_symbol ~prefix:"__a" () in
+        let b = gen_symbol ~prefix:"__b" () in
+        let build eq =
+          [%expr
+            fun [%p pvar a] [%p pvar b] -> [%e eq] ![%e evar a] ![%e evar b]]
+        in
+        Result.map build (derive (List.hd args))
+    | "seq" -> Error (W.Unsupported_equality "seq")
+    | "bag" -> Error (W.Unsupported_equality "bag")
+    | "set" -> Error (W.Unsupported_equality "set")
+    | _ -> assert false
+
+  and synonyms ~loc (constructor : Translated.type_) args =
+    Common.synonyms ~loc ~derive ~core constructor args
+
+  and variant ~loc constructors =
+    Common.result_of_list
+      (fun (_, c) -> Common.constructor derive c)
+      constructors
+    |> Result.map (fun operators ->
+           let cases =
+             Common.same_constructor_cases ~loc ~combinator:conjunction
+               ~default:[%expr true] operators constructors
+             @ Common.catch_all ~loc ~default:[%expr false]
+           in
+           Common.variant ~loc ~cases)
+
+  and record ~loc fields =
+    Common.record ~loc ~derive ~combinator:conjunction fields
+
+  and tuple ~loc = Common.tuple ~loc ~derive ~combinator:conjunction
+
+  and derive (t : Translated.type_) =
+    let loc = t.loc in
+    match t.kind with
+    | Translated.Abstract -> Error (W.Unsupported_equality "abstract")
+    | Translated.Alpha -> Error (W.Unsupported_equality "polymorphic")
+    | Translated.Core args -> core ~loc t.name args
+    | Translated.Synonyms (c, a) -> synonyms ~loc c a
+    | Translated.Variant cstrs -> variant ~loc cstrs
+    | Translated.Record fields -> record ~loc fields
+    | Translated.Tuple types -> tuple ~loc types
 end

--- a/src/core/types.mli
+++ b/src/core/types.mli
@@ -6,3 +6,7 @@ module Mutability : sig
 
   val type_spec : driver:Drv.t -> Gospel.Tast.type_spec -> Translated.mutability
 end
+
+module Comparison : sig
+  val derive : Translated.type_ -> (Ppxlib.expression, Warnings.kind) result
+end

--- a/src/core/types.mli
+++ b/src/core/types.mli
@@ -10,3 +10,7 @@ end
 module Comparison : sig
   val derive : Translated.type_ -> (Ppxlib.expression, Warnings.kind) result
 end
+
+module Equality : sig
+  val derive : Translated.type_ -> (Ppxlib.expression, Warnings.kind) result
+end

--- a/src/core/warnings.ml
+++ b/src/core/warnings.ml
@@ -7,6 +7,7 @@ type kind =
   | Ghost_value of string
   | Ghost_type of string
   | Unsupported_model of string * string
+  | Unsupported_comparison of string
   | Function_without_definition of string
   | Predicate_without_definition of string
 
@@ -14,7 +15,8 @@ type t = kind * Location.t
 
 let level = function
   | Unsupported _ | Ghost_value _ | Ghost_type _ | Unsupported_model _
-  | Function_without_definition _ | Predicate_without_definition _ ->
+  | Unsupported_comparison _ | Function_without_definition _
+  | Predicate_without_definition _ ->
       Warning
 
 exception Error of t
@@ -39,6 +41,11 @@ let pp_kind ppf = function
   | Unsupported_model (type_, name) ->
       pf ppf "Model %a of type %a is not supported. It was not translated."
         quoted name quoted type_
+  | Unsupported_comparison name ->
+      pf ppf
+        "Comparison for the type %a is not supported. The clause has not been \
+         translated."
+        quoted name
   | Function_without_definition name ->
       pf ppf "The function %a has no definition. It was not translated." quoted
         name

--- a/src/core/warnings.ml
+++ b/src/core/warnings.ml
@@ -8,6 +8,8 @@ type kind =
   | Ghost_type of string
   | Unsupported_model of string * string
   | Unsupported_comparison of string
+  | Unsupported_equality of string
+  | Unsupported_printer of string
   | Function_without_definition of string
   | Predicate_without_definition of string
 
@@ -15,8 +17,8 @@ type t = kind * Location.t
 
 let level = function
   | Unsupported _ | Ghost_value _ | Ghost_type _ | Unsupported_model _
-  | Unsupported_comparison _ | Function_without_definition _
-  | Predicate_without_definition _ ->
+  | Unsupported_comparison _ | Unsupported_equality _ | Unsupported_printer _
+  | Function_without_definition _ | Predicate_without_definition _ ->
       Warning
 
 exception Error of t
@@ -44,6 +46,16 @@ let pp_kind ppf = function
   | Unsupported_comparison name ->
       pf ppf
         "Comparison for the type %a is not supported. The clause has not been \
+         translated."
+        quoted name
+  | Unsupported_equality name ->
+      pf ppf
+        "Equality for the type %a is not supported. The clause has not been \
+         translated."
+        quoted name
+  | Unsupported_printer name ->
+      pf ppf
+        "Printer for the type %a is not supported. The clause has not been \
          translated."
         quoted name
   | Function_without_definition name ->

--- a/src/default/dune
+++ b/src/default/dune
@@ -2,4 +2,4 @@
  (name ortac_default)
  (preprocess
   (pps ppxlib.metaquot))
- (libraries ortac_core fmt gospel ppxlib ppxlib.ast))
+ (libraries ortac_core fmt gospel ppxlib ppxlib.astlib))

--- a/src/monolith/dune
+++ b/src/monolith/dune
@@ -2,4 +2,4 @@
  (name ortac_monolith)
  (preprocess
   (pps ppxlib.metaquot))
- (libraries ortac_core monolith fmt gospel ppxlib ppxlib.ast))
+ (libraries ortac_core monolith fmt gospel ppxlib ppxlib.astlib))

--- a/src/runtime/ortac_runtime.ml
+++ b/src/runtime/ortac_runtime.ml
@@ -155,6 +155,17 @@ module Array = struct
   let length arr = Array.length arr |> Z.of_int
   let for_all = Array.for_all
 
+  let equal eq a b =
+    let stop = Array.length a in
+    let wrong = Array.length b in
+    let rec loop i =
+      if i = stop then stop = wrong
+      else if i = wrong then false
+      else if eq a.(i) b.(i) then loop (succ i)
+      else false
+    in
+    loop 0
+
   let compare cmp a b =
     let stop = Array.length a in
     let wrong = Array.length b in

--- a/src/runtime/ortac_runtime.ml
+++ b/src/runtime/ortac_runtime.ml
@@ -154,4 +154,14 @@ module Array = struct
 
   let length arr = Array.length arr |> Z.of_int
   let for_all = Array.for_all
+
+  let compare cmp a b =
+    let stop = Array.length a in
+    let wrong = Array.length b in
+    let rec loop i =
+      if i = stop then compare stop wrong
+      else if i = wrong then -1
+      else match cmp a.(i) b.(i) with 0 -> loop (succ i) | i -> i
+    in
+    loop 0
 end

--- a/src/runtime/ortac_runtime_intf.ml
+++ b/src/runtime/ortac_runtime_intf.ml
@@ -58,5 +58,6 @@ module type S = sig
     val get : 'a array -> Z.t -> 'a
     val length : 'a array -> Z.t
     val for_all : ('a -> bool) -> 'a array -> bool
+    val compare : ('a -> 'a -> int) -> 'a array -> 'a array -> int
   end
 end

--- a/src/runtime/ortac_runtime_intf.ml
+++ b/src/runtime/ortac_runtime_intf.ml
@@ -58,6 +58,7 @@ module type S = sig
     val get : 'a array -> Z.t -> 'a
     val length : 'a array -> Z.t
     val for_all : ('a -> bool) -> 'a array -> bool
+    val equal : ('a -> 'a -> bool) -> 'a array -> 'a array -> bool
     val compare : ('a -> 'a -> int) -> 'a array -> 'a array -> int
   end
 end

--- a/test/unit/dune
+++ b/test/unit/dune
@@ -1,0 +1,12 @@
+(rule
+ (targets generated.ml)
+ (deps generate/suite.exe)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run %{deps}))))
+
+(test
+ (name test)
+ (package ortac)
+ (libraries ortac_core ortac-runtime fmt alcotest))

--- a/test/unit/generate/dune
+++ b/test/unit/generate/dune
@@ -1,0 +1,5 @@
+(executable
+ (name suite)
+ (preprocess
+  (pps ppxlib.metaquot))
+ (libraries fmt ortac_core ppxlib ppxlib.ast ppxlib.astlib))

--- a/test/unit/generate/suite.ml
+++ b/test/unit/generate/suite.ml
@@ -13,6 +13,8 @@ module Types = struct
   let array = type_ ~name:"array" ~kind:(Core [ int ])
   let list = type_ ~name:"list" ~kind:(Core [ int ])
   let tuple = type_ ~name:"tuple" ~kind:(Tuple [ int; int; string ])
+  let ref_ = type_ ~name:"ref" ~kind:(Core [ int ])
+  let t = type_ ~name:"t" ~kind:(Synonyms (array, [ string ]))
 
   let record =
     type_ ~name:"record" ~kind:(Record [ ("f0", int); ("f1", string) ])
@@ -44,94 +46,232 @@ module Comparison = struct
   let tuple = Ortac_core.Types.Comparison.derive Types.tuple |> Result.get_ok
   let list = Ortac_core.Types.Comparison.derive Types.list |> Result.get_ok
   let record = Ortac_core.Types.Comparison.derive Types.record |> Result.get_ok
+  let ref_ = Ortac_core.Types.Comparison.derive Types.ref_ |> Result.get_ok
+  let t = Ortac_core.Types.Comparison.derive Types.t |> Result.get_ok
 
   let variant =
     Ortac_core.Types.Comparison.derive Types.variant |> Result.get_ok
+
+  module Tests = struct
+    let int =
+      [%stri
+        let cmp_int () =
+          Alcotest.(check (list int))
+            "compare two int"
+            [ [%e int] 1 1; [%e int] 1 2; [%e int] 2 1 ]
+            [ 0; -1; 1 ]]
+
+    let tuple =
+      [%stri
+        let cmp_tuple () =
+          Alcotest.(check (list int))
+            "compare two tuples"
+            [
+              [%e tuple] (1, 2, "3") (1, 2, "3");
+              [%e tuple] (1, 1, "3") (1, 2, "3");
+              [%e tuple] (1, 2, "4") (1, 2, "3");
+            ]
+            [ 0; -1; 1 ]]
+
+    let array =
+      [%stri
+        let cmp_array () =
+          Alcotest.(check (list int))
+            "compare two arrays"
+            [
+              [%e array] [| 1; 2; 3 |] [| 1; 2; 3 |];
+              [%e array] [| 1; 2; 3 |] [| 2 |];
+              [%e array] [| 1; 2; 3 |] [| 0 |];
+            ]
+            [ 0; -1; 1 ]]
+
+    let record =
+      [%stri
+        let cmp_record () =
+          Alcotest.(check (list int))
+            "compare two records"
+            [
+              [%e record] { f0 = 0; f1 = "hello" } { f0 = 0; f1 = "hello" };
+              [%e record] { f0 = 0; f1 = "hello" } { f0 = 0; f1 = "world" };
+              [%e record] { f0 = 0; f1 = "world" } { f0 = 0; f1 = "hello" };
+            ]
+            [ 0; -1; 1 ]]
+
+    let variant =
+      [%stri
+        let cmp_variant () =
+          Alcotest.(check (list int))
+            "compare two variants"
+            [
+              [%e variant] (C0 (0, "hello")) (C0 (0, "hello"));
+              [%e variant] (C0 (0, "hello")) (C1 { c1a = 0; c1b = "hello" });
+              [%e variant] C2 (C0 (0, "hello"));
+              [%e variant] C2 C2;
+            ]
+            [ 0; -1; 1; 0 ]]
+
+    let ref_ =
+      [%stri
+        let cmp_ref () =
+          let a = ref 42 in
+          let b = ref 42 in
+          let c = ref 73 in
+          Alcotest.(check (list int))
+            "compare two ref"
+            [ [%e ref_] a b; [%e ref_] a c; [%e ref_] c a ]
+            [ 0; -1; 1 ]]
+
+    let t =
+      [%stri
+        let cmp_t () =
+          let a = [| "h"; "e"; "l"; "l"; "o" |] in
+          let b = [| "w"; "o"; "r"; "l"; "d" |] in
+          Alcotest.(check (list int))
+            "compare two arrays"
+            [ [%e t] a a; [%e t] a b; [%e t] b a ]
+            [ 0; -1; 1 ]]
+
+    let tests = [ int; tuple; array; record; variant; ref_; t ]
+  end
 end
 
-module Tests = struct
-  let int =
-    [%stri
-      let cmp_int () =
-        Alcotest.(check (list int))
-          "compare two int"
-          [
-            [%e Comparison.int] 1 1;
-            [%e Comparison.int] 1 2;
-            [%e Comparison.int] 2 1;
-          ]
-          [ 0; -1; 1 ]]
+module Equality = struct
+  let int = Ortac_core.Types.Equality.derive Types.int |> Result.get_ok
+  let string = Ortac_core.Types.Equality.derive Types.string |> Result.get_ok
+  let array = Ortac_core.Types.Equality.derive Types.array |> Result.get_ok
+  let tuple = Ortac_core.Types.Equality.derive Types.tuple |> Result.get_ok
+  let list = Ortac_core.Types.Equality.derive Types.list |> Result.get_ok
+  let record = Ortac_core.Types.Equality.derive Types.record |> Result.get_ok
+  let variant = Ortac_core.Types.Equality.derive Types.variant |> Result.get_ok
+  let ref_ = Ortac_core.Types.Equality.derive Types.ref_ |> Result.get_ok
+  let t = Ortac_core.Types.Equality.derive Types.t |> Result.get_ok
 
-  let tuple =
-    [%stri
-      let cmp_tuple () =
-        Alcotest.(check (list int))
-          "compare two tuples"
-          [
-            [%e Comparison.tuple] (1, 2, "3") (1, 2, "3");
-            [%e Comparison.tuple] (1, 1, "3") (1, 2, "3");
-            [%e Comparison.tuple] (1, 2, "4") (1, 2, "3");
-          ]
-          [ 0; -1; 1 ]]
+  module Tests = struct
+    let int =
+      [%stri
+        let eq_int () =
+          Alcotest.(check (list bool))
+            "equality between two int"
+            [ [%e int] 42 42; [%e int] 42 73 ]
+            [ true; false ]]
 
-  let array =
-    [%stri
-      let cmp_array () =
-        Alcotest.(check (list int))
-          "compare two arrays"
-          [
-            [%e Comparison.array] [| 1; 2; 3 |] [| 1; 2; 3 |];
-            [%e Comparison.array] [| 1; 2; 3 |] [| 2 |];
-            [%e Comparison.array] [| 1; 2; 3 |] [| 0 |];
-          ]
-          [ 0; -1; 1 ]]
+    let ref_ =
+      [%stri
+        let eq_ref () =
+          let a = ref 42 in
+          let b = ref 42 in
+          let c = ref 73 in
+          Alcotest.(check (list bool))
+            "equality between two ref"
+            [ [%e ref_] a b; [%e ref_] a c ]
+            [ true; false ]]
 
-  let record =
-    [%stri
-      let cmp_record () =
-        Alcotest.(check (list int))
-          "compare two records"
-          [
-            [%e Comparison.record] { f0 = 0; f1 = "hello" }
-              { f0 = 0; f1 = "hello" };
-            [%e Comparison.record] { f0 = 0; f1 = "hello" }
-              { f0 = 0; f1 = "world" };
-            [%e Comparison.record] { f0 = 0; f1 = "world" }
-              { f0 = 0; f1 = "hello" };
-          ]
-          [ 0; -1; 1 ]]
+    let list =
+      [%stri
+        let eq_list () =
+          Alcotest.(check (list bool))
+            "equality between two list"
+            [
+              [%e list] [ 42; 73 ] [ 42; 73 ];
+              [%e list] [ 42; 73 ] [ 42; 74 ];
+              [%e list] [ 42; 73 ] [ 42 ];
+              [%e list] [ 42 ] [ 42; 73 ];
+              [%e list] [] [ 42; 73 ];
+            ]
+            [ true; false; false; false; false ]]
 
-  let variant =
-    [%stri
-      let cmp_variant () =
-        Alcotest.(check (list int))
-          "compare two variants"
-          [
-            [%e Comparison.variant] (C0 (0, "hello")) (C0 (0, "hello"));
-            [%e Comparison.variant]
-              (C0 (0, "hello"))
-              (C1 { c1a = 0; c1b = "hello" });
-            [%e Comparison.variant] C2 (C0 (0, "hello"));
-          ]
-          [ 0; -1; 1 ]]
+    let array =
+      [%stri
+        let eq_array () =
+          Alcotest.(check (list bool))
+            "equality between two list"
+            [
+              [%e array] [| 42; 73 |] [| 42; 73 |];
+              [%e array] [| 42; 73 |] [| 42; 74 |];
+              [%e array] [| 42; 73 |] [| 42 |];
+              [%e array] [| 42 |] [| 42; 73 |];
+              [%e array] [||] [| 42; 73 |];
+            ]
+            [ true; false; false; false; false ]]
 
-  let tests = [ int; tuple; array; record; variant ]
+    let tuple =
+      [%stri
+        let eq_tuple () =
+          Alcotest.(check (list bool))
+            "equality between two tuple"
+            [
+              [%e tuple] (42, 73, "hello") (42, 73, "hello");
+              [%e tuple] (42, 73, "hello") (42, 73, "world");
+            ]
+            [ true; false ]]
+
+    let record =
+      [%stri
+        let eq_record () =
+          Alcotest.(check (list bool))
+            "compare two records"
+            [
+              [%e record] { f0 = 0; f1 = "hello" } { f0 = 0; f1 = "hello" };
+              [%e record] { f0 = 0; f1 = "hello" } { f0 = 0; f1 = "world" };
+            ]
+            [ true; false ]]
+
+    let variant =
+      [%stri
+        let eq_variant () =
+          Alcotest.(check (list bool))
+            "compare two variants"
+            [
+              [%e variant] (C0 (0, "hello")) (C0 (0, "hello"));
+              [%e variant]
+                (C1 { c1a = 0; c1b = "world" })
+                (C1 { c1a = 0; c1b = "hello" });
+              [%e variant] C2 (C0 (0, "hello"));
+              [%e variant] C2 C2;
+            ]
+            [ true; false; false; true ]]
+
+    let t =
+      [%stri
+        let eq_t () =
+          let a = [| "h"; "e"; "l"; "l"; "o" |] in
+          let b = [| "w"; "o"; "r"; "l"; "d" |] in
+          Alcotest.(check (list bool))
+            "compare two arrays"
+            [ [%e t] a a; [%e t] a b; [%e t] b a ]
+            [ true; false; false ]]
+
+    let tests = [ int; ref_; list; array; tuple; record; variant; t ]
+  end
 end
 
 let suite =
-  [
-    [%stri
-      let suite =
-        ( "Comparison",
-          [
-            ("compare int is ok", `Quick, cmp_int);
-            ("compare tuple is ok", `Quick, cmp_tuple);
-            ("compare array is ok", `Quick, cmp_array);
-            ("compare record is ok", `Quick, cmp_record);
-            ("compare variant is ok", `Quick, cmp_variant);
-          ] )];
-  ]
+  [%str
+    let comparison_suite =
+      ( "Comparison",
+        [
+          ("compare int is ok", `Quick, cmp_int);
+          ("compare tuple is ok", `Quick, cmp_tuple);
+          ("compare array is ok", `Quick, cmp_array);
+          ("compare record is ok", `Quick, cmp_record);
+          ("compare variant is ok", `Quick, cmp_variant);
+          ("compare synonym is ok", `Quick, cmp_t);
+          ("compare ref is ok", `Quick, cmp_ref);
+        ] )
+
+    let equality_suite =
+      ( "Equality",
+        [
+          ("equality between int is ok", `Quick, eq_int);
+          ("equality between list is ok", `Quick, eq_list);
+          ("equality between array is ok", `Quick, eq_array);
+          ("equality between tuple is ok", `Quick, eq_tuple);
+          ("equality between record is ok", `Quick, eq_record);
+          ("equality between variant is ok", `Quick, eq_variant);
+          ("equality between ref is ok", `Quick, eq_ref);
+          ("equality between synonym is ok", `Quick, eq_t);
+        ] )]
 
 let () =
   Fmt.pf Fmt.stdout "%a@." Ppxlib_ast.Pprintast.structure
-    (Types.types @ Tests.tests @ suite)
+    (Types.types @ Comparison.Tests.tests @ Equality.Tests.tests @ suite)

--- a/test/unit/generate/suite.ml
+++ b/test/unit/generate/suite.ml
@@ -1,0 +1,137 @@
+open Ppxlib
+
+let loc = Location.none
+
+module Types = struct
+  open Ortac_core
+
+  let mutable_ = Translated.Unknown
+  let ghost = false
+  let type_ = Translated.type_ ~loc ~mutable_ ~ghost
+  let int = type_ ~name:"int" ~kind:(Core [])
+  let string = type_ ~name:"string" ~kind:(Core [])
+  let array = type_ ~name:"array" ~kind:(Core [ int ])
+  let list = type_ ~name:"list" ~kind:(Core [ int ])
+  let tuple = type_ ~name:"tuple" ~kind:(Tuple [ int; int; string ])
+
+  let record =
+    type_ ~name:"record" ~kind:(Record [ ("f0", int); ("f1", string) ])
+
+  let variant =
+    type_ ~name:"variant"
+      ~kind:
+        (Variant
+           [
+             ("C0", Translated.Unnamed [ int; string ]);
+             ("C1", Translated.Named [ ("c1a", int); ("c1b", string) ]);
+             ("C2", Translated.Unnamed []);
+           ])
+
+  let types =
+    [%str
+      type record = { f0 : int; f1 : string }
+
+      type variant =
+        | C0 of (int * string)
+        | C1 of { c1a : int; c1b : string }
+        | C2]
+end
+
+module Comparison = struct
+  let int = Ortac_core.Types.Comparison.derive Types.int |> Result.get_ok
+  let string = Ortac_core.Types.Comparison.derive Types.string |> Result.get_ok
+  let array = Ortac_core.Types.Comparison.derive Types.array |> Result.get_ok
+  let tuple = Ortac_core.Types.Comparison.derive Types.tuple |> Result.get_ok
+  let list = Ortac_core.Types.Comparison.derive Types.list |> Result.get_ok
+  let record = Ortac_core.Types.Comparison.derive Types.record |> Result.get_ok
+
+  let variant =
+    Ortac_core.Types.Comparison.derive Types.variant |> Result.get_ok
+end
+
+module Tests = struct
+  let int =
+    [%stri
+      let cmp_int () =
+        Alcotest.(check (list int))
+          "compare two int"
+          [
+            [%e Comparison.int] 1 1;
+            [%e Comparison.int] 1 2;
+            [%e Comparison.int] 2 1;
+          ]
+          [ 0; -1; 1 ]]
+
+  let tuple =
+    [%stri
+      let cmp_tuple () =
+        Alcotest.(check (list int))
+          "compare two tuples"
+          [
+            [%e Comparison.tuple] (1, 2, "3") (1, 2, "3");
+            [%e Comparison.tuple] (1, 1, "3") (1, 2, "3");
+            [%e Comparison.tuple] (1, 2, "4") (1, 2, "3");
+          ]
+          [ 0; -1; 1 ]]
+
+  let array =
+    [%stri
+      let cmp_array () =
+        Alcotest.(check (list int))
+          "compare two arrays"
+          [
+            [%e Comparison.array] [| 1; 2; 3 |] [| 1; 2; 3 |];
+            [%e Comparison.array] [| 1; 2; 3 |] [| 2 |];
+            [%e Comparison.array] [| 1; 2; 3 |] [| 0 |];
+          ]
+          [ 0; -1; 1 ]]
+
+  let record =
+    [%stri
+      let cmp_record () =
+        Alcotest.(check (list int))
+          "compare two records"
+          [
+            [%e Comparison.record] { f0 = 0; f1 = "hello" }
+              { f0 = 0; f1 = "hello" };
+            [%e Comparison.record] { f0 = 0; f1 = "hello" }
+              { f0 = 0; f1 = "world" };
+            [%e Comparison.record] { f0 = 0; f1 = "world" }
+              { f0 = 0; f1 = "hello" };
+          ]
+          [ 0; -1; 1 ]]
+
+  let variant =
+    [%stri
+      let cmp_variant () =
+        Alcotest.(check (list int))
+          "compare two variants"
+          [
+            [%e Comparison.variant] (C0 (0, "hello")) (C0 (0, "hello"));
+            [%e Comparison.variant]
+              (C0 (0, "hello"))
+              (C1 { c1a = 0; c1b = "hello" });
+            [%e Comparison.variant] C2 (C0 (0, "hello"));
+          ]
+          [ 0; -1; 1 ]]
+
+  let tests = [ int; tuple; array; record; variant ]
+end
+
+let suite =
+  [
+    [%stri
+      let suite =
+        ( "Comparison",
+          [
+            ("compare int is ok", `Quick, cmp_int);
+            ("compare tuple is ok", `Quick, cmp_tuple);
+            ("compare array is ok", `Quick, cmp_array);
+            ("compare record is ok", `Quick, cmp_record);
+            ("compare variant is ok", `Quick, cmp_variant);
+          ] )];
+  ]
+
+let () =
+  Fmt.pf Fmt.stdout "%a@." Ppxlib_ast.Pprintast.structure
+    (Types.types @ Tests.tests @ suite)

--- a/test/unit/test.ml
+++ b/test/unit/test.ml
@@ -1,0 +1,3 @@
+let () =
+  Fmt.(set_style_renderer stderr `Ansi_tty);
+  Alcotest.run "Gospel-rtac" [ Generated.suite ]

--- a/test/unit/test.ml
+++ b/test/unit/test.ml
@@ -1,3 +1,4 @@
 let () =
   Fmt.(set_style_renderer stderr `Ansi_tty);
-  Alcotest.run "Gospel-rtac" [ Generated.suite ]
+  Alcotest.run "Gospel-rtac"
+    [ Generated.comparison_suite; Generated.equality_suite ]


### PR DESCRIPTION
In this PR we derive some functions from the information
present in the `Translated.type_`.

- [x] comparison function
- [x] equality function for simple types (int, list, array, record, variant...)
- [ ] equality function for bags and sets 
- [ ] how to use it in terms (need a translation `Gospel.Tterm.t_node -> Translated.type_`)
