### PR TITLE
remove ppxlib and ppxlib.ast dependencies for cli

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -10,6 +10,4 @@
   gospel
   ortac_default
   ortac_core
-  ortac_monolith
-  ppxlib
-  ppxlib.ast))
+  ortac_monolith))


### PR DESCRIPTION
These dependencies dates from the first separated cli but are no longer needed.