### PR TITLE
Fixes lower bound for alcotest

### DIFF
--- a/ortac.opam
+++ b/ortac.opam
@@ -32,7 +32,7 @@ depends: [
   "fmt"
   "ppxlib" {>= "0.26.0"}
   "gospel"
-  "alcotest" {with-test}
+  "alcotest" {>= "0.8.1" with-test}
   "pprint" {with-test}
   "ortac-runtime" {with-test}
   "ortac-runtime-monolith" {with-test}


### PR DESCRIPTION
`Alcotest.failf` was added in [0.8.1](https://github.com/mirage/alcotest/blob/main/CHANGES.md#081-2017-08-03)