### PR TITLE
Map the full Gospelstdlib to the Ortac_runtime.Gospelstdlib module

### DIFF
--- a/src/core/builder.ml
+++ b/src/core/builder.ml
@@ -5,13 +5,13 @@ include Ast_builder.Make (struct
 end)
 
 let noloc txt = { txt; loc = Location.none }
-let epred e = eapply (evar "Ortac_runtime.Z.pred") [ e ]
-let esucc e = eapply (evar "Ortac_runtime.Z.succ") [ e ]
+let epred e = eapply (evar "Ortac_runtime.Gospelstdlib.pred") [ e ]
+let esucc e = eapply (evar "Ortac_runtime.Gospelstdlib.succ") [ e ]
 
 let econst = function
   | Pconst_integer (c, o) ->
       Pconst_integer (c, o) |> pexp_constant |> fun e ->
-      eapply (evar "Ortac_runtime.Z.of_int") [ e ]
+      eapply (evar "Ortac_runtime.Gospelstdlib.integer_of_int") [ e ]
   | _ as e -> pexp_constant e
 
 let eposition pos =

--- a/src/core/context.ml
+++ b/src/core/context.ml
@@ -33,6 +33,33 @@ let builtins =
     ([ "infix =" ], "(=)");
   ]
 
+let supported_stdlib =
+  [
+    ([], "prefix !");
+    ([], "infix +");
+    ([], "infix -");
+    ([], "infix *");
+    ([], "infix /");
+    ([], "mod");
+    ([], "pow");
+    ([], "logand");
+    ([], "prefix -");
+    ([], "infix >");
+    ([], "infix >=");
+    ([], "infix <");
+    ([], "infix <=");
+    ([], "integer_of_int");
+    ([], "abs");
+    ([], "min");
+    ([], "max");
+    ([], "succ");
+    ([], "pred");
+    ([ "Array" ], "make");
+    ([ "Array" ], "length");
+    ([ "Array" ], "get");
+    ([ "Array" ], "for_all");
+  ]
+
 (** Map a name from the Gospel parser to an OCaml name when possible
 
     The strategy is as follows, always dropping the "*fix " prefix of the
@@ -62,15 +89,7 @@ let process_name name =
   else if starts p_mix then None
   else Some name
 
-let fold_namespace f path ns v =
-  let rec aux path ns v =
-    let v = Gospel.Tmodule.Mstr.fold (f path) ns.ns_ls v in
-    Gospel.Tmodule.Mstr.fold (fun s -> aux (path @ [ s ])) ns.ns_ns v
-  in
-  aux path ns v
-
 let init module_name env =
-  let gostd = Gospel.Tmodule.Mstr.find "Gospelstdlib" env.ns_ns in
   let process_gostd_entry path name ls lib =
     match process_name name with
     | None -> lib
@@ -86,7 +105,12 @@ let init module_name env =
       L.empty builtins
   in
   let stdlib =
-    fold_namespace process_gostd_entry [ "Gospelstdlib" ] gostd stdlib
+    List.fold_left
+      (fun lib (path, name) ->
+        let fullpath = "Gospelstdlib" :: path in
+        let ls = get_ls_env env (fullpath @ [ name ]) in
+        process_gostd_entry fullpath name ls lib)
+      stdlib supported_stdlib
   in
   { module_name; stdlib; env; functions = L.empty }
 

--- a/src/core/dune
+++ b/src/core/dune
@@ -4,3 +4,9 @@
  (preprocess
   (pps ppxlib.metaquot))
  (libraries fmt gospel ppxlib ppxlib.ast))
+
+(rule
+ (enabled_if
+  (< %{ocaml_version} 4.13))
+ (action
+  (copy string.pre413.ml string.ml)))

--- a/src/core/string.pre413.ml
+++ b/src/core/string.pre413.ml
@@ -1,0 +1,8 @@
+include Stdlib.String
+
+(* Before 4.13, starts_with is not provided *)
+let starts_with ~prefix word =
+  let rec aux pos =
+    pos < 0 || (get prefix pos = get word pos && aux (pos - 1))
+  in
+  length prefix <= length word && aux (length prefix - 1)

--- a/src/runtime/ortac_runtime.ml
+++ b/src/runtime/ortac_runtime.ml
@@ -130,10 +130,10 @@ module Gospelstdlib = struct
   let ( - ) = Z.( - )
   let ( * ) = Z.( * )
   let ( / ) = Z.( / )
-  let ( < ) = Z.Compare.( < )
-  let ( <= ) = Z.Compare.( <= )
-  let ( > ) = Z.Compare.( > )
-  let ( >= ) = Z.Compare.( >= )
+  let ( < ) = Z.lt
+  let ( <= ) = Z.leq
+  let ( > ) = Z.gt
+  let ( >= ) = Z.geq
   let ( mod ) = Z.( mod )
   let ( ~- ) = Z.( ~- )
   let abs = Z.abs

--- a/src/runtime/ortac_runtime.ml
+++ b/src/runtime/ortac_runtime.ml
@@ -120,30 +120,56 @@ module Errors = struct
         raise (Error t)
 end
 
-module Z = struct
-  include Z
+module Gospelstdlib = struct
+  (** Implementation of the Gospel Stdlib *)
+
+  (* TODO: This should follow the same order than in gospelstdlib.mli *)
+
+  let ( ~! ) = ( ! )
+  let ( + ) = Z.( + )
+  let ( - ) = Z.( - )
+  let ( * ) = Z.( * )
+  let ( / ) = Z.( / )
+  let ( < ) = Z.Compare.( < )
+  let ( <= ) = Z.Compare.( <= )
+  let ( > ) = Z.Compare.( > )
+  let ( >= ) = Z.Compare.( >= )
+  let ( mod ) = Z.( mod )
+  let ( ~- ) = Z.( ~- )
+  let abs = Z.abs
+  let logand = Z.logand
+  let max = Z.max
+  let min = Z.min
+  let pred = Z.pred
+  let succ = Z.succ
 
   let pow x n =
-    try pow x (to_int n) with Overflow -> invalid_arg "Exponent too big"
+    try Z.pow x (Z.to_int n) with Z.Overflow -> invalid_arg "Exponent too big"
+
+  let integer_of_int = Z.of_int
+
+  module Array = struct
+    let make z =
+      if Z.(z > of_int Sys.max_array_length) then
+        raise (Invalid_argument "Array length too big")
+      else Array.make (Z.to_int z)
+
+    let get arr z =
+      if Z.(z < zero || z >= of_int (Array.length arr)) then
+        raise (Invalid_argument "Out of array bounds")
+      else Array.unsafe_get arr (Z.to_int z)
+
+    let length arr = Array.length arr |> Z.of_int
+    let for_all = Array.for_all
+  end
+end
+
+module Z = struct
+  open Z
 
   let rec forall start stop p =
     start > stop || (p start && forall (succ start) stop p)
 
   let rec exists start stop p =
     start <= stop && (p start || exists (succ start) stop p)
-end
-
-module Array = struct
-  let make z =
-    if Z.(z > of_int Sys.max_array_length) then
-      raise (Invalid_argument "Array length too big")
-    else Array.make (Z.to_int z)
-
-  let get arr z =
-    if Z.(z < zero || z >= of_int (Array.length arr)) then
-      raise (Invalid_argument "Out of array bounds")
-    else Array.unsafe_get arr (Z.to_int z)
-
-  let length arr = Array.length arr |> Z.of_int
-  let for_all = Array.for_all
 end

--- a/src/runtime/ortac_runtime_intf.ml
+++ b/src/runtime/ortac_runtime_intf.ml
@@ -39,24 +39,42 @@ module type S = sig
     (** [report l] prints the content of [l] *)
   end
 
+  module Gospelstdlib : sig
+    val ( ~! ) : 'a ref -> 'a
+    val ( + ) : Z.t -> Z.t -> Z.t
+    val ( - ) : Z.t -> Z.t -> Z.t
+    val ( * ) : Z.t -> Z.t -> Z.t
+    val ( / ) : Z.t -> Z.t -> Z.t
+    val ( < ) : Z.t -> Z.t -> bool
+    val ( <= ) : Z.t -> Z.t -> bool
+    val ( > ) : Z.t -> Z.t -> bool
+    val ( >= ) : Z.t -> Z.t -> bool
+    val ( mod ) : Z.t -> Z.t -> Z.t
+    val ( ~- ) : Z.t -> Z.t
+    val abs : Z.t -> Z.t
+    val logand : Z.t -> Z.t -> Z.t
+    val max : Z.t -> Z.t -> Z.t
+    val min : Z.t -> Z.t -> Z.t
+    val pred : Z.t -> Z.t
+    val succ : Z.t -> Z.t
+    val pow : Z.t -> Z.t -> Z.t
+    val integer_of_int : int -> Z.t
+
+    module Array : sig
+      val make : Z.t -> 'a -> 'a array
+      val get : 'a array -> Z.t -> 'a
+      val length : 'a array -> Z.t
+      val for_all : ('a -> bool) -> 'a array -> bool
+    end
+  end
+
   module Z : sig
-    include module type of Z
-
-    val pow : t -> t -> t
-
-    val exists : t -> t -> (t -> bool) -> bool
+    val exists : Z.t -> Z.t -> (Z.t -> bool) -> bool
     (** [exists i j p] is [true] iff the predicate there exists [k] within [i]
         and [j], included, for which [p] holds. *)
 
-    val forall : t -> t -> (t -> bool) -> bool
+    val forall : Z.t -> Z.t -> (Z.t -> bool) -> bool
     (** [forall i j p] is [true] iff the predicate `p` holds forall [k] within
         [i] and [j], included. *)
-  end
-
-  module Array : sig
-    val make : Z.t -> 'a -> 'a array
-    val get : 'a array -> Z.t -> 'a
-    val length : 'a array -> Z.t
-    val for_all : ('a -> bool) -> 'a array -> bool
   end
 end

--- a/test/generated/default/wrapper.expected.ml
+++ b/test/generated/default/wrapper.expected.ml
@@ -5,11 +5,13 @@ let __invariant___001_ __error___002_ __position___003_ t =
     not
       (try
          let __t1__004_ =
-           Ortac_runtime.Z.leq (Ortac_runtime.Z.of_int 0)
-             (Ortac_runtime.Z.of_int t.size) in
+           Ortac_runtime.Gospelstdlib.(<=)
+             (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+             (Ortac_runtime.Gospelstdlib.integer_of_int t.size) in
          let __t2__005_ =
-           Ortac_runtime.Z.leq (Ortac_runtime.Z.of_int t.size)
-             (Ortac_runtime.Z.of_int 32) in
+           Ortac_runtime.Gospelstdlib.(<=)
+             (Ortac_runtime.Gospelstdlib.integer_of_int t.size)
+             (Ortac_runtime.Gospelstdlib.integer_of_int 32) in
          __t1__004_ && __t2__005_
        with
        | e ->
@@ -35,12 +37,15 @@ let __invariant___006_ __error___007_ __position___008_ t =
     not
       (try
          let __t1__009_ =
-           Ortac_runtime.Z.leq (Ortac_runtime.Z.of_int 0)
-             (Ortac_runtime.Z.of_int t.mask) in
+           Ortac_runtime.Gospelstdlib.(<=)
+             (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+             (Ortac_runtime.Gospelstdlib.integer_of_int t.mask) in
          let __t2__010_ =
-           Ortac_runtime.Z.lt (Ortac_runtime.Z.of_int t.mask)
-             (Ortac_runtime.Z.pow (Ortac_runtime.Z.of_int 2)
-                (Ortac_runtime.Z.of_int t.size)) in
+           Ortac_runtime.Gospelstdlib.(<)
+             (Ortac_runtime.Gospelstdlib.integer_of_int t.mask)
+             (Ortac_runtime.Gospelstdlib.pow
+                (Ortac_runtime.Gospelstdlib.integer_of_int 2)
+                (Ortac_runtime.Gospelstdlib.integer_of_int t.size)) in
          __t1__009_ && __t2__010_
        with
        | e ->
@@ -63,9 +68,11 @@ let __invariant___006_ __error___007_ __position___008_ t =
       |> (Ortac_runtime.Errors.register __error___007_)
 let __logical_mem__011_ i bv =
   not
-    ((Ortac_runtime.Z.logand (Ortac_runtime.Z.of_int bv.mask)
-        (Ortac_runtime.Z.pow (Ortac_runtime.Z.of_int 2) i))
-       = (Ortac_runtime.Z.of_int 0))
+    ((Ortac_runtime.Gospelstdlib.logand
+        (Ortac_runtime.Gospelstdlib.integer_of_int bv.mask)
+        (Ortac_runtime.Gospelstdlib.pow
+           (Ortac_runtime.Gospelstdlib.integer_of_int 2) i))
+       = (Ortac_runtime.Gospelstdlib.integer_of_int 0))
 let create n =
   let __error__012_ =
     Ortac_runtime.Errors.create
@@ -89,11 +96,13 @@ let create n =
     not
       (try
          let __t1__013_ =
-           Ortac_runtime.Z.leq (Ortac_runtime.Z.of_int 0)
-             (Ortac_runtime.Z.of_int n) in
+           Ortac_runtime.Gospelstdlib.(<=)
+             (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+             (Ortac_runtime.Gospelstdlib.integer_of_int n) in
          let __t2__014_ =
-           Ortac_runtime.Z.leq (Ortac_runtime.Z.of_int n)
-             (Ortac_runtime.Z.of_int 32) in
+           Ortac_runtime.Gospelstdlib.(<=)
+             (Ortac_runtime.Gospelstdlib.integer_of_int n)
+             (Ortac_runtime.Gospelstdlib.integer_of_int 32) in
          __t1__013_ && __t2__014_
        with
        | e ->
@@ -119,8 +128,10 @@ let create n =
    if
      not
        (try
-          Ortac_runtime.Z.forall (Ortac_runtime.Z.of_int 0)
-            (Ortac_runtime.Z.pred (Ortac_runtime.Z.of_int n))
+          Ortac_runtime.Z.forall
+            (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+            (Ortac_runtime.Gospelstdlib.pred
+               (Ortac_runtime.Gospelstdlib.integer_of_int n))
             (fun i_1 -> not (__logical_mem__011_ i_1 bv_1))
         with
         | e ->
@@ -181,11 +192,13 @@ let add i_2 bv_2 =
     not
       (try
          let __t1__016_ =
-           Ortac_runtime.Z.leq (Ortac_runtime.Z.of_int 0)
-             (Ortac_runtime.Z.of_int i_2) in
+           Ortac_runtime.Gospelstdlib.(<=)
+             (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+             (Ortac_runtime.Gospelstdlib.integer_of_int i_2) in
          let __t2__017_ =
-           Ortac_runtime.Z.lt (Ortac_runtime.Z.of_int i_2)
-             (Ortac_runtime.Z.of_int bv_2.size) in
+           Ortac_runtime.Gospelstdlib.(<)
+             (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
+             (Ortac_runtime.Gospelstdlib.integer_of_int bv_2.size) in
          __t1__016_ && __t2__017_
        with
        | e ->
@@ -242,11 +255,13 @@ let mem i_3 bv_3 =
     not
       (try
          let __t1__021_ =
-           Ortac_runtime.Z.leq (Ortac_runtime.Z.of_int 0)
-             (Ortac_runtime.Z.of_int i_3) in
+           Ortac_runtime.Gospelstdlib.(<=)
+             (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+             (Ortac_runtime.Gospelstdlib.integer_of_int i_3) in
          let __t2__022_ =
-           Ortac_runtime.Z.lt (Ortac_runtime.Z.of_int i_3)
-             (Ortac_runtime.Z.of_int bv_3.size) in
+           Ortac_runtime.Gospelstdlib.(<)
+             (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
+             (Ortac_runtime.Gospelstdlib.integer_of_int bv_3.size) in
          __t1__021_ && __t2__022_
        with
        | e ->
@@ -280,7 +295,8 @@ let mem i_3 bv_3 =
      not
        (try
           (b = true) =
-            (__logical_mem__011_ (Ortac_runtime.Z.of_int i_3) bv_3)
+            (__logical_mem__011_
+               (Ortac_runtime.Gospelstdlib.integer_of_int i_3) bv_3)
         with
         | e ->
             ((Ortac_runtime.Specification_failure

--- a/test/generated/monolith/wrapper.expected.ml
+++ b/test/generated/monolith/wrapper.expected.ml
@@ -9,11 +9,13 @@ module R =
         not
           (try
              let __t1__004_ =
-               Ortac_runtime.Z.leq (Ortac_runtime.Z.of_int 0)
-                 (Ortac_runtime.Z.of_int t.size) in
+               Ortac_runtime.Gospelstdlib.(<=)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int t.size) in
              let __t2__005_ =
-               Ortac_runtime.Z.leq (Ortac_runtime.Z.of_int t.size)
-                 (Ortac_runtime.Z.of_int 32) in
+               Ortac_runtime.Gospelstdlib.(<=)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int t.size)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int 32) in
              __t1__004_ && __t2__005_
            with
            | e ->
@@ -39,12 +41,15 @@ module R =
         not
           (try
              let __t1__009_ =
-               Ortac_runtime.Z.leq (Ortac_runtime.Z.of_int 0)
-                 (Ortac_runtime.Z.of_int t.mask) in
+               Ortac_runtime.Gospelstdlib.(<=)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int t.mask) in
              let __t2__010_ =
-               Ortac_runtime.Z.lt (Ortac_runtime.Z.of_int t.mask)
-                 (Ortac_runtime.Z.pow (Ortac_runtime.Z.of_int 2)
-                    (Ortac_runtime.Z.of_int t.size)) in
+               Ortac_runtime.Gospelstdlib.(<)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int t.mask)
+                 (Ortac_runtime.Gospelstdlib.pow
+                    (Ortac_runtime.Gospelstdlib.integer_of_int 2)
+                    (Ortac_runtime.Gospelstdlib.integer_of_int t.size)) in
              __t1__009_ && __t2__010_
            with
            | e ->
@@ -67,9 +72,11 @@ module R =
           |> (Ortac_runtime.Errors.register __error___007_)
     let __logical_mem__011_ i bv =
       not
-        ((Ortac_runtime.Z.logand (Ortac_runtime.Z.of_int bv.mask)
-            (Ortac_runtime.Z.pow (Ortac_runtime.Z.of_int 2) i))
-           = (Ortac_runtime.Z.of_int 0))
+        ((Ortac_runtime.Gospelstdlib.logand
+            (Ortac_runtime.Gospelstdlib.integer_of_int bv.mask)
+            (Ortac_runtime.Gospelstdlib.pow
+               (Ortac_runtime.Gospelstdlib.integer_of_int 2) i))
+           = (Ortac_runtime.Gospelstdlib.integer_of_int 0))
     let create n =
       let __error__012_ =
         Ortac_runtime.Errors.create
@@ -93,11 +100,13 @@ module R =
         not
           (try
              let __t1__013_ =
-               Ortac_runtime.Z.leq (Ortac_runtime.Z.of_int 0)
-                 (Ortac_runtime.Z.of_int n) in
+               Ortac_runtime.Gospelstdlib.(<=)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int n) in
              let __t2__014_ =
-               Ortac_runtime.Z.leq (Ortac_runtime.Z.of_int n)
-                 (Ortac_runtime.Z.of_int 32) in
+               Ortac_runtime.Gospelstdlib.(<=)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int n)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int 32) in
              __t1__013_ && __t2__014_
            with
            | e ->
@@ -124,8 +133,10 @@ module R =
        if
          not
            (try
-              Ortac_runtime.Z.forall (Ortac_runtime.Z.of_int 0)
-                (Ortac_runtime.Z.pred (Ortac_runtime.Z.of_int n))
+              Ortac_runtime.Z.forall
+                (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                (Ortac_runtime.Gospelstdlib.pred
+                   (Ortac_runtime.Gospelstdlib.integer_of_int n))
                 (fun i_1 -> not (__logical_mem__011_ i_1 bv_1))
             with
             | e ->
@@ -186,11 +197,13 @@ module R =
         not
           (try
              let __t1__016_ =
-               Ortac_runtime.Z.leq (Ortac_runtime.Z.of_int 0)
-                 (Ortac_runtime.Z.of_int i_2) in
+               Ortac_runtime.Gospelstdlib.(<=)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int i_2) in
              let __t2__017_ =
-               Ortac_runtime.Z.lt (Ortac_runtime.Z.of_int i_2)
-                 (Ortac_runtime.Z.of_int bv_2.size) in
+               Ortac_runtime.Gospelstdlib.(<)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int bv_2.size) in
              __t1__016_ && __t2__017_
            with
            | e ->
@@ -248,11 +261,13 @@ module R =
         not
           (try
              let __t1__021_ =
-               Ortac_runtime.Z.leq (Ortac_runtime.Z.of_int 0)
-                 (Ortac_runtime.Z.of_int i_3) in
+               Ortac_runtime.Gospelstdlib.(<=)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int i_3) in
              let __t2__022_ =
-               Ortac_runtime.Z.lt (Ortac_runtime.Z.of_int i_3)
-                 (Ortac_runtime.Z.of_int bv_3.size) in
+               Ortac_runtime.Gospelstdlib.(<)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
+                 (Ortac_runtime.Gospelstdlib.integer_of_int bv_3.size) in
              __t1__021_ && __t2__022_
            with
            | e ->
@@ -287,7 +302,8 @@ module R =
          not
            (try
               (b = true) =
-                (__logical_mem__011_ (Ortac_runtime.Z.of_int i_3) bv_3)
+                (__logical_mem__011_
+                   (Ortac_runtime.Gospelstdlib.integer_of_int i_3) bv_3)
             with
             | e ->
                 ((Ortac_runtime.Specification_failure


### PR DESCRIPTION
This is really a one-commit PR, but it was based on #72.

Instead of hard-coding an association table that maps Gospel Stdlib values to their equivalent OCaml code, expect the target runtime to provide its own implementation in the Ortac_runtime.Gospelstdlib module, following exactly the same structure as the Gospel Stdlib. Consequently, Ortac_runtime_intf.Gospelstdlib could be generated (using fold_namespace for instance...). It is still handwritten, because the implementation is real only partial for now.
That restructuring makes it clearer which parts of the runtime is exposed to support the specification translations and which parts should really only be used by the generator (`Z.forall`, `Z.exists`). On the other hand, the generator does call the functions that are provided by the `Gospelstdlib` sub-module (`pred`, etc.)

To ensure that `Ortac_runtime.Z` does not shadow `Z` in the implementation of the `Gospelstdlib`, `Gospelstdlib` is implemented before

The expected test results are updated accordingly
