### PR TITLE
Fix monolith plugin

### DIFF
--- a/plugins/monolith/generators.ml
+++ b/plugins/monolith/generators.ml
@@ -89,9 +89,11 @@ let generator_expr drv (ty_kind : Tast.type_kind) =
 
 let generator_definition drv (type_decl : Tast.type_declaration) =
   let id = B.pvar type_decl.td_ts.ts_ident.id_str in
-  match generator_expr drv type_decl.td_kind with
-  | None -> None
-  | Some generator -> Some [%stri let [%p id] = [%e generator]]
+  if type_decl.td_private = Tast.Private then None
+  else
+    match generator_expr drv type_decl.td_kind with
+    | None -> None
+    | Some generator -> Some [%stri let [%p id] = [%e generator]]
 
 let generator_option drv (sig_item : Tast.signature_item) =
   match sig_item.sig_desc with

--- a/plugins/monolith/printers.ml
+++ b/plugins/monolith/printers.ml
@@ -101,7 +101,9 @@ let printer_definition drv (type_decl : Tast.type_declaration) =
 
 let printer_option drv (sig_item : Tast.signature_item) =
   match sig_item.sig_desc with
-  | Tast.Sig_type (_, [ type_decl ], _) -> printer_definition drv type_decl
+  | Tast.Sig_type (_, [ type_decl ], _) when type_decl.td_private = Tast.Public
+    ->
+      printer_definition drv type_decl
   | _ -> None
 
 let printers drv s =

--- a/plugins/monolith/spec.ml
+++ b/plugins/monolith/spec.ml
@@ -23,6 +23,7 @@ let spec_constructor (type_decl : Tast.type_declaration) =
 let spec_dispatch (type_decl : Tast.type_declaration) =
   match type_decl.td_kind with
   | Pty_abstract -> Some (spec_abstract type_decl)
+  | _ when type_decl.td_private = Tast.Private -> Some (spec_abstract type_decl)
   | Pty_variant _ | Pty_record _ -> Some (spec_constructor type_decl)
 
 let spec_option (sig_item : Tast.signature_item) =

--- a/test/generated/default/dune
+++ b/test/generated/default/dune
@@ -1,3 +1,8 @@
+(rule
+ (target wrapper.mli)
+ (action
+  (copy ../lib.mli %{target})))
+
 (test
  (name wrapper)
  (package ortac)

--- a/test/generated/dune.common
+++ b/test/generated/dune.common
@@ -1,9 +1,4 @@
 (rule
- (target wrapper.mli)
- (action
-  (copy ../lib.mli %{target})))
-
-(rule
  (target lib.mli)
  (action
   (copy ../lib.mli %{target})))

--- a/test/generated/monolith/dune
+++ b/test/generated/monolith/dune
@@ -1,11 +1,9 @@
-; (executable
-;  (name wrapper)
-;  (libraries pprint ortac-runtime-monolith monolith))
-
-; (rule
-;  (alias runtest)
-;  (deps wrapper.exe)
-;  (action (progn)))
+(test
+ (name wrapper)
+ (libraries pprint ortac-runtime-monolith monolith)
+ (action
+  (echo
+   "\n%{dep:wrapper.exe} has been generated with the ortac-monolith plugin.\n")))
 
 (rule
  (target wrapper.ml)

--- a/test/generated/monolith/wrapper.expected.ml
+++ b/test/generated/monolith/wrapper.expected.ml
@@ -313,24 +313,9 @@ module R =
        b)
   end
 module C = Lib
-module G =
-  struct
-    let set () =
-      { R.size = (Gen.int Int.max_int ()); R.mask = (Gen.int Int.max_int ())
-      }
-  end
-module P =
-  struct
-    let set { R.size; R.mask } =
-      M.print_record ""
-        [("size", (Print.int size)); ("mask", (Print.int mask))]
-  end
-module S =
-  struct
-    let set =
-      let neg = easily_constructible G.set P.set in
-      let pos = deconstructible P.set in ifpol neg pos
-  end
+module G = struct  end
+module P = struct  end
+module S = struct let set = declare_abstract_type ~var:"set" () end
 let () =
   ((let spec = M.int ^!> S.set in
     declare "create is Ok" spec R.create C.create);


### PR DESCRIPTION
The plugin was broken during the last gospel update.

This PR does two things:

1. Make the monolith plugin handle private types as abstract
2. Refactor dune files for the tests, mainly lib.mli is not the correct interface for the wrapper.ml generated by ortac-monolith