### PR TITLE
Accept any version of ocamlformat

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,3 @@
-version = 0.24.1
 parse-docstrings = true
 break-infix = fit-or-vertical
 module-item-spacing = compact


### PR DESCRIPTION
OCamlFormat seems rather stable, so this avoids the annoyance of imposing a specific version for all developers.