### PR TITLE
Make Warnings.kind an extensible type

### DIFF
--- a/src/core/ocaml_of_gospel.ml
+++ b/src/core/ocaml_of_gospel.ml
@@ -28,7 +28,7 @@ type bound = Inf of expression | Sup of expression
 let rec bounds ~context ~loc (var : Symbols.vsymbol) (t1 : Tterm.term)
     (t2 : Tterm.term) =
   let unsupported () =
-    raise (W.Error (Unsupported "ill formed quantification", loc))
+    raise W.(Error (Unsupported "ill formed quantification", loc))
   in
   (* [comb] extracts a bound from an the operator [f] and expression [e].
      [right] indicates if [e] is on the right side of the operator. *)

--- a/src/core/warnings.ml
+++ b/src/core/warnings.ml
@@ -51,7 +51,9 @@ let pp_kind ppf = function
         name
   | _ -> raise Unkown_kind
 
-let pp ppf (k, loc) =
+let pp_param pp_kind level ppf (k, loc) =
   pf ppf "%a@\n%a@[%a@]@\n"
     (styled `Bold Location.print)
     loc pp_level (level k) pp_kind k
+
+let pp = pp_param pp_kind level

--- a/src/core/warnings.ml
+++ b/src/core/warnings.ml
@@ -1,8 +1,9 @@
 open Ppxlib
 
 type level = Warning | Error
+type kind = ..
 
-type kind =
+type kind +=
   | Unsupported of string
   | Ghost_value of string
   | Ghost_type of string
@@ -10,12 +11,15 @@ type kind =
   | Function_without_definition of string
   | Predicate_without_definition of string
 
+exception Unkown_kind
+
 type t = kind * Location.t
 
 let level = function
   | Unsupported _ | Ghost_value _ | Ghost_type _ | Unsupported_model _
   | Function_without_definition _ | Predicate_without_definition _ ->
       Warning
+  | _ -> raise Unkown_kind
 
 exception Error of t
 
@@ -45,6 +49,7 @@ let pp_kind ppf = function
   | Predicate_without_definition name ->
       pf ppf "The predicate %a has no definition. It was not translated." quoted
         name
+  | _ -> raise Unkown_kind
 
 let pp ppf (k, loc) =
   pf ppf "%a@\n%a@[%a@]@\n"


### PR DESCRIPTION
This PR proposes to make `Ortac_core.Warnings.kind` an extensible type. The rational is that plugins can come with their own warnings. This allows them to reuse the `Ortac_core` warning mechanism by extending the `kind` type, the `level` and the `pp_kind` functions.