### PR TITLE
Add a subset of `Gospelstdlib.List` to the supported subset

### DIFF
--- a/src/core/context.ml
+++ b/src/core/context.ml
@@ -58,6 +58,17 @@ let supported_stdlib =
     ([ "Array" ], "length");
     ([ "Array" ], "get");
     ([ "Array" ], "for_all");
+    ([ "List" ], "length");
+    ([ "List" ], "hd");
+    ([ "List" ], "tl");
+    ([ "List" ], "nth");
+    ([ "List" ], "rev");
+    ([ "List" ], "init");
+    ([ "List" ], "map");
+    ([ "List" ], "mapi");
+    ([ "List" ], "fold_left");
+    ([ "List" ], "fold_right");
+    ([ "List" ], "mem");
   ]
 
 (** Map a name from the Gospel parser to an OCaml name when possible

--- a/src/runtime/ortac_runtime.ml
+++ b/src/runtime/ortac_runtime.ml
@@ -162,6 +162,29 @@ module Gospelstdlib = struct
     let length arr = Array.length arr |> Z.of_int
     let for_all = Array.for_all
   end
+
+  module List = struct
+    let length l = List.length l |> Z.of_int
+    let hd = List.hd
+    let tl = List.tl
+    let nth l i = List.nth l (Z.to_int i)
+    let rev = List.rev
+
+    let init i f =
+      let i = Z.to_int i in
+      let f i = f (Z.of_int i) in
+      List.init i f
+
+    let map = List.map
+
+    let mapi f =
+      let f i = f (Z.of_int i) in
+      List.mapi f
+
+    let fold_left = List.fold_left
+    let fold_right = List.fold_right
+    let mem = List.mem
+  end
 end
 
 module Z = struct

--- a/src/runtime/ortac_runtime_intf.ml
+++ b/src/runtime/ortac_runtime_intf.ml
@@ -66,6 +66,20 @@ module type S = sig
       val length : 'a array -> Z.t
       val for_all : ('a -> bool) -> 'a array -> bool
     end
+
+    module List : sig
+      val length : 'a list -> Z.t
+      val hd : 'a list -> 'a
+      val tl : 'a list -> 'a list
+      val nth : 'a list -> Z.t -> 'a
+      val rev : 'a list -> 'a list
+      val init : Z.t -> (Z.t -> 'a) -> 'a list
+      val map : ('a -> 'b) -> 'a list -> 'b list
+      val mapi : (Z.t -> 'a -> 'b) -> 'a list -> 'b list
+      val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b list -> 'a
+      val fold_right : ('b -> 'a -> 'a) -> 'b list -> 'a -> 'a
+      val mem : 'a -> 'a list -> bool
+    end
   end
 
   module Z : sig


### PR DESCRIPTION
Extend the supported subset of the gospel standard library with a subset of the List module (fix #85).
This should be enough in order to write some meaningful tests for the `qcheck-stm` plugin, as most of the time, `stm` models are lists.
There is no need to add too much of the List module, as the gospel standard library is expected to change in a near future.