### PR TITLE
Support exceptional postconditions and checks clauses

### DIFF
--- a/plugins/qcheck-stm/src/ir.ml
+++ b/plugins/qcheck-stm/src/ir.ml
@@ -1,7 +1,7 @@
 open Gospel
 module Ident = Identifier.Ident
 
-type xpost = Ttypes.xsymbol * Tterm.pattern * Tterm.term
+type xpost = Ttypes.xsymbol * Tterm.pattern option * Tterm.term
 
 type new_state_formulae = {
   model : Ident.t; (* the name of the model's field *)

--- a/plugins/qcheck-stm/test/errors.expected
+++ b/plugins/qcheck-stm/test/errors.expected
@@ -1,3 +1,0 @@
-File "array.mli", line 20, characters 24-28:
-Warning: `make' returns a sut.
-

--- a/plugins/qcheck-stm/test/stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/stm_tests.expected.ml
@@ -90,13 +90,18 @@ module Spec =
       match (cmd__005_, res__007_) with
       | (Length, Res ((Int, _), i_3)) ->
           i_3 = (Lazy.force new_state__008_).size
-      | (Get i, Res ((Char, _), a_4)) ->
-          a_4 =
-            (Ortac_runtime.Gospelstdlib.List.nth
-               (Lazy.force new_state__008_).contents
-               (Ortac_runtime.Gospelstdlib.integer_of_int i))
-      | (Set (i_1, a_1), Res ((Unit, _), _)) -> true
-      | (Fill (i_2, j_1, a_2), Res ((Unit, _), _)) -> true
+      | (Get i, Res ((Result (Char, Exn), _), a_4)) ->
+          (match a_4 with
+           | Ok a_4 ->
+               a_4 =
+                 (Ortac_runtime.Gospelstdlib.List.nth
+                    (Lazy.force new_state__008_).contents
+                    (Ortac_runtime.Gospelstdlib.integer_of_int i))
+           | _ -> false)
+      | (Set (i_1, a_1), Res ((Result (Unit, Exn), _), res)) ->
+          (match res with | Ok _ -> true | _ -> false)
+      | (Fill (i_2, j_1, a_2), Res ((Result (Unit, Exn), _), res)) ->
+          (match res with | Ok _ -> true | _ -> false)
       | (To_list, Res ((List (Char), _), l)) ->
           l = (Lazy.force new_state__008_).contents
       | (Mem a_3, Res ((Bool, _), b)) ->

--- a/plugins/qcheck-stm/test/stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/stm_tests.expected.ml
@@ -77,8 +77,8 @@ module Spec =
           }
       | To_list -> state__002_
       | Mem a_3 -> state__002_
-    let precond cmd__009_ state__010_ =
-      match cmd__009_ with
+    let precond cmd__013_ state__014_ =
+      match cmd__013_ with
       | Length -> true
       | Get i -> true
       | Set (i_1, a_1) -> true
@@ -91,17 +91,59 @@ module Spec =
       | (Length, Res ((Int, _), i_3)) ->
           i_3 = (Lazy.force new_state__008_).size
       | (Get i, Res ((Result (Char, Exn), _), a_4)) ->
-          (match a_4 with
-           | Ok a_4 ->
-               a_4 =
-                 (Ortac_runtime.Gospelstdlib.List.nth
-                    (Lazy.force new_state__008_).contents
-                    (Ortac_runtime.Gospelstdlib.integer_of_int i))
-           | _ -> false)
+          if
+            let __t1__009_ =
+              Ortac_runtime.Gospelstdlib.(<=)
+                (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                (Ortac_runtime.Gospelstdlib.integer_of_int i) in
+            let __t2__010_ =
+              Ortac_runtime.Gospelstdlib.(<)
+                (Ortac_runtime.Gospelstdlib.integer_of_int i)
+                (Ortac_runtime.Gospelstdlib.integer_of_int state__006_.size) in
+            __t1__009_ && __t2__010_
+          then
+            (match a_4 with
+             | Ok a_4 ->
+                 a_4 =
+                   (Ortac_runtime.Gospelstdlib.List.nth
+                      (Lazy.force new_state__008_).contents
+                      (Ortac_runtime.Gospelstdlib.integer_of_int i))
+             | _ -> false)
+          else
+            (match a_4 with | Error (Invalid_argument _) -> true | _ -> false)
       | (Set (i_1, a_1), Res ((Result (Unit, Exn), _), res)) ->
-          (match res with | Ok _ -> true | _ -> false)
+          if
+            let __t1__011_ =
+              Ortac_runtime.Gospelstdlib.(<=)
+                (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
+            let __t2__012_ =
+              Ortac_runtime.Gospelstdlib.(<)
+                (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
+                (Ortac_runtime.Gospelstdlib.integer_of_int state__006_.size) in
+            __t1__011_ && __t2__012_
+          then (match res with | Ok _ -> true | _ -> false)
+          else
+            (match res with | Error (Invalid_argument _) -> true | _ -> false)
       | (Fill (i_2, j_1, a_2), Res ((Result (Unit, Exn), _), res)) ->
-          (match res with | Ok _ -> true | _ -> false)
+          if
+            (Ortac_runtime.Gospelstdlib.(<=)
+               (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+               (Ortac_runtime.Gospelstdlib.integer_of_int i_2))
+              &&
+              ((Ortac_runtime.Gospelstdlib.(<=)
+                  (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                  (Ortac_runtime.Gospelstdlib.integer_of_int j_1))
+                 &&
+                 (Ortac_runtime.Gospelstdlib.(<=)
+                    (Ortac_runtime.Gospelstdlib.(+)
+                       (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
+                       (Ortac_runtime.Gospelstdlib.integer_of_int j_1))
+                    (Ortac_runtime.Gospelstdlib.integer_of_int
+                       state__006_.size)))
+          then (match res with | Ok _ -> true | _ -> false)
+          else
+            (match res with | Error (Invalid_argument _) -> true | _ -> false)
       | (To_list, Res ((List (Char), _), l)) ->
           l = (Lazy.force new_state__008_).contents
       | (Mem a_3, Res ((Bool, _), b)) ->
@@ -109,21 +151,21 @@ module Spec =
             (Ortac_runtime.Gospelstdlib.List.mem a_3
                (Lazy.force new_state__008_).contents)
       | _ -> true
-    let run cmd__011_ sut__012_ =
-      match cmd__011_ with
-      | Length -> Res (int, (length sut__012_))
+    let run cmd__015_ sut__016_ =
+      match cmd__015_ with
+      | Length -> Res (int, (length sut__016_))
       | Get i ->
-          Res ((result char exn), (protect (fun () -> get sut__012_ i) ()))
+          Res ((result char exn), (protect (fun () -> get sut__016_ i) ()))
       | Set (i_1, a_1) ->
           Res
             ((result unit exn),
-              (protect (fun () -> set sut__012_ i_1 a_1) ()))
+              (protect (fun () -> set sut__016_ i_1 a_1) ()))
       | Fill (i_2, j_1, a_2) ->
           Res
             ((result unit exn),
-              (protect (fun () -> fill sut__012_ i_2 j_1 a_2) ()))
-      | To_list -> Res ((list char), (to_list sut__012_))
-      | Mem a_3 -> Res (bool, (mem a_3 sut__012_))
+              (protect (fun () -> fill sut__016_ i_2 j_1 a_2) ()))
+      | To_list -> Res ((list char), (to_list sut__016_))
+      | Mem a_3 -> Res (bool, (mem a_3 sut__016_))
   end
 module STMTests = (STM_sequential.Make)(Spec)
 let _ =

--- a/plugins/qcheck-stm/test/stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/stm_tests.expected.ml
@@ -45,83 +45,116 @@ module Spec =
       | Length -> state__002_
       | Get i -> state__002_
       | Set (i_1, a_1) ->
-          {
-            state__002_ with
-            contents =
-              (Ortac_runtime.Gospelstdlib.List.mapi
-                 (fun j ->
-                    fun x ->
-                      if j = (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
-                      then a_1
-                      else x) state__002_.contents)
-          }
+          if
+            let __t1__003_ =
+              Ortac_runtime.Gospelstdlib.(<=)
+                (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
+            let __t2__004_ =
+              Ortac_runtime.Gospelstdlib.(<)
+                (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
+                (Ortac_runtime.Gospelstdlib.integer_of_int state__002_.size) in
+            __t1__003_ && __t2__004_
+          then
+            {
+              state__002_ with
+              contents =
+                (Ortac_runtime.Gospelstdlib.List.mapi
+                   (fun j ->
+                      fun x ->
+                        if
+                          j = (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
+                        then a_1
+                        else x) state__002_.contents)
+            }
+          else state__002_
       | Fill (i_2, j_1, a_2) ->
-          {
-            state__002_ with
-            contents =
-              (Ortac_runtime.Gospelstdlib.List.mapi
-                 (fun k ->
-                    fun x_1 ->
-                      if
-                        let __t1__003_ =
-                          Ortac_runtime.Gospelstdlib.(<=)
-                            (Ortac_runtime.Gospelstdlib.integer_of_int i_2) k in
-                        let __t2__004_ =
-                          Ortac_runtime.Gospelstdlib.(<) k
-                            (Ortac_runtime.Gospelstdlib.(+)
-                               (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
-                               (Ortac_runtime.Gospelstdlib.integer_of_int j_1)) in
-                        __t1__003_ && __t2__004_
-                      then a_2
-                      else x_1) state__002_.contents)
-          }
+          if
+            (Ortac_runtime.Gospelstdlib.(<=)
+               (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+               (Ortac_runtime.Gospelstdlib.integer_of_int i_2))
+              &&
+              ((Ortac_runtime.Gospelstdlib.(<=)
+                  (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                  (Ortac_runtime.Gospelstdlib.integer_of_int j_1))
+                 &&
+                 (Ortac_runtime.Gospelstdlib.(<=)
+                    (Ortac_runtime.Gospelstdlib.(+)
+                       (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
+                       (Ortac_runtime.Gospelstdlib.integer_of_int j_1))
+                    (Ortac_runtime.Gospelstdlib.integer_of_int
+                       state__002_.size)))
+          then
+            {
+              state__002_ with
+              contents =
+                (Ortac_runtime.Gospelstdlib.List.mapi
+                   (fun k ->
+                      fun x_1 ->
+                        if
+                          let __t1__005_ =
+                            Ortac_runtime.Gospelstdlib.(<=)
+                              (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
+                              k in
+                          let __t2__006_ =
+                            Ortac_runtime.Gospelstdlib.(<) k
+                              (Ortac_runtime.Gospelstdlib.(+)
+                                 (Ortac_runtime.Gospelstdlib.integer_of_int
+                                    i_2)
+                                 (Ortac_runtime.Gospelstdlib.integer_of_int
+                                    j_1)) in
+                          __t1__005_ && __t2__006_
+                        then a_2
+                        else x_1) state__002_.contents)
+            }
+          else state__002_
       | To_list -> state__002_
       | Mem a_3 -> state__002_
-    let precond cmd__013_ state__014_ =
-      match cmd__013_ with
+    let precond cmd__015_ state__016_ =
+      match cmd__015_ with
       | Length -> true
       | Get i -> true
       | Set (i_1, a_1) -> true
       | Fill (i_2, j_1, a_2) -> true
       | To_list -> true
       | Mem a_3 -> true
-    let postcond cmd__005_ state__006_ res__007_ =
-      let new_state__008_ = lazy (next_state cmd__005_ state__006_) in
-      match (cmd__005_, res__007_) with
+    let postcond cmd__007_ state__008_ res__009_ =
+      let new_state__010_ = lazy (next_state cmd__007_ state__008_) in
+      match (cmd__007_, res__009_) with
       | (Length, Res ((Int, _), i_3)) ->
-          i_3 = (Lazy.force new_state__008_).size
+          i_3 = (Lazy.force new_state__010_).size
       | (Get i, Res ((Result (Char, Exn), _), a_4)) ->
           if
-            let __t1__009_ =
+            let __t1__011_ =
               Ortac_runtime.Gospelstdlib.(<=)
                 (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                 (Ortac_runtime.Gospelstdlib.integer_of_int i) in
-            let __t2__010_ =
+            let __t2__012_ =
               Ortac_runtime.Gospelstdlib.(<)
                 (Ortac_runtime.Gospelstdlib.integer_of_int i)
-                (Ortac_runtime.Gospelstdlib.integer_of_int state__006_.size) in
-            __t1__009_ && __t2__010_
+                (Ortac_runtime.Gospelstdlib.integer_of_int state__008_.size) in
+            __t1__011_ && __t2__012_
           then
             (match a_4 with
              | Ok a_4 ->
                  a_4 =
                    (Ortac_runtime.Gospelstdlib.List.nth
-                      (Lazy.force new_state__008_).contents
+                      (Lazy.force new_state__010_).contents
                       (Ortac_runtime.Gospelstdlib.integer_of_int i))
              | _ -> false)
           else
             (match a_4 with | Error (Invalid_argument _) -> true | _ -> false)
       | (Set (i_1, a_1), Res ((Result (Unit, Exn), _), res)) ->
           if
-            let __t1__011_ =
+            let __t1__013_ =
               Ortac_runtime.Gospelstdlib.(<=)
                 (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                 (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
-            let __t2__012_ =
+            let __t2__014_ =
               Ortac_runtime.Gospelstdlib.(<)
                 (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
-                (Ortac_runtime.Gospelstdlib.integer_of_int state__006_.size) in
-            __t1__011_ && __t2__012_
+                (Ortac_runtime.Gospelstdlib.integer_of_int state__008_.size) in
+            __t1__013_ && __t2__014_
           then (match res with | Ok _ -> true | _ -> false)
           else
             (match res with | Error (Invalid_argument _) -> true | _ -> false)
@@ -140,32 +173,32 @@ module Spec =
                        (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
                        (Ortac_runtime.Gospelstdlib.integer_of_int j_1))
                     (Ortac_runtime.Gospelstdlib.integer_of_int
-                       state__006_.size)))
+                       state__008_.size)))
           then (match res with | Ok _ -> true | _ -> false)
           else
             (match res with | Error (Invalid_argument _) -> true | _ -> false)
       | (To_list, Res ((List (Char), _), l)) ->
-          l = (Lazy.force new_state__008_).contents
+          l = (Lazy.force new_state__010_).contents
       | (Mem a_3, Res ((Bool, _), b)) ->
           (b = true) =
             (Ortac_runtime.Gospelstdlib.List.mem a_3
-               (Lazy.force new_state__008_).contents)
+               (Lazy.force new_state__010_).contents)
       | _ -> true
-    let run cmd__015_ sut__016_ =
-      match cmd__015_ with
-      | Length -> Res (int, (length sut__016_))
+    let run cmd__017_ sut__018_ =
+      match cmd__017_ with
+      | Length -> Res (int, (length sut__018_))
       | Get i ->
-          Res ((result char exn), (protect (fun () -> get sut__016_ i) ()))
+          Res ((result char exn), (protect (fun () -> get sut__018_ i) ()))
       | Set (i_1, a_1) ->
           Res
             ((result unit exn),
-              (protect (fun () -> set sut__016_ i_1 a_1) ()))
+              (protect (fun () -> set sut__018_ i_1 a_1) ()))
       | Fill (i_2, j_1, a_2) ->
           Res
             ((result unit exn),
-              (protect (fun () -> fill sut__016_ i_2 j_1 a_2) ()))
-      | To_list -> Res ((list char), (to_list sut__016_))
-      | Mem a_3 -> Res (bool, (mem a_3 sut__016_))
+              (protect (fun () -> fill sut__018_ i_2 j_1 a_2) ()))
+      | To_list -> Res ((list char), (to_list sut__018_))
+      | Mem a_3 -> Res (bool, (mem a_3 sut__018_))
   end
 module STMTests = (STM_sequential.Make)(Spec)
 let _ =

--- a/plugins/qcheck-stm/test/stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/stm_tests.expected.ml
@@ -107,9 +107,16 @@ module Spec =
     let run cmd__011_ sut__012_ =
       match cmd__011_ with
       | Length -> Res (int, (length sut__012_))
-      | Get i -> Res (char, (get sut__012_ i))
-      | Set (i_1, a_1) -> Res (unit, (set sut__012_ i_1 a_1))
-      | Fill (i_2, j_1, a_2) -> Res (unit, (fill sut__012_ i_2 j_1 a_2))
+      | Get i ->
+          Res ((result char exn), (protect (fun () -> get sut__012_ i) ()))
+      | Set (i_1, a_1) ->
+          Res
+            ((result unit exn),
+              (protect (fun () -> set sut__012_ i_1 a_1) ()))
+      | Fill (i_2, j_1, a_2) ->
+          Res
+            ((result unit exn),
+              (protect (fun () -> fill sut__012_ i_2 j_1 a_2) ()))
       | To_list -> Res ((list char), (to_list sut__012_))
       | Mem a_3 -> Res (bool, (mem a_3 sut__012_))
   end

--- a/src/core/ocaml_of_gospel.mli
+++ b/src/core/ocaml_of_gospel.mli
@@ -1,5 +1,5 @@
-val pattern : Gospel.Tterm.pattern_node -> Ppxlib.pattern
-(** [pattern pn] translates a Gospel pattern into the matching OCaml pattern *)
+val pattern : Gospel.Tterm.pattern -> Ppxlib.pattern
+(** [pattern p] translates a Gospel pattern into the matching OCaml pattern *)
 
 val term : context:Context.t -> Gospel.Tterm.term -> Ppxlib.expression
 (** [term ~context t] translates a Gospel typed term into the corresponding


### PR DESCRIPTION
`qcheck-stm` wrap returned values of function that may raises an exception in a result type, so that it can tell something in the `postcond` function.

In order to support exceptional postconditions and checks clauses (gospel ones), we have to:
1. amend the `run` function that we generate:
    - a function that may raise an exception and which returned type is `'a`  will be encoded as returning an `('a, exn) result`
    - a function that may raise an exception will be called wrapped in the `protect` combinator provided by `qcheck-stm`
2. amend the `postcond` function that we generate so that it will make the appropriate verifications.

As gospel has a different semantic for the `raises` clauses (exceptional posticonditions) and the `checks` clauses, we generate an expression of the form:

```
if all the `checks` are true
then match res with
       | Ok res -> checks the normal postconditions
       | Error (exception pattern 0) -> checks the `raises` clause for the exception pattern 0
       | Error (exception pattern 1) -> checks the `raises` clause for the exception pattern 1
       ...
       | _ -> false
else match res with
       | Error (Invalid_argument _) -> true
       | _ -> false
```



Co-authored-by: Samuel Hym [samuel.hym@rustyne.lautre.net](mailto:samuel.hym@rustyne.lautre.net)