### PR TITLE
Add a `launchtests` alias to run the _generated_ QCheck-STM tests

### DIFF
--- a/plugins/qcheck-stm/test/dune
+++ b/plugins/qcheck-stm/test/dune
@@ -38,3 +38,8 @@
   (progn
    (diff errors.expected errors)
    (diff stm_tests.expected.ml stm_tests.ml))))
+
+(rule
+ (alias launchtests)
+ (action
+  (run %{dep:stm_tests.exe} -v)))


### PR DESCRIPTION
It would be nice to be able to easily trigger the generated tests, rather than stopping at generating them.
This PR proposes a different alias, `launchtests` for that. It currently only defines the behaviour for the QCheck-STM plugin, in part because the Monolith plugin comes with two tests runners (both might be attached, at least when `afl-fuzz` is available) that intentionally do not terminate (which makes it less clearly useful in an alias).