### PR TITLE
Detach plugin tests from the `default` build target

### DIFF
--- a/dune
+++ b/dune
@@ -3,7 +3,7 @@
  (deps
   (alias_rec src/default)
   (alias_rec bin/default)
-  (alias_rec plugins/default)))
+  (alias plugins/default)))
 
 (alias
  (name runtest)

--- a/plugins/dune
+++ b/plugins/dune
@@ -1,0 +1,5 @@
+(alias
+ (name default)
+ (deps
+  (alias monolith/default)
+  (alias qcheck-stm/default)))

--- a/plugins/monolith/dune
+++ b/plugins/monolith/dune
@@ -1,0 +1,4 @@
+(alias
+ (name default)
+ (deps
+  (alias_rec src/default)))

--- a/plugins/qcheck-stm/dune
+++ b/plugins/qcheck-stm/dune
@@ -1,0 +1,4 @@
+(alias
+ (name default)
+ (deps
+  (alias_rec src/default)))


### PR DESCRIPTION
This was another [PR](n-osborne/ortac#19), shown as merged, but it vanished before getting to the actual `main`.