### PR TITLE
Avoid useless warning about init_sut returning sut

### DIFF
--- a/plugins/qcheck-stm/src/ortac_qcheck_stm.ml
+++ b/plugins/qcheck-stm/src/ortac_qcheck_stm.ml
@@ -7,12 +7,10 @@ module Stm_of_ir = Stm_of_ir
 let main path init sut =
   let open Reserr in
   let pp = Fmt.((pp Ppxlib_ast.Pprintast.structure) stdout) in
-  let _ =
-    let* sigs, config = Config.init path init sut in
-    let* ir = Ir_of_gospel.run sigs config in
-    Stm_of_ir.stm config ir |> pp |> ok
-  in
-  ()
+  pp
+    (let* sigs, config = Config.init path init sut in
+     let* ir = Ir_of_gospel.run sigs config in
+     Stm_of_ir.stm config ir)
 
 open Cmdliner
 

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -156,7 +156,14 @@ let pp_kind ppf kind =
   | _ -> W.pp_kind ppf kind
 
 let pp_errors = W.pp_param pp_kind level |> Fmt.list
-let pp pp_ok = Fmt.(pair (result ~ok:pp_ok ~error:pp_errors) pp_errors)
+
+let pp pp_ok ppf r =
+  let open Fmt in
+  match r with
+  | Ok a, warns -> (
+      pf ppf "%a@." pp_ok a;
+      match warns with [] -> () | warns -> pf stderr "%a@." pp_errors warns)
+  | Error errs, warns -> pf stderr "%a@." pp_errors (errs @ warns)
 
 let promote r =
   let rec aux = function

--- a/plugins/qcheck-stm/test/errors.expected
+++ b/plugins/qcheck-stm/test/errors.expected
@@ -1,3 +1,0 @@
-File "array.mli", line 20, characters 24-28:
-Warning: `make' returns a sut.
-

--- a/plugins/qcheck-stm/test/errors.expected
+++ b/plugins/qcheck-stm/test/errors.expected
@@ -1,0 +1,3 @@
+File "array.mli", line 20, characters 24-28:
+Warning: `make' returns a sut.
+


### PR DESCRIPTION
- Print errors and warnings and stderr
- Do not generate a warning about init_sut returning sut
