### PR TITLE
Rewrite the Ortac-runtime implementation of the Gospel Stdlib

### DIFF
--- a/src/core/context.ml
+++ b/src/core/context.ml
@@ -40,12 +40,26 @@ let builtins =
 
     - infix operators are kept as is
     - prefix operators are prefixed with ~
-    - mixfix operators are dropped
+    - mixfix operators are prefixed with __mix_ and encoded to ascii
     - other names are kept as is
 
     TODO? maybe, some filtering should be performed also on other names, such as
-    names containing "#" *)
+    names containing "#" and return [None] on those *)
 let process_name name =
+  let convert_mix_symbol = function
+    | '-' -> 'm' (* minus *)
+    | '.' -> 'd' (* dot *)
+    | '>' -> 'g' (* greater *)
+    | '[' -> 'B' (* bracket (open) *)
+    | ']' -> 'b' (* bracket (close) *)
+    | '_' -> 'u' (* underscore *)
+    | '{' -> 'C' (* curly (open) *)
+    | '}' -> 'c' (* curly (close) *)
+    | c -> failwith (Printf.sprintf "Cannot convert mixfix symbol '%c'" c)
+    (* this should not happen: all the symbols used in the Stdlib
+       should be covered *)
+  in
+
   let lname = String.length name in
   let drop prefix =
     let lp = String.length prefix in
@@ -59,7 +73,8 @@ let process_name name =
      shorter the better *)
   if starts p_pre then Some ("~" ^ drop p_pre)
   else if starts p_in then Some (drop p_in)
-  else if starts p_mix then None
+  else if starts p_mix then
+    Some ("__mix_" ^ String.map convert_mix_symbol (drop p_mix))
   else Some name
 
 let fold_namespace f path ns v =

--- a/src/core/context.ml
+++ b/src/core/context.ml
@@ -33,6 +33,15 @@ let builtins =
     ([ "infix =" ], "(=)");
   ]
 
+(** [unsupported_stdlib] contains all the entries of the Gospel Stdlib that
+    cannot be translated *)
+let unsupported_stdlib =
+  let t = Hashtbl.create 1 in
+  List.iter
+    (fun f -> Hashtbl.add t ("Gospelstdlib" :: f) ())
+    [ [ "Order"; "is_pre_order" ] ];
+  t
+
 (** Map a name from the Gospel parser to an OCaml name when possible
 
     The strategy is as follows, always dropping the "*fix " prefix of the
@@ -90,8 +99,11 @@ let init module_name env =
     match process_name name with
     | None -> lib
     | Some name ->
-        let fullpath = "Ortac_runtime" :: (path @ [ name ]) in
-        L.add ls (String.concat "." fullpath) lib
+        let fullpath = path @ [ name ] in
+        if Hashtbl.mem unsupported_stdlib fullpath then lib
+        else
+          let fullpath = "Ortac_runtime" :: fullpath in
+          L.add ls (String.concat "." fullpath) lib
   in
   let stdlib =
     List.fold_left

--- a/src/runtime/ortac_runtime.ml
+++ b/src/runtime/ortac_runtime.ml
@@ -120,6 +120,8 @@ module Errors = struct
         raise (Error t)
 end
 
+type integer = Z.t
+
 module Gospelstdlib = struct
   (** Implementation of the Gospel Stdlib *)
 

--- a/src/runtime/ortac_runtime.ml
+++ b/src/runtime/ortac_runtime.ml
@@ -125,45 +125,28 @@ type integer = Z.t
 module Gospelstdlib = struct
   (** Implementation of the Gospel Stdlib *)
 
-  (* TODO: This should follow the same order than in gospelstdlib.mli *)
-
-  let ( ~! ) = ( ! )
+  let succ = Z.succ
+  let pred = Z.pred
+  let ( ~- ) = Z.( ~- )
   let ( + ) = Z.( + )
   let ( - ) = Z.( - )
   let ( * ) = Z.( * )
   let ( / ) = Z.( / )
-  let ( < ) = Z.lt
-  let ( <= ) = Z.leq
-  let ( > ) = Z.gt
-  let ( >= ) = Z.geq
   let ( mod ) = Z.( mod )
-  let ( ~- ) = Z.( ~- )
-  let abs = Z.abs
-  let logand = Z.logand
-  let max = Z.max
-  let min = Z.min
-  let pred = Z.pred
-  let succ = Z.succ
 
   let pow x n =
     try Z.pow x (Z.to_int n) with Z.Overflow -> invalid_arg "Exponent too big"
 
+  let abs = Z.abs
+  let min = Z.min
+  let max = Z.max
+  let ( > ) = Z.gt
+  let ( >= ) = Z.geq
+  let ( < ) = Z.lt
+  let ( <= ) = Z.leq
+  let logand = Z.logand
   let integer_of_int = Z.of_int
-
-  module Array = struct
-    let make z =
-      if Z.(z > of_int Sys.max_array_length) then
-        raise (Invalid_argument "Array length too big")
-      else Array.make (Z.to_int z)
-
-    let get arr z =
-      if Z.(z < zero || z >= of_int (Array.length arr)) then
-        raise (Invalid_argument "Out of array bounds")
-      else Array.unsafe_get arr (Z.to_int z)
-
-    let length arr = Array.length arr |> Z.of_int
-    let for_all = Array.for_all
-  end
+  let ( ~! ) = ( ! )
 
   module List = struct
     let length l = List.length l |> Z.of_int
@@ -186,6 +169,22 @@ module Gospelstdlib = struct
     let fold_left = List.fold_left
     let fold_right = List.fold_right
     let mem = List.mem
+  end
+
+  module Array = struct
+    let length arr = Array.length arr |> Z.of_int
+
+    let get arr z =
+      if Z.(z < zero || z >= of_int (Array.length arr)) then
+        raise (Invalid_argument "Out of array bounds")
+      else Array.unsafe_get arr (Z.to_int z)
+
+    let make z =
+      if Z.(z > of_int Sys.max_array_length) then
+        raise (Invalid_argument "Array length too big")
+      else Array.make (Z.to_int z)
+
+    let for_all = Array.for_all
   end
 end
 

--- a/src/runtime/ortac_runtime.ml
+++ b/src/runtime/ortac_runtime.ml
@@ -125,6 +125,16 @@ type integer = Z.t
 module Gospelstdlib = struct
   (** Implementation of the Gospel Stdlib *)
 
+  let niy x = failwith "%s is not implemented yet" x
+
+  type 'a sequence = 'a list
+
+  type 'a bag = unit
+  (** dummy placeholder *)
+
+  type 'a set = unit
+  (** dummy placeholder *)
+
   let succ = Z.succ
   let pred = Z.pred
   let ( ~- ) = Z.( ~- )
@@ -145,14 +155,27 @@ module Gospelstdlib = struct
   let ( < ) = Z.lt
   let ( <= ) = Z.leq
   let logand = Z.logand
+  let logor = Z.logor
+  let logxor = Z.logxor
+  let lognot = Z.lognot
+  let shift_left v s = Z.shift_left v (Z.to_int s)
+  let shift_right v s = Z.shift_right v (Z.to_int s)
+  let shift_right_trunc v s = Z.shift_right_trunc v (Z.to_int s)
   let integer_of_int = Z.of_int
+  let max_int = Z.of_int max_int
+  let min_int = Z.of_int min_int
+  let fst = fst
+  let snd = snd
   let ( ~! ) = ( ! )
 
   module List = struct
+    type 'a t = 'a list
+
     let length l = List.length l |> Z.of_int
     let hd = List.hd
     let tl = List.tl
     let nth l i = List.nth l (Z.to_int i)
+    let nth_opt l i = try Some (nth l i) with _ -> None
     let rev = List.rev
 
     let init i f =
@@ -168,10 +191,61 @@ module Gospelstdlib = struct
 
     let fold_left = List.fold_left
     let fold_right = List.fold_right
+    let map2 = List.map2
+    let for_all = List.for_all
+    let _exists = List.exists
+    let for_all2 = List.for_all2
+    let _exists2 = List.exists2
     let mem = List.mem
+    let to_seq = Fun.id
+    let of_seq = Fun.id
   end
 
+  module Sequence = struct
+    type 'a t = 'a sequence
+
+    let length = List.length
+    let empty = []
+    let singleton x = [ x ]
+    let init = List.init
+    let cons x xs = x :: xs
+    let snoc xs x = xs @ [ x ]
+    let hd = List.hd
+    let tl = List.tl
+    let append = Stdlib.List.append
+    let mem s x = List.mem x s (* is that flip intentional? *)
+    let map = List.map
+    let filter = Stdlib.List.filter
+    let filter_map = Stdlib.List.filter_map
+    let get = List.nth
+
+    let set xs n x =
+      let err () = failwith "index out of bounds" in
+      let n = Z.to_int n in
+      let open Stdlib in
+      (* to get standard (-) and (<) back *)
+      let rec aux = function
+        | [], 0 -> [ x ]
+        | _ :: xs, 0 -> x :: xs
+        | [], _ -> err ()
+        | x :: xs, n -> x :: aux (xs, n - 1)
+      in
+      if n < 0 then err () else aux (xs, n)
+
+    let rev = List.rev
+    let fold_left = List.fold_left
+    let fold_right = List.fold_right
+  end
+
+  let ( ++ ) = Sequence.append
+  let __mix_Bub = Sequence.get
+  let __mix_Buddub _ = niy "__mix_Buddub (* [_.._] *)"
+  let __mix_Buddb _ = niy "__mix_Buddb (* [_..] *)"
+  let __mix_Bddub _ = niy "__mix_Bddub (* [.._] *)"
+
   module Array = struct
+    type 'a t = 'a array
+
     let length arr = Array.length arr |> Z.of_int
 
     let get arr z =
@@ -184,7 +258,109 @@ module Gospelstdlib = struct
         raise (Invalid_argument "Array length too big")
       else Array.make (Z.to_int z)
 
+    let init n f = Array.init (Z.to_int n) (fun i -> f (Z.of_int i))
+    let append = Array.append
+    let concat = Array.concat
+    let sub xs i j = Array.sub xs (Z.to_int i) (Z.to_int j)
+    let map = Array.map
+    let mapi f xs = Array.mapi (fun i x -> f (Z.of_int i) x) xs
+    let fold_left = Array.fold_left
+    let fold_right = Array.fold_right
+    let map2 = Array.map2
     let for_all = Array.for_all
+    let _exists = Array.exists
+    let for_all2 = Array.for_all2
+    let _exists2 = Array.exists2
+    let mem = Array.mem
+    let to_list = Array.to_list
+    let of_list = Array.of_list
+    let to_seq = Array.to_list
+    let of_seq = Array.of_list
+    let to_bag _ = niy "to_bag"
+    let permut _ = niy "permut"
+    let permut_sub _ = niy "permut_sub"
+  end
+
+  module Bag = struct
+    type 'a t = ('a bag[@alert "-not_implemented"])
+
+    let occurrences _ = niy "occurrences"
+    let empty = ()
+    let is_empty _ = niy "is_empty"
+    let mem _ = niy "mem"
+    let add _ = niy "add"
+    let singleton _ = niy "singleton"
+    let remove _ = niy "remove"
+    let union _ = niy "union"
+    let sum _ = niy "sum"
+    let inter _ = niy "inter"
+    let disjoint _ = niy "disjoint"
+    let diff _ = niy "diff"
+    let subset _ = niy "subset"
+    let choose _ = niy "choose"
+    let choose_opt _ = niy "choose_opt"
+    let map _ = niy "map"
+    let fold _ = niy "fold"
+    let for_all _ = niy "for_all"
+    let _exists _ = niy "_exists"
+    let filter _ = niy "filter"
+    let filter_map _ = niy "filter_map"
+    let partition _ = niy "partition"
+    let cardinal _ = niy "cardinal"
+    let to_list _ = niy "to_list"
+    let of_list _ = niy "of_list"
+    let to_seq _ = niy "to_seq"
+    let of_seq _ = niy "of_seq"
+  end
+
+  let __mix_Cc = ()
+
+  module Set = struct
+    type 'a t = ('a set[@alert "-not_implemented"])
+
+    let compare _ = niy "compare"
+    let empty = ()
+    let is_empty _ = niy "is_empty"
+    let mem _ = niy "mem"
+    let add _ = niy "add"
+    let singleton _ = niy "singleton"
+    let remove _ = niy "remove"
+    let union _ = niy "union"
+    let inter _ = niy "inter"
+    let disjoint _ = niy "disjoint"
+    let diff _ = niy "diff"
+    let subt _ = niy "subt"
+    let cardinal _ = niy "cardinal"
+    let choose _ = niy "choose"
+    let choose_opt _ = niy "choose_opt"
+    let map _ = niy "map"
+    let fold _ = niy "fold"
+    let for_all _ = niy "for_all"
+    let _exists _ = niy "_exists"
+    let filter _ = niy "filter"
+    let filter_map _ = niy "filter_map"
+    let partition _ = niy "partition"
+    let to_list _ = niy "to_list"
+    let of_list _ = niy "of_list"
+    let to_seq _ = niy "to_seq"
+    let of_seq _ = niy "of_seq"
+  end
+
+  let __mix_Bmgb _ = niy "__mix_Bmgb (* [->] *)"
+
+  module Map = struct end
+
+  module Order = struct
+    let is_pre_order _ =
+      failwith "is_pre_order cannot be implemented as a test!"
+  end
+
+  module Sys = struct
+    let big_endian = Sys.big_endian
+    let int_size = Sys.int_size
+    let max_array_length = Sys.max_array_length
+    let max_string_length = Sys.max_string_length
+    let word_size = Sys.word_size
   end
 end
 

--- a/src/runtime/ortac_runtime_intf.ml
+++ b/src/runtime/ortac_runtime_intf.ml
@@ -39,43 +39,45 @@ module type S = sig
     (** [report l] prints the content of [l] *)
   end
 
+  type integer
+
   module Gospelstdlib : sig
     val ( ~! ) : 'a ref -> 'a
-    val ( + ) : Z.t -> Z.t -> Z.t
-    val ( - ) : Z.t -> Z.t -> Z.t
-    val ( * ) : Z.t -> Z.t -> Z.t
-    val ( / ) : Z.t -> Z.t -> Z.t
-    val ( < ) : Z.t -> Z.t -> bool
-    val ( <= ) : Z.t -> Z.t -> bool
-    val ( > ) : Z.t -> Z.t -> bool
-    val ( >= ) : Z.t -> Z.t -> bool
-    val ( mod ) : Z.t -> Z.t -> Z.t
-    val ( ~- ) : Z.t -> Z.t
-    val abs : Z.t -> Z.t
-    val logand : Z.t -> Z.t -> Z.t
-    val max : Z.t -> Z.t -> Z.t
-    val min : Z.t -> Z.t -> Z.t
-    val pred : Z.t -> Z.t
-    val succ : Z.t -> Z.t
-    val pow : Z.t -> Z.t -> Z.t
-    val integer_of_int : int -> Z.t
+    val ( + ) : integer -> integer -> integer
+    val ( - ) : integer -> integer -> integer
+    val ( * ) : integer -> integer -> integer
+    val ( / ) : integer -> integer -> integer
+    val ( < ) : integer -> integer -> bool
+    val ( <= ) : integer -> integer -> bool
+    val ( > ) : integer -> integer -> bool
+    val ( >= ) : integer -> integer -> bool
+    val ( mod ) : integer -> integer -> integer
+    val ( ~- ) : integer -> integer
+    val abs : integer -> integer
+    val logand : integer -> integer -> integer
+    val max : integer -> integer -> integer
+    val min : integer -> integer -> integer
+    val pred : integer -> integer
+    val succ : integer -> integer
+    val pow : integer -> integer -> integer
+    val integer_of_int : int -> integer
 
     module Array : sig
-      val make : Z.t -> 'a -> 'a array
-      val get : 'a array -> Z.t -> 'a
-      val length : 'a array -> Z.t
+      val make : integer -> 'a -> 'a array
+      val get : 'a array -> integer -> 'a
+      val length : 'a array -> integer
       val for_all : ('a -> bool) -> 'a array -> bool
     end
 
     module List : sig
-      val length : 'a list -> Z.t
+      val length : 'a list -> integer
       val hd : 'a list -> 'a
       val tl : 'a list -> 'a list
-      val nth : 'a list -> Z.t -> 'a
+      val nth : 'a list -> integer -> 'a
       val rev : 'a list -> 'a list
-      val init : Z.t -> (Z.t -> 'a) -> 'a list
+      val init : integer -> (integer -> 'a) -> 'a list
       val map : ('a -> 'b) -> 'a list -> 'b list
-      val mapi : (Z.t -> 'a -> 'b) -> 'a list -> 'b list
+      val mapi : (integer -> 'a -> 'b) -> 'a list -> 'b list
       val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b list -> 'a
       val fold_right : ('b -> 'a -> 'a) -> 'b list -> 'a -> 'a
       val mem : 'a -> 'a list -> bool
@@ -83,11 +85,11 @@ module type S = sig
   end
 
   module Z : sig
-    val exists : Z.t -> Z.t -> (Z.t -> bool) -> bool
+    val exists : integer -> integer -> (integer -> bool) -> bool
     (** [exists i j p] is [true] iff the predicate there exists [k] within [i]
         and [j], included, for which [p] holds. *)
 
-    val forall : Z.t -> Z.t -> (Z.t -> bool) -> bool
+    val forall : integer -> integer -> (integer -> bool) -> bool
     (** [forall i j p] is [true] iff the predicate `p` holds forall [k] within
         [i] and [j], included. *)
   end

--- a/src/runtime/ortac_runtime_intf.ml
+++ b/src/runtime/ortac_runtime_intf.ml
@@ -42,6 +42,14 @@ module type S = sig
   type integer
 
   module Gospelstdlib : sig
+    type 'a sequence
+
+    type 'a bag
+    [@@alert not_implemented "The type [bag] is not implemented yet"]
+
+    type 'a set
+    [@@alert not_implemented "The type [set] is not implemented yet"]
+
     (** {1 Arithmetic} *)
 
     val succ : integer -> integer
@@ -67,38 +75,323 @@ module type S = sig
     (** {2 Bitwise operations} *)
 
     val logand : integer -> integer -> integer
+    val logor : integer -> integer -> integer
+    val logxor : integer -> integer -> integer
+    val lognot : integer -> integer
+    val shift_left : integer -> integer -> integer
+    val shift_right : integer -> integer -> integer
+    val shift_right_trunc : integer -> integer -> integer
 
     (** {2 Machine integers} *)
 
     val integer_of_int : int -> integer
+    val max_int : integer
+    val min_int : integer
+
+    (** {1 Couples} *)
+
+    val fst : 'a * 'b -> 'a
+    val snd : 'a * 'b -> 'b
 
     (** {1 References} *)
 
     val ( ~! ) : 'a ref -> 'a
 
+    (** {1 Sequences} *)
+
+    val ( ++ ) : 'a sequence -> 'a sequence -> 'a sequence
+
+    val __mix_Bub (* [_] *) : 'a sequence -> integer -> 'a
+      [@@alert not_implemented "This function is not implemented yet"]
+
+    val __mix_Buddub (* [_.._] *) :
+      'a sequence -> integer -> integer -> 'a sequence
+      [@@alert not_implemented "This function is not implemented yet"]
+
+    val __mix_Buddb (* [_..] *) : 'a sequence -> integer -> 'a sequence
+      [@@alert not_implemented "This function is not implemented yet"]
+
+    val __mix_Bddub (* [.._] *) : 'a sequence -> integer -> 'a sequence
+      [@@alert not_implemented "This function is not implemented yet"]
+
+    module Sequence : sig
+      type 'a t = 'a sequence
+
+      val length : 'a t -> integer
+      val empty : 'a t
+      val singleton : 'a -> 'a t
+      val init : integer -> (integer -> 'a) -> 'a t
+      val cons : 'a -> 'a t -> 'a t
+      val snoc : 'a t -> 'a -> 'a t
+      val hd : 'a t -> 'a
+      val tl : 'a t -> 'a t
+      val append : 'a t -> 'a t -> 'a t
+      val mem : 'a t -> 'a -> bool
+      val map : ('a -> 'b) -> 'a t -> 'b t
+      val filter : ('a -> bool) -> 'a t -> 'a t
+      val filter_map : ('a -> 'b option) -> 'a t -> 'b t
+      val get : 'a t -> integer -> 'a
+      val set : 'a t -> integer -> 'a -> 'a t
+      val rev : 'a t -> 'a t
+      val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
+      val fold_right : ('a -> 'b -> 'b) -> 'a t -> 'b -> 'b
+    end
+
     (** {1 Lists} *)
 
     module List : sig
-      val length : 'a list -> integer
-      val hd : 'a list -> 'a
-      val tl : 'a list -> 'a list
-      val nth : 'a list -> integer -> 'a
-      val rev : 'a list -> 'a list
-      val init : integer -> (integer -> 'a) -> 'a list
-      val map : ('a -> 'b) -> 'a list -> 'b list
-      val mapi : (integer -> 'a -> 'b) -> 'a list -> 'b list
-      val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b list -> 'a
-      val fold_right : ('b -> 'a -> 'a) -> 'b list -> 'a -> 'a
-      val mem : 'a -> 'a list -> bool
+      type 'a t = 'a list
+
+      val length : 'a t -> integer
+      val hd : 'a t -> 'a
+      val tl : 'a t -> 'a t
+      val nth : 'a t -> integer -> 'a
+      val nth_opt : 'a t -> integer -> 'a option
+      val rev : 'a t -> 'a t
+      val init : integer -> (integer -> 'a) -> 'a t
+      val map : ('a -> 'b) -> 'a t -> 'b t
+      val mapi : (integer -> 'a -> 'b) -> 'a t -> 'b t
+      val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
+      val fold_right : ('b -> 'a -> 'a) -> 'b t -> 'a -> 'a
+      val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+      val for_all : ('a -> bool) -> 'a t -> bool
+      val _exists : ('a -> bool) -> 'a t -> bool
+      val for_all2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
+      val _exists2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
+      val mem : 'a -> 'a t -> bool
+      val to_seq : 'a t -> 'a sequence
+      val of_seq : 'a sequence -> 'a t
     end
 
     (** {1 Arrays} *)
 
     module Array : sig
-      val length : 'a array -> integer
-      val get : 'a array -> integer -> 'a
-      val make : integer -> 'a -> 'a array
-      val for_all : ('a -> bool) -> 'a array -> bool
+      type 'a t = 'a array
+
+      val length : 'a t -> integer
+      val get : 'a t -> integer -> 'a
+      val make : integer -> 'a -> 'a t
+      val init : integer -> (integer -> 'a) -> 'a t
+      val append : 'a t -> 'a t -> 'a t
+      val concat : 'a t list -> 'a t
+      val sub : 'a t -> integer -> integer -> 'a t
+      val map : ('a -> 'b) -> 'a t -> 'b t
+      val mapi : (integer -> 'a -> 'b) -> 'a t -> 'b t
+      val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b t -> 'a
+      val fold_right : ('b -> 'a -> 'a) -> 'b t -> 'a -> 'a
+      val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
+      val for_all : ('a -> bool) -> 'a t -> bool
+      val _exists : ('a -> bool) -> 'a t -> bool
+      val for_all2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
+      val _exists2 : ('a -> 'b -> bool) -> 'a t -> 'b t -> bool
+      val mem : 'a -> 'a t -> bool
+      val to_list : 'a t -> 'a list
+      val of_list : 'a list -> 'a t
+      val to_seq : 'a t -> 'a sequence
+      val of_seq : 'a sequence -> 'a t
+
+      val to_bag : ('a t -> 'a bag[@alert "-not_implemented"])
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val permut : 'a t -> 'a t -> bool
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val permut_sub : 'a t -> 'a t -> integer -> integer -> bool
+        [@@alert not_implemented "This function is not implemented yet"]
+    end
+
+    (** {1 Bags} *)
+
+    module Bag : sig
+      type 'a t = ('a bag[@alert "-not_implemented"])
+
+      val occurrences : 'a -> 'a t -> integer
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val empty : 'a t
+        [@@alert not_implemented "This value is not implemented yet"]
+
+      val is_empty : 'a t -> bool
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val mem : 'a -> 'a t -> bool
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val add : 'a -> 'a t -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val singleton : 'a -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val remove : 'a -> 'a t -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val union : 'a t -> 'a t -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val sum : 'a t -> 'a t -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val inter : 'a t -> 'a t -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val disjoint : 'a t -> 'a t -> bool
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val diff : 'a t -> 'a t -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val subset : 'a t -> 'a t -> bool
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val choose : 'a t -> 'a
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val choose_opt : 'a t -> 'a option
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val map : ('a -> 'b) -> 'a t -> 'b t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val fold : ('b -> 'a -> 'a) -> 'b t -> 'a -> 'a
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val for_all : ('a -> bool) -> 'a t -> bool
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val _exists : ('a -> bool) -> 'a t -> bool
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val filter : ('a -> bool) -> 'a t -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val filter_map : ('a -> 'b option) -> 'a t -> 'b t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val partition : ('a -> bool) -> 'a t -> 'a t * 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val cardinal : 'a t -> integer
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val to_list : 'a t -> 'a list
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val of_list : 'a list -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val to_seq : 'a t -> 'a sequence
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val of_seq : 'a sequence -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+    end
+
+    (** {1 Sets} *)
+
+    val __mix_Cc (* {} *) : ('a set[@alert "-not_implemented"])
+      [@@alert not_implemented "This value is not implemented yet"]
+
+    module Set : sig
+      type 'a t = ('a set[@alert "-not_implemented"])
+
+      val compare : 'a t -> 'a t -> int
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val empty : 'a t
+        [@@alert not_implemented "This value is not implemented yet"]
+
+      val is_empty : 'a t -> bool
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val mem : 'a -> 'a t -> bool
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val add : 'a -> 'a t -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val singleton : 'a -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val remove : 'a -> 'a t -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val union : 'a t -> 'a t -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val inter : 'a t -> 'a t -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val disjoint : 'a t -> 'a t -> bool
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val diff : 'a t -> 'a t -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val subt : 'a t -> 'a t -> bool
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val cardinal : 'a t -> int
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val choose : 'a t -> int
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val choose_opt : 'a t -> 'a option
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val map : ('a -> 'b) -> 'a t -> 'b t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val fold : ('b -> 'a -> 'a) -> 'b t -> 'a -> 'a
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val for_all : ('a -> bool) -> 'a t -> bool
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val _exists : ('a -> bool) -> 'a t -> bool
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val filter : ('a -> bool) -> 'a t -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val filter_map : ('a -> 'b option) -> 'a t -> 'b t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val partition : ('a -> bool) -> 'a t -> 'a t * 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val to_list : 'a t -> 'a list
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val of_list : 'a list -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val to_seq : 'a t -> 'a sequence
+        [@@alert not_implemented "This function is not implemented yet"]
+
+      val of_seq : 'a sequence -> 'a t
+        [@@alert not_implemented "This function is not implemented yet"]
+    end
+
+    val __mix_Bmgb (* [->] *) : ('a -> 'b) -> 'a -> 'b -> 'a -> 'b
+      [@@alert not_implemented "This function is not implemented yet"]
+    (* and it is not clear how it should be implemented in Ortac *)
+
+    module Map : sig end
+
+    module Order : sig
+      val is_pre_order : ('a -> 'a -> int) -> bool
+        [@@alert not_implemented "This function cannot be implemented in Ortac"]
+      (** This function cannot be implemented as a test in Ortac! *)
+    end
+
+    module Sys : sig
+      val big_endian : bool
+      val int_size : int
+      val max_array_length : int
+      val max_string_length : int
+      val word_size : int
     end
   end
 

--- a/src/runtime/ortac_runtime_intf.ml
+++ b/src/runtime/ortac_runtime_intf.ml
@@ -42,32 +42,41 @@ module type S = sig
   type integer
 
   module Gospelstdlib : sig
-    val ( ~! ) : 'a ref -> 'a
+    (** {1 Arithmetic} *)
+
+    val succ : integer -> integer
+    val pred : integer -> integer
+    val ( ~- ) : integer -> integer
     val ( + ) : integer -> integer -> integer
     val ( - ) : integer -> integer -> integer
     val ( * ) : integer -> integer -> integer
     val ( / ) : integer -> integer -> integer
-    val ( < ) : integer -> integer -> bool
-    val ( <= ) : integer -> integer -> bool
+    val ( mod ) : integer -> integer -> integer
+    val pow : integer -> integer -> integer
+    val abs : integer -> integer
+    val min : integer -> integer -> integer
+    val max : integer -> integer -> integer
+
+    (** {2 Comparisons} *)
+
     val ( > ) : integer -> integer -> bool
     val ( >= ) : integer -> integer -> bool
-    val ( mod ) : integer -> integer -> integer
-    val ( ~- ) : integer -> integer
-    val abs : integer -> integer
+    val ( < ) : integer -> integer -> bool
+    val ( <= ) : integer -> integer -> bool
+
+    (** {2 Bitwise operations} *)
+
     val logand : integer -> integer -> integer
-    val max : integer -> integer -> integer
-    val min : integer -> integer -> integer
-    val pred : integer -> integer
-    val succ : integer -> integer
-    val pow : integer -> integer -> integer
+
+    (** {2 Machine integers} *)
+
     val integer_of_int : int -> integer
 
-    module Array : sig
-      val make : integer -> 'a -> 'a array
-      val get : 'a array -> integer -> 'a
-      val length : 'a array -> integer
-      val for_all : ('a -> bool) -> 'a array -> bool
-    end
+    (** {1 References} *)
+
+    val ( ~! ) : 'a ref -> 'a
+
+    (** {1 Lists} *)
 
     module List : sig
       val length : 'a list -> integer
@@ -81,6 +90,15 @@ module type S = sig
       val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b list -> 'a
       val fold_right : ('b -> 'a -> 'a) -> 'b list -> 'a -> 'a
       val mem : 'a -> 'a list -> bool
+    end
+
+    (** {1 Arrays} *)
+
+    module Array : sig
+      val length : 'a array -> integer
+      val get : 'a array -> integer -> 'a
+      val make : integer -> 'a -> 'a array
+      val for_all : ('a -> bool) -> 'a array -> bool
     end
   end
 


### PR DESCRIPTION
This PR should be reviewed commit by commit, each commit message explains (in quite some details) what this PR brings.

TLDR:
- a lot more specifications should be translatable now!
- it provides an ascii encoding for the mixfix operators in order to be OCaml-syntax compatible,
- it completes the Ortac runtime with the functions from the OCaml Stdlib (leaving out functions or modules that are not so obvious, such as `Bag` and `Set`),
- it completes the Ortac-runtime interface with the whole Gospel Stdlib, with `alert` attributes on functions that are implemented, so that it pushes warning from the code generator stage to the compiling-the-generated-code stage, ie when the Ortac runtime is actually involved.

On that last aspect, it might make more sense, instead of assuming that the whole Gospel Stdlib is implemented in the Ortac runtime, to provide an explicit list of what is _not_ supported, when there is a good reason for that. In particular, `Order.is_pre_order` probably doesn’t make much sense for a testing tool such as Ortac. It would be more user-friendly to have the code generators skip such specifications instead of generating code that will never compile. Maybe that could be left for a further PR.