### PR TITLE
Cmd pretty printer

### DIFF
--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -29,13 +29,15 @@ type W.kind +=
   | Ensures_not_found_for_next_state of string
   | Type_not_supported of string
   | Impossible_init_state_generation of init_state_error
+  | Functional_argument of string
 
 let level kind =
   match kind with
   | Constant_value _ | Returning_sut _ | No_sut_argument _
   | Multiple_sut_arguments _ | Incompatible_type _ | No_spec _
   | Impossible_term_substitution _ | Ignored_modifies _
-  | Ensures_not_found_for_next_state _ | Type_not_supported _ ->
+  | Ensures_not_found_for_next_state _ | Type_not_supported _
+  | Functional_argument _ ->
       W.Warning
   | No_sut_type _ | No_init_function _ | Syntax_error_in_type _
   | Sut_type_not_supported _ | Type_not_supported_for_sut_parameter _
@@ -153,6 +155,8 @@ let pp_kind ppf kind =
         "Mismatch number of arguments between %a and the function \
          specification."
         W.quoted fct
+  | Functional_argument a ->
+      pf ppf "Functional argument (%a) are not tested." W.quoted a
   | _ -> W.pp_kind ppf kind
 
 let pp_errors = W.pp_param pp_kind level |> Fmt.list

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -29,6 +29,7 @@ type W.kind +=
   | Ensures_not_found_for_next_state of string
   | Type_not_supported of string
   | Impossible_init_state_generation of init_state_error
+  | Functional_argument of string
 
 type 'a reserr
 

--- a/plugins/qcheck-stm/test/array_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/array_stm_tests.expected.ml
@@ -9,7 +9,19 @@ module Spec =
       | Set of int * char 
       | Fill of int * int * char 
       | To_list 
-      | Mem of char [@@deriving show { with_path = false }]
+      | Mem of char 
+    let show_cmd cmd__001_ =
+      match cmd__001_ with
+      | Length -> Format.asprintf "%s" "length"
+      | Get i -> Format.asprintf "%s %a" "get" (Util.Pp.pp_int true) i
+      | Set (i_1, a_1) ->
+          Format.asprintf "%s %a %a" "set" (Util.Pp.pp_int true) i_1
+            (Util.Pp.pp_char true) a_1
+      | Fill (i_2, j, a_2) ->
+          Format.asprintf "%s %a %a %a" "fill" (Util.Pp.pp_int true) i_2
+            (Util.Pp.pp_int true) j (Util.Pp.pp_char true) a_2
+      | To_list -> Format.asprintf "%s" "to_list"
+      | Mem a_3 -> Format.asprintf "%s %a" "mem" (Util.Pp.pp_char true) a_3
     type nonrec state = {
       size: int ;
       contents: char list }
@@ -33,42 +45,42 @@ module Spec =
                (pure (fun i -> Get i)) <*> int;
                ((pure (fun i_1 -> fun a_1 -> Set (i_1, a_1))) <*> int) <*>
                  char;
-               (((pure
-                    (fun i_2 -> fun j_1 -> fun a_2 -> Fill (i_2, j_1, a_2)))
+               (((pure (fun i_2 -> fun j -> fun a_2 -> Fill (i_2, j, a_2)))
                    <*> int)
                   <*> int)
                  <*> char;
                pure To_list;
                (pure (fun a_3 -> Mem a_3)) <*> char])
-    let next_state cmd__001_ state__002_ =
-      match cmd__001_ with
-      | Length -> state__002_
-      | Get i -> state__002_
+    let next_state cmd__002_ state__003_ =
+      match cmd__002_ with
+      | Length -> state__003_
+      | Get i -> state__003_
       | Set (i_1, a_1) ->
           if
-            let __t1__003_ =
+            let __t1__004_ =
               Ortac_runtime.Gospelstdlib.(<=)
                 (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                 (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
-            let __t2__004_ =
+            let __t2__005_ =
               Ortac_runtime.Gospelstdlib.(<)
                 (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
-                (Ortac_runtime.Gospelstdlib.integer_of_int state__002_.size) in
-            __t1__003_ && __t2__004_
+                (Ortac_runtime.Gospelstdlib.integer_of_int state__003_.size) in
+            __t1__004_ && __t2__005_
           then
             {
-              state__002_ with
+              state__003_ with
               contents =
                 (Ortac_runtime.Gospelstdlib.List.mapi
-                   (fun j ->
+                   (fun j_1 ->
                       fun x ->
                         if
-                          j = (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
+                          j_1 =
+                            (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
                         then a_1
-                        else x) state__002_.contents)
+                        else x) state__003_.contents)
             }
-          else state__002_
-      | Fill (i_2, j_1, a_2) ->
+          else state__003_
+      | Fill (i_2, j, a_2) ->
           if
             (Ortac_runtime.Gospelstdlib.(<=)
                (Ortac_runtime.Gospelstdlib.integer_of_int 0)
@@ -76,89 +88,88 @@ module Spec =
               &&
               ((Ortac_runtime.Gospelstdlib.(<=)
                   (Ortac_runtime.Gospelstdlib.integer_of_int 0)
-                  (Ortac_runtime.Gospelstdlib.integer_of_int j_1))
+                  (Ortac_runtime.Gospelstdlib.integer_of_int j))
                  &&
                  (Ortac_runtime.Gospelstdlib.(<=)
                     (Ortac_runtime.Gospelstdlib.(+)
                        (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
-                       (Ortac_runtime.Gospelstdlib.integer_of_int j_1))
+                       (Ortac_runtime.Gospelstdlib.integer_of_int j))
                     (Ortac_runtime.Gospelstdlib.integer_of_int
-                       state__002_.size)))
+                       state__003_.size)))
           then
             {
-              state__002_ with
+              state__003_ with
               contents =
                 (Ortac_runtime.Gospelstdlib.List.mapi
                    (fun k ->
                       fun x_1 ->
                         if
-                          let __t1__005_ =
+                          let __t1__006_ =
                             Ortac_runtime.Gospelstdlib.(<=)
                               (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
                               k in
-                          let __t2__006_ =
+                          let __t2__007_ =
                             Ortac_runtime.Gospelstdlib.(<) k
                               (Ortac_runtime.Gospelstdlib.(+)
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
                                     i_2)
-                                 (Ortac_runtime.Gospelstdlib.integer_of_int
-                                    j_1)) in
-                          __t1__005_ && __t2__006_
+                                 (Ortac_runtime.Gospelstdlib.integer_of_int j)) in
+                          __t1__006_ && __t2__007_
                         then a_2
-                        else x_1) state__002_.contents)
+                        else x_1) state__003_.contents)
             }
-          else state__002_
-      | To_list -> state__002_
-      | Mem a_3 -> state__002_
-    let precond cmd__015_ state__016_ =
-      match cmd__015_ with
+          else state__003_
+      | To_list -> state__003_
+      | Mem a_3 -> state__003_
+    let precond cmd__016_ state__017_ =
+      match cmd__016_ with
       | Length -> true
       | Get i -> true
       | Set (i_1, a_1) -> true
-      | Fill (i_2, j_1, a_2) -> true
+      | Fill (i_2, j, a_2) -> true
       | To_list -> true
       | Mem a_3 -> true
-    let postcond cmd__007_ state__008_ res__009_ =
-      let new_state__010_ = lazy (next_state cmd__007_ state__008_) in
-      match (cmd__007_, res__009_) with
+    let postcond cmd__008_ state__009_ res__010_ =
+      let new_state__011_ = lazy (next_state cmd__008_ state__009_) in
+      match (cmd__008_, res__010_) with
       | (Length, Res ((Int, _), i_3)) ->
-          i_3 = (Lazy.force new_state__010_).size
+          i_3 = (Lazy.force new_state__011_).size
       | (Get i, Res ((Result (Char, Exn), _), a_4)) ->
           if
-            let __t1__011_ =
+            let __t1__012_ =
               Ortac_runtime.Gospelstdlib.(<=)
                 (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                 (Ortac_runtime.Gospelstdlib.integer_of_int i) in
-            let __t2__012_ =
+            let __t2__013_ =
               Ortac_runtime.Gospelstdlib.(<)
                 (Ortac_runtime.Gospelstdlib.integer_of_int i)
-                (Ortac_runtime.Gospelstdlib.integer_of_int state__008_.size) in
-            __t1__011_ && __t2__012_
+                (Ortac_runtime.Gospelstdlib.integer_of_int state__009_.size) in
+            __t1__012_ && __t2__013_
           then
             (match a_4 with
              | Ok a_4 ->
                  a_4 =
                    (Ortac_runtime.Gospelstdlib.List.nth
-                      (Lazy.force new_state__010_).contents
+                      (Lazy.force new_state__011_).contents
                       (Ortac_runtime.Gospelstdlib.integer_of_int i))
              | _ -> false)
           else
             (match a_4 with | Error (Invalid_argument _) -> true | _ -> false)
       | (Set (i_1, a_1), Res ((Result (Unit, Exn), _), res)) ->
           if
-            let __t1__013_ =
+            let __t1__014_ =
               Ortac_runtime.Gospelstdlib.(<=)
                 (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                 (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
-            let __t2__014_ =
+            let __t2__015_ =
               Ortac_runtime.Gospelstdlib.(<)
                 (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
-                (Ortac_runtime.Gospelstdlib.integer_of_int state__008_.size) in
-            __t1__013_ && __t2__014_
+                (Ortac_runtime.Gospelstdlib.integer_of_int state__009_.size) in
+            __t1__014_ && __t2__015_
           then (match res with | Ok _ -> true | _ -> false)
           else
             (match res with | Error (Invalid_argument _) -> true | _ -> false)
-      | (Fill (i_2, j_1, a_2), Res ((Result (Unit, Exn), _), res)) ->
+      | (Fill (i_2, j, a_2), Res ((Result (Unit, Exn), _), res)) ->
           if
             (Ortac_runtime.Gospelstdlib.(<=)
                (Ortac_runtime.Gospelstdlib.integer_of_int 0)
@@ -166,39 +177,39 @@ module Spec =
               &&
               ((Ortac_runtime.Gospelstdlib.(<=)
                   (Ortac_runtime.Gospelstdlib.integer_of_int 0)
-                  (Ortac_runtime.Gospelstdlib.integer_of_int j_1))
+                  (Ortac_runtime.Gospelstdlib.integer_of_int j))
                  &&
                  (Ortac_runtime.Gospelstdlib.(<=)
                     (Ortac_runtime.Gospelstdlib.(+)
                        (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
-                       (Ortac_runtime.Gospelstdlib.integer_of_int j_1))
+                       (Ortac_runtime.Gospelstdlib.integer_of_int j))
                     (Ortac_runtime.Gospelstdlib.integer_of_int
-                       state__008_.size)))
+                       state__009_.size)))
           then (match res with | Ok _ -> true | _ -> false)
           else
             (match res with | Error (Invalid_argument _) -> true | _ -> false)
       | (To_list, Res ((List (Char), _), l)) ->
-          l = (Lazy.force new_state__010_).contents
+          l = (Lazy.force new_state__011_).contents
       | (Mem a_3, Res ((Bool, _), b)) ->
           (b = true) =
             (Ortac_runtime.Gospelstdlib.List.mem a_3
-               (Lazy.force new_state__010_).contents)
+               (Lazy.force new_state__011_).contents)
       | _ -> true
-    let run cmd__017_ sut__018_ =
-      match cmd__017_ with
-      | Length -> Res (int, (length sut__018_))
+    let run cmd__018_ sut__019_ =
+      match cmd__018_ with
+      | Length -> Res (int, (length sut__019_))
       | Get i ->
-          Res ((result char exn), (protect (fun () -> get sut__018_ i) ()))
+          Res ((result char exn), (protect (fun () -> get sut__019_ i) ()))
       | Set (i_1, a_1) ->
           Res
             ((result unit exn),
-              (protect (fun () -> set sut__018_ i_1 a_1) ()))
-      | Fill (i_2, j_1, a_2) ->
+              (protect (fun () -> set sut__019_ i_1 a_1) ()))
+      | Fill (i_2, j, a_2) ->
           Res
             ((result unit exn),
-              (protect (fun () -> fill sut__018_ i_2 j_1 a_2) ()))
-      | To_list -> Res ((list char), (to_list sut__018_))
-      | Mem a_3 -> Res (bool, (mem a_3 sut__018_))
+              (protect (fun () -> fill sut__019_ i_2 j a_2) ()))
+      | To_list -> Res ((list char), (to_list sut__019_))
+      | Mem a_3 -> Res (bool, (mem a_3 sut__019_))
   end
 module STMTests = (STM_sequential.Make)(Spec)
 let _ =

--- a/plugins/qcheck-stm/test/dune
+++ b/plugins/qcheck-stm/test/dune
@@ -15,11 +15,10 @@
   qcheck-core.runner
   qcheck-stm.stm
   qcheck-stm.sequential
+  qcheck-multicoretests-util
   ortac-runtime
   array)
  (flags :standard -w -26-27-32-33)
- (preprocess
-  (pps ppx_deriving.show))
  (action
   (echo
    "\n%{dep:array_stm_tests.exe} has been generated with the ortac-qcheck-stm plugin.\n")))
@@ -58,11 +57,10 @@
   qcheck-core.runner
   qcheck-stm.stm
   qcheck-stm.sequential
+  qcheck-multicoretests-util
   ortac-runtime
   hashtbl)
  (flags :standard -w -23-26-27-32-33 -w -37)
- (preprocess
-  (pps ppx_deriving.show))
  (action
   (echo
    "\n%{dep:hashtbl_stm_tests.exe} has been generated with the ortac-qcheck-stm plugin.\n")))

--- a/plugins/qcheck-stm/test/hashtbl_errors.expected
+++ b/plugins/qcheck-stm/test/hashtbl_errors.expected
@@ -1,8 +1,17 @@
 File "hashtbl.mli", line 19, characters 25-35:
 Warning: `copy' returns a sut.
 
+File "hashtbl.mli", line 63, characters 12-28:
+Warning: Functional argument (`'a -> 'b -> unit') are not tested.
+
 File "hashtbl.mli", line 63, characters 0-51:
 Warning: The function `iter' is not specified.
+
+File "hashtbl.mli", line 64, characters 26-47:
+Warning: Functional argument (`'a -> 'b -> 'b option') are not tested.
+
+File "hashtbl.mli", line 73, characters 12-32:
+Warning: Functional argument (`'a -> 'b -> 'c -> 'c') are not tested.
 
 File "hashtbl.mli", line 73, characters 0-59:
 Warning: The function `fold' is not specified.
@@ -73,12 +82,6 @@ Warning: `seeded_hash_param' have no sut argument.
 File "hashtbl.mli", line 106, characters 0-54:
 Warning: The function `seeded_hash_param' is not specified.
 
-File "hashtbl.mli", line 2, characters 18-26:
-Warning: No translatable `ensures` clause found to generate `next_state` for model `contents'.
-
 File "hashtbl.mli", line 30, characters 24-66:
 Warning: unsupported quantification. The clause has not been translated
-
-File "hashtbl.mli", line 64, characters 26-47:
-Warning: Type not supported `'a -> 'b -> 'b option'.
 

--- a/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
@@ -18,8 +18,26 @@ module Spec =
       | Mem of char 
       | Remove of char 
       | Replace of char * int 
-      | Filter_map_inplace of (char -> int -> int option) 
-      | Length [@@deriving show { with_path = false }]
+      | Length 
+    let show_cmd cmd__001_ =
+      match cmd__001_ with
+      | Clear -> Format.asprintf "%s" "clear"
+      | Reset -> Format.asprintf "%s" "reset"
+      | Add (a_2, b_2) ->
+          Format.asprintf "%s %a %a" "add" (Util.Pp.pp_char true) a_2
+            (Util.Pp.pp_int true) b_2
+      | Find a_3 -> Format.asprintf "%s %a" "find" (Util.Pp.pp_char true) a_3
+      | Find_opt a_4 ->
+          Format.asprintf "%s %a" "find_opt" (Util.Pp.pp_char true) a_4
+      | Find_all a_5 ->
+          Format.asprintf "%s %a" "find_all" (Util.Pp.pp_char true) a_5
+      | Mem a_6 -> Format.asprintf "%s %a" "mem" (Util.Pp.pp_char true) a_6
+      | Remove a_7 ->
+          Format.asprintf "%s %a" "remove" (Util.Pp.pp_char true) a_7
+      | Replace (a_8, b_3) ->
+          Format.asprintf "%s %a %a" "replace" (Util.Pp.pp_char true) a_8
+            (Util.Pp.pp_int true) b_3
+      | Length -> Format.asprintf "%s" "length"
     type nonrec state = {
       contents: (char * int) list }
     let init_state = let random = false
@@ -43,32 +61,31 @@ module Spec =
                ((pure (fun a_8 -> fun b_3 -> Replace (a_8, b_3))) <*> char)
                  <*> int;
                pure Length])
-    let next_state cmd__001_ state__002_ =
-      match cmd__001_ with
-      | Clear -> { state__002_ with contents = [] }
-      | Reset -> { state__002_ with contents = [] }
+    let next_state cmd__002_ state__003_ =
+      match cmd__002_ with
+      | Clear -> { state__003_ with contents = [] }
+      | Reset -> { state__003_ with contents = [] }
       | Add (a_2, b_2) ->
-          { state__002_ with contents = ((a_2, b_2) :: state__002_.contents)
+          { state__003_ with contents = ((a_2, b_2) :: state__003_.contents)
           }
-      | Find a_3 -> state__002_
-      | Find_opt a_4 -> state__002_
-      | Find_all a_5 -> state__002_
-      | Mem a_6 -> state__002_
+      | Find a_3 -> state__003_
+      | Find_opt a_4 -> state__003_
+      | Find_all a_5 -> state__003_
+      | Mem a_6 -> state__003_
       | Remove a_7 ->
           {
-            state__002_ with
-            contents = (remove_first a_7 state__002_.contents)
+            state__003_ with
+            contents = (remove_first a_7 state__003_.contents)
           }
       | Replace (a_8, b_3) ->
           {
-            state__002_ with
+            state__003_ with
             contents =
-              ((a_8, b_3) :: (remove_first a_8 state__002_.contents))
+              ((a_8, b_3) :: (remove_first a_8 state__003_.contents))
           }
-      | Filter_map_inplace f -> state__002_
-      | Length -> state__002_
-    let precond cmd__007_ state__008_ =
-      match cmd__007_ with
+      | Length -> state__003_
+    let precond cmd__008_ state__009_ =
+      match cmd__008_ with
       | Clear -> true
       | Reset -> true
       | Add (a_2, b_2) -> true
@@ -78,11 +95,10 @@ module Spec =
       | Mem a_6 -> true
       | Remove a_7 -> true
       | Replace (a_8, b_3) -> true
-      | Filter_map_inplace f -> true
       | Length -> true
-    let postcond cmd__003_ state__004_ res__005_ =
-      let new_state__006_ = lazy (next_state cmd__003_ state__004_) in
-      match (cmd__003_, res__005_) with
+    let postcond cmd__004_ state__005_ res__006_ =
+      let new_state__007_ = lazy (next_state cmd__004_ state__005_) in
+      match (cmd__004_, res__006_) with
       | (Clear, Res ((Unit, _), _)) -> true
       | (Reset, Res ((Unit, _), _)) -> true
       | (Add (a_2, b_2), Res ((Unit, _), _)) -> true
@@ -90,13 +106,13 @@ module Spec =
           (match b_4 with
            | Ok b_4 ->
                Ortac_runtime.Gospelstdlib.List.mem (a_3, b_4)
-                 (Lazy.force new_state__006_).contents
+                 (Lazy.force new_state__007_).contents
            | Error (Not_found) ->
                not
                  (Ortac_runtime.Gospelstdlib.List.mem a_3
                     (Ortac_runtime.Gospelstdlib.List.map
                        (fun x_1 -> Ortac_runtime.Gospelstdlib.fst x_1)
-                       (Lazy.force new_state__006_).contents))
+                       (Lazy.force new_state__007_).contents))
            | _ -> false)
       | (Find_opt a_4, Res ((Option (Int), _), o)) ->
           (match o with
@@ -106,13 +122,13 @@ module Spec =
                    (Ortac_runtime.Gospelstdlib.List.mem a_4
                       (Ortac_runtime.Gospelstdlib.List.map
                          (fun x_2 -> Ortac_runtime.Gospelstdlib.fst x_2)
-                         (Lazy.force new_state__006_).contents))
+                         (Lazy.force new_state__007_).contents))
                then true
                else false
            | Some b_5 ->
                if
                  Ortac_runtime.Gospelstdlib.List.mem (a_4, b_5)
-                   (Lazy.force new_state__006_).contents
+                   (Lazy.force new_state__007_).contents
                then true
                else false)
             = true
@@ -124,47 +140,33 @@ module Spec =
                   then Some (Ortac_runtime.Gospelstdlib.snd x_3)
                   else None)
                (Ortac_runtime.Gospelstdlib.List.to_seq
-                  (Lazy.force new_state__006_).contents))
+                  (Lazy.force new_state__007_).contents))
       | (Mem a_6, Res ((Bool, _), b_6)) ->
           (b_6 = true) =
             (Ortac_runtime.Gospelstdlib.List.mem a_6
                (Ortac_runtime.Gospelstdlib.List.map
                   (fun x_4 -> Ortac_runtime.Gospelstdlib.fst x_4)
-                  (Lazy.force new_state__006_).contents))
+                  (Lazy.force new_state__007_).contents))
       | (Remove a_7, Res ((Unit, _), _)) -> true
       | (Replace (a_8, b_3), Res ((Unit, _), _)) -> true
-      | (Filter_map_inplace f, Res ((Unit, _), _)) ->
-          (Ortac_runtime.Gospelstdlib.List.to_seq
-             (Lazy.force new_state__006_).contents)
-            =
-            (Ortac_runtime.Gospelstdlib.Sequence.filter_map
-               (fun x_5 ->
-                  match f (Ortac_runtime.Gospelstdlib.fst x_5)
-                          (Ortac_runtime.Gospelstdlib.snd x_5)
-                  with
-                  | None -> None
-                  | Some b' ->
-                      Some ((Ortac_runtime.Gospelstdlib.fst x_5), b'))
-               (Ortac_runtime.Gospelstdlib.List.to_seq state__004_.contents))
       | (Length, Res ((Int, _), i)) ->
           (Ortac_runtime.Gospelstdlib.integer_of_int i) =
             (Ortac_runtime.Gospelstdlib.List.length
-               (Lazy.force new_state__006_).contents)
+               (Lazy.force new_state__007_).contents)
       | _ -> true
-    let run cmd__009_ sut__010_ =
-      match cmd__009_ with
-      | Clear -> Res (unit, (clear sut__010_))
-      | Reset -> Res (unit, (reset sut__010_))
-      | Add (a_2, b_2) -> Res (unit, (add sut__010_ a_2 b_2))
+    let run cmd__010_ sut__011_ =
+      match cmd__010_ with
+      | Clear -> Res (unit, (clear sut__011_))
+      | Reset -> Res (unit, (reset sut__011_))
+      | Add (a_2, b_2) -> Res (unit, (add sut__011_ a_2 b_2))
       | Find a_3 ->
-          Res ((result int exn), (protect (fun () -> find sut__010_ a_3) ()))
-      | Find_opt a_4 -> Res ((option int), (find_opt sut__010_ a_4))
-      | Find_all a_5 -> Res ((list int), (find_all sut__010_ a_5))
-      | Mem a_6 -> Res (bool, (mem sut__010_ a_6))
-      | Remove a_7 -> Res (unit, (remove sut__010_ a_7))
-      | Replace (a_8, b_3) -> Res (unit, (replace sut__010_ a_8 b_3))
-      | Filter_map_inplace f -> Res (unit, (filter_map_inplace f sut__010_))
-      | Length -> Res (int, (length sut__010_))
+          Res ((result int exn), (protect (fun () -> find sut__011_ a_3) ()))
+      | Find_opt a_4 -> Res ((option int), (find_opt sut__011_ a_4))
+      | Find_all a_5 -> Res ((list int), (find_all sut__011_ a_5))
+      | Mem a_6 -> Res (bool, (mem sut__011_ a_6))
+      | Remove a_7 -> Res (unit, (remove sut__011_ a_7))
+      | Replace (a_8, b_3) -> Res (unit, (replace sut__011_ a_8 b_3))
+      | Length -> Res (int, (length sut__011_))
   end
 module STMTests = (STM_sequential.Make)(Spec)
 let _ =


### PR DESCRIPTION
This PR fixes #101 

A filtering of higher order values is added in the `ir_of_gospel` step as the pretty printer library does not support functional values. As `cmd`s correponding to higher order values are not generated in `arb_cmd` anywat, an other strategy would have been to let the pretty printer fail in these cases which it will never encounter. But now the user has a bit more information.