### PR TITLE
Add assymetric conjunction to possible quantification

### DIFF
--- a/src/core/ocaml_of_gospel.ml
+++ b/src/core/ocaml_of_gospel.ml
@@ -119,7 +119,7 @@ and term ~context (t : Tterm.term) : expression =
             t_node =
               Tbinop
                 ( ((Timplies | Tand | Tand_asym) as op),
-                  { t_node = Tbinop (Tand, t1, t2); _ },
+                  { t_node = Tbinop ((Tand | Tand_asym), t1, t2); _ },
                   p );
             _;
           } ) ->


### PR DESCRIPTION
Before
```
forall x. 0 < x /\ x < 10 -> P
```
was accepted, but not
```
forall x. 0 < x && x < 10 -> P
```
This PR proposes to accept it, as I don't see any reason why it shouldn't.
