### PR TITLE
Route Gospel errors as other errors in qcheck-stm plugin

### DIFF
--- a/plugins/qcheck-stm/src/config.ml
+++ b/plugins/qcheck-stm/src/config.ml
@@ -84,13 +84,16 @@ let init_sut_from_string str =
   with _ -> Reserr.(error (Syntax_error_in_init_sut str, Location.none))
 
 let init path init_sut sut_str =
-  let module_name = Utils.module_name_of_path path in
-  Parser_frontend.parse_ocaml_gospel path |> Utils.type_check [] path
-  |> fun (env, sigs) ->
-  assert (List.length env = 1);
-  let namespace = List.hd env in
-  let context = Context.init module_name namespace in
   let open Reserr in
-  let* sut_core_type = sut_core_type sut_str
-  and* init_sut = init_sut_from_string init_sut in
-  ok (sigs, { context; sut_core_type; init_sut })
+  try
+    let module_name = Utils.module_name_of_path path in
+    Parser_frontend.parse_ocaml_gospel path |> Utils.type_check [] path
+    |> fun (env, sigs) ->
+    assert (List.length env = 1);
+    let namespace = List.hd env in
+    let context = Context.init module_name namespace in
+    let* sut_core_type = sut_core_type sut_str
+    and* init_sut = init_sut_from_string init_sut in
+    ok (sigs, { context; sut_core_type; init_sut })
+  with Gospel.Warnings.Error (l, k) ->
+    error (Ortac_core.Warnings.GospelError k, l)

--- a/src/core/warnings.ml
+++ b/src/core/warnings.ml
@@ -2,13 +2,16 @@ open Ppxlib
 
 type level = Warning | Error
 type kind = ..
-type kind += Unsupported of string
+type kind += GospelError of Gospel.Warnings.kind | Unsupported of string
 
 exception Unkown_kind
 
 type t = kind * Location.t
 
-let level = function Unsupported _ -> Warning | _ -> raise Unkown_kind
+let level = function
+  | GospelError _ -> Error
+  | Unsupported _ -> Warning
+  | _ -> raise Unkown_kind
 
 exception Error of t
 
@@ -23,6 +26,7 @@ let pp_level ppf = function
 let quoted ppf = pf ppf "`%s'"
 
 let pp_kind ppf = function
+  | GospelError k -> pf ppf "Gospel error: %a" Gospel.Warnings.pp_kind k
   | Unsupported msg ->
       pf ppf "unsupported %s. The clause has not been translated" msg
   | _ -> raise Unkown_kind


### PR DESCRIPTION
Add basic support for Gospel errors in Ortac Core and use that to report properly Gospel errors in the qcheck-stm plugin