### PR TITLE
Cleanup QCheck-STM warnings

### DIFF
--- a/plugins/monolith/src/warnings.ml
+++ b/plugins/monolith/src/warnings.ml
@@ -22,7 +22,7 @@ open Fmt
 let styled_list l pp = List.fold_left (fun acc x -> styled x acc) pp l
 
 let pp_level ppf = function
-  | Warning -> pf ppf "%a: " (styled_list [ `Yellow; `Bold ] string) "Warning"
+  | Warning -> pf ppf "%a: " (styled_list [ `Magenta; `Bold ] string) "Warning"
   | Error -> pf ppf "%a: " (styled_list [ `Red; `Bold ] string) "Error"
 
 let pp_kind ppf = function

--- a/plugins/monolith/test/generated/errors.expected
+++ b/plugins/monolith/test/generated/errors.expected
@@ -1,3 +1,4 @@
 File "lib.mli", line 20, characters 44-52:
-Warning: unsupported old operator. The clause has not been translated
-
+20 |                 mem j bv <-> i = j \/ mem j (old bv) *)
+                                                 ^^^^^^^^
+Warning: Skipping clause: unsupported old operator.

--- a/plugins/qcheck-stm/src/ir.ml
+++ b/plugins/qcheck-stm/src/ir.ml
@@ -16,7 +16,7 @@ type next_state = {
   (* description of the new values are stored with the index of the
      postcondition they come from *)
   formulae : (int * new_state_formulae) list;
-  modifies : Ident.t list;
+  modifies : (Ident.t * Ppxlib.Location.t) list;
 }
 
 type postcond = {

--- a/plugins/qcheck-stm/src/ir_of_gospel.ml
+++ b/plugins/qcheck-stm/src/ir_of_gospel.ml
@@ -16,9 +16,7 @@ let higher_order_test vd =
   let rec contains_arrow ty =
     match ty.ptyp_desc with
     | Ptyp_arrow (_, _, _) ->
-        error
-          ( Functional_argument (Fmt.str "%a" Pprintast.core_type ty),
-            ty.ptyp_loc )
+        error (Functional_argument vd.vd_name.id_str, ty.ptyp_loc)
     | Ptyp_tuple xs | Ptyp_constr (_, xs) ->
         let* _ = List.map contains_arrow xs |> sequence in
         ok ()

--- a/plugins/qcheck-stm/src/ir_of_gospel.ml
+++ b/plugins/qcheck-stm/src/ir_of_gospel.ml
@@ -38,11 +38,12 @@ let is_a_function ty =
 let unify value_name sut_ty ty =
   let open Ppxlib in
   let open Reserr in
+  let show_type = Fmt.to_to_string Pprintast.core_type in
   let add_if_needed a x i =
     match List.assoc_opt a i with
     | None -> ok ((a, x) :: i)
     | Some y when x.ptyp_desc = y.ptyp_desc -> ok i
-    | _ -> error (Incompatible_type value_name, ty.ptyp_loc)
+    | _ -> error (Incompatible_type (value_name, show_type sut_ty), ty.ptyp_loc)
   in
   let rec aux i = function
     | [], [] -> ok i
@@ -54,10 +55,13 @@ let unify value_name sut_ty ty =
           | Ptyp_tuple xs, Ptyp_tuple ys -> aux i (xs, ys)
           | Ptyp_constr (c, xs), Ptyp_constr (d, ys) when c.txt = d.txt ->
               aux i (xs, ys)
-          | _ -> error (Incompatible_type value_name, ty.ptyp_loc)
+          | _ ->
+              error
+                (Incompatible_type (value_name, show_type sut_ty), ty.ptyp_loc)
         in
         aux i (xs, ys)
-    | _, _ -> error (Incompatible_type value_name, ty.ptyp_loc)
+    | _, _ ->
+        error (Incompatible_type (value_name, show_type sut_ty), ty.ptyp_loc)
   in
   match (sut_ty.ptyp_desc, ty.ptyp_desc) with
   | Ptyp_constr (t, args_sut), Ptyp_constr (t', args_ty) when t.txt = t'.txt ->

--- a/plugins/qcheck-stm/src/ir_of_gospel.ml
+++ b/plugins/qcheck-stm/src/ir_of_gospel.ml
@@ -153,10 +153,7 @@ let next_state sut state spec =
     | { t_node = Tvar vs; _ } when is_t vs -> List.map fst state |> ok
     | { t_node = Tfield ({ t_node = Tvar vs; _ }, m); _ } when is_t vs ->
         ok [ m.ls_name ]
-    | t ->
-        error
-          ( Ignored_modifies (Fmt.str "%a" Gospel.Tterm_printer.print_term t),
-            t.t_loc )
+    | t -> error (Ignored_modifies, t.t_loc)
   in
   let* modifies = concat_map check_modify spec.sp_wr in
   let modifies = List.sort_uniq Ident.compare modifies in

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -128,8 +128,8 @@ let pp_kind ppf kind =
   (* TODO: This error message is broad and used in seemingly different contexts;
      we might turn it into more specific error messages *)
   | Type_not_supported ty -> pf ppf "Type %a not supported" W.quoted ty
-  | Functional_argument a ->
-      pf ppf "Skipping function with argument of type %a:@ %a" W.quoted a text
+  | Functional_argument f ->
+      pf ppf "Skipping %a:@ %a" W.quoted f text
         "functions are not supported yet as arguments"
   | Ghost_values (id, k) ->
       pf ppf "Skipping function with a ghost %s %a"

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -19,7 +19,6 @@ type W.kind +=
   | Syntax_error_in_type of string
   | Syntax_error_in_init_sut of string
   | Sut_type_not_supported of string
-  | Init_sut_not_supported of string
   | Type_parameter_not_instantiated of string
   | Type_not_supported_for_sut_parameter of string
   | Incompatible_type of (string * string)
@@ -44,9 +43,9 @@ let level kind =
       W.Warning
   | No_sut_type _ | No_init_function _ | Syntax_error_in_type _
   | Sut_type_not_supported _ | Type_not_supported_for_sut_parameter _
-  | Init_sut_not_supported _ | Syntax_error_in_init_sut _
-  | Type_parameter_not_instantiated _ | Sut_type_not_specified _ | No_models _
-  | Impossible_init_state_generation _ ->
+  | Syntax_error_in_init_sut _ | Type_parameter_not_instantiated _
+  | Sut_type_not_specified _ | No_models _ | Impossible_init_state_generation _
+    ->
       W.Error
   | _ -> W.level kind
 
@@ -156,9 +155,6 @@ let pp_kind ppf kind =
       pf ppf "Unsupported SUT type %a:@ %a" W.quoted ty text
         "SUT type must be a type constructor, possibly applied to type \
          arguments"
-  | Init_sut_not_supported e ->
-      (* DEAD? *)
-      pf ppf "The expression %a given for init_sut in not supported." W.quoted e
   | Type_parameter_not_instantiated ty ->
       pf ppf "Unsupported type parameter %a:@ %a" W.quoted ty text
         "SUT type should be fully instantiated"

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -109,7 +109,7 @@ let pp_kind ppf kind =
         W.quoted t
   | No_spec fct ->
       pf ppf "Skipping %a:@ %a" W.quoted fct text
-        "functions without specification cannot be tested"
+        "functions without specifications cannot be tested"
   | Impossible_term_substitution (t, why) ->
       let msg =
         match why with

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -118,19 +118,19 @@ let pp_kind ppf kind =
         (* The following cases should not be reported to the user at the moment
            (because they should be caught at some other points) *)
         | `Old ->
-            "occurrences of the SUT in clauses are not supported under `old` \
+            "occurrences of the SUT in clauses are not supported under old \
              operator"
         | `New ->
-            "occurrences of the SUT in clauses are not supported above `old` \
+            "occurrences of the SUT in clauses are not supported above old \
              operator"
       in
       pf ppf "Skipping clause:@ %a" text msg
   | Ignored_modifies ->
-      pf ppf "Skipping unsupported `modifies` clause:@ %a" text
-        "expected `modifies x` or `modifies x.model` where `x` is the SUT"
+      pf ppf "Skipping unsupported modifies clause:@ %a" text
+        "expected \"modifies x\" or \"modifies x.model\" where x is the SUT"
   | Ensures_not_found_for_next_state (f, m) ->
       pf ppf "Skipping %s:@ model@ %s@ %a" f m text
-        "is declared as modified by the function but no translatable `ensures` \
+        "is declared as modified by the function but no translatable ensures \
          clause was found"
   | Functional_argument f ->
       pf ppf "Skipping %s:@ %a" f text

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -91,23 +91,23 @@ let pp_kind ppf kind =
   match kind with
   (* Warnings *)
   | Constant_value id ->
-      pf ppf "Skipping %a:@ %a" W.quoted id text "constants cannot be tested"
+      pf ppf "Skipping %s:@ %a" id text "constants cannot be tested"
   | Returning_sut id ->
-      pf ppf "Skipping %a:@ %a" W.quoted id text
+      pf ppf "Skipping %s:@ %a" id text
         "functions returning a SUT value cannot be tested"
   | No_sut_argument id ->
-      pf ppf "Skipping %a:@ %a" W.quoted id text
+      pf ppf "Skipping %s:@ %a" id text
         "functions with no SUT argument cannot be tested"
   | Multiple_sut_arguments id ->
-      pf ppf "Skipping %a:@ %a" W.quoted id text
+      pf ppf "Skipping %s:@ %a" id text
         "functions with multiple SUT arguments cannot be tested"
   | Incompatible_type (v, t) ->
-      pf ppf "Skipping %a:@ %a%a" W.quoted v text
+      pf ppf "Skipping %s:@ %a%s" v text
         "the type of its SUT-type argument is incompatible with the configured \
          SUT type: "
-        W.quoted t
+        t
   | No_spec fct ->
-      pf ppf "Skipping %a:@ %a" W.quoted fct text
+      pf ppf "Skipping %s:@ %a" fct text
         "functions without specifications cannot be tested"
   | Impossible_term_substitution why ->
       let msg =
@@ -129,54 +129,51 @@ let pp_kind ppf kind =
       pf ppf "Skipping unsupported `modifies` clause:@ %a" text
         "expected `modifies x` or `modifies x.model` where `x` is the SUT"
   | Ensures_not_found_for_next_state (f, m) ->
-      pf ppf "Skipping %a:@ model@ %a@ %a" W.quoted f W.quoted m text
+      pf ppf "Skipping %s:@ model@ %s@ %a" f m text
         "is declared as modified by the function but no translatable `ensures` \
          clause was found"
   | Functional_argument f ->
-      pf ppf "Skipping %a:@ %a" W.quoted f text
+      pf ppf "Skipping %s:@ %a" f text
         "functions are not supported yet as arguments"
   | Ghost_values (id, k) ->
-      pf ppf "Skipping %a:@ %a%a%a" W.quoted id text "functions with a ghost "
-        text
+      pf ppf "Skipping %s:@ %a%a%a" id text "functions with a ghost " text
         (match k with `Arg -> "argument" | `Ret -> "returned value")
         text " are not supported"
   (* This following message is broad and used in seemingly different contexts
      but in fact we support all the types that the Gospel type-checker supports,
      so that error message should never get reported to the end user *)
-  | Type_not_supported ty -> pf ppf "Type %a not supported" W.quoted ty
+  | Type_not_supported ty -> pf ppf "Type %s not supported" ty
   (* Errors *)
-  | No_sut_type ty -> pf ppf "Type %a not declared in the module" W.quoted ty
-  | No_init_function f ->
-      pf ppf "Function %a not declared in the module" W.quoted f
-  | Syntax_error_in_type t -> pf ppf "Syntax error in type %a" W.quoted t
-  | Syntax_error_in_init_sut s ->
-      pf ppf "Syntax error in OCaml expression %a" W.quoted s
+  | No_sut_type ty -> pf ppf "Type %s not declared in the module" ty
+  | No_init_function f -> pf ppf "Function %s not declared in the module" f
+  | Syntax_error_in_type t -> pf ppf "Syntax error in type %s" t
+  | Syntax_error_in_init_sut s -> pf ppf "Syntax error in OCaml expression %s" s
   | Sut_type_not_supported ty ->
-      pf ppf "Unsupported SUT type %a:@ %a" W.quoted ty text
+      pf ppf "Unsupported SUT type %s:@ %a" ty text
         "SUT type must be a type constructor, possibly applied to type \
          arguments"
   | Type_parameter_not_instantiated ty ->
-      pf ppf "Unsupported type parameter %a:@ %a" W.quoted ty text
+      pf ppf "Unsupported type parameter %s:@ %a" ty text
         "SUT type should be fully instantiated"
   | Type_not_supported_for_sut_parameter ty ->
-      pf ppf "Unsupported type parameter %a:@ %a" W.quoted ty text
+      pf ppf "Unsupported type parameter %s:@ %a" ty text
         "only constructors and tuples are supported in arguments for the SUT \
          type"
   | Sut_type_not_specified ty ->
-      pf ppf "Missing specification for the SUT type %a" W.quoted ty
-  | No_models ty -> pf ppf "Missing model(s) for the SUT type %a" W.quoted ty
+      pf ppf "Missing specification for the SUT type %s" ty
+  | No_models ty -> pf ppf "Missing model(s) for the SUT type %s" ty
   | Impossible_init_state_generation (Not_a_function_call fct) ->
-      pf ppf "Unsupported INIT expression %a:@ %a" W.quoted fct text
+      pf ppf "Unsupported INIT expression %s:@ %a" fct text
         "the INIT expression is expected to be a function call (the \
          specification of that function is required to initialize the model \
          state)"
   | Impossible_init_state_generation (No_specification fct) ->
-      pf ppf "Unsupported INIT function %a:@ %a" W.quoted fct text
+      pf ppf "Unsupported INIT function %s:@ %a" fct text
         "the function called in the INIT expression must be specified to \
          initialize the model state"
   | Impossible_init_state_generation
       (No_appropriate_specifications (fct, models)) ->
-      pf ppf "Unsupported INIT function %a:@ %a:@ %a" W.quoted fct text
+      pf ppf "Unsupported INIT function %s:@ %a:@ %a" fct text
         "the specification of the function called in the INIT expression does \
          not specify the following fields of the model"
         (Fmt.list ~sep:(Fmt.any ",@ ") Fmt.string)
@@ -188,14 +185,14 @@ let pp_kind ppf kind =
          the model"
         model
   | Impossible_init_state_generation (Not_returning_sut fct) ->
-      pf ppf "Unsupported INIT expression %a:@ %a" W.quoted fct text
+      pf ppf "Unsupported INIT expression %s:@ %a" fct text
         "the function called in the INIT expression must return a value of SUT \
          type"
   | Impossible_init_state_generation (Qualified_name fct) ->
-      pf ppf "Unsupported INIT function %a:@ %a" W.quoted fct text
+      pf ppf "Unsupported INIT function %s:@ %a" fct text
         "qualified names are not yet supported"
   | Impossible_init_state_generation (Mismatch_number_of_arguments fct) ->
-      pf ppf "Error in INIT expression %a:@ %a" W.quoted fct text
+      pf ppf "Error in INIT expression %s:@ %a" fct text
         "mismatch in the number of arguments between the INIT expression and \
          the function specification"
   | _ -> W.pp_kind ppf kind

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -133,9 +133,6 @@ let pp_kind ppf kind =
       pf ppf "Skipping %a:@ model@ %a@ %a" W.quoted f W.quoted m text
         "is declared as modified by the function but no translatable `ensures` \
          clause was found"
-  (* TODO: This error message is broad and used in seemingly different contexts;
-     we might turn it into more specific error messages *)
-  | Type_not_supported ty -> pf ppf "Type %a not supported" W.quoted ty
   | Functional_argument f ->
       pf ppf "Skipping %a:@ %a" W.quoted f text
         "functions are not supported yet as arguments"
@@ -144,6 +141,10 @@ let pp_kind ppf kind =
         text
         (match k with `Arg -> "argument" | `Ret -> "returned value")
         text " are not supported"
+  (* This following message is broad and used in seemingly different contexts
+     but in fact we support all the types that the Gospel type-checker supports,
+     so that error message should never get reported to the end user *)
+  | Type_not_supported ty -> pf ppf "Type %a not supported" W.quoted ty
   (* Errors *)
   | No_sut_type ty -> pf ppf "Type %a not declared in the module" W.quoted ty
   | No_init_function f ->

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -20,7 +20,7 @@ type W.kind +=
   | Init_sut_not_supported of string
   | Type_parameter_not_instantiated of string
   | Type_not_supported_for_sut_parameter of string
-  | Incompatible_type of string
+  | Incompatible_type of (string * string)
   | Sut_type_not_specified of string
   | No_models of string
   | No_spec of string
@@ -100,10 +100,11 @@ let pp_kind ppf kind =
   | Multiple_sut_arguments id ->
       pf ppf "Skipping %a:@ %a" W.quoted id text
         "functions with multiple SUT arguments cannot be tested"
-  | Incompatible_type v ->
-      pf ppf "Skipping %a:@ %a" W.quoted v text
-        "the type of its SUT-type argument is incompatible with command-line \
-         argument"
+  | Incompatible_type (v, t) ->
+      pf ppf "Skipping %a:@ %a%a" W.quoted v text
+        "the type of its SUT-type argument is incompatible with the configured \
+         SUT type: "
+        W.quoted t
   | No_spec fct ->
       pf ppf "Skipping %a:@ %a" W.quoted fct text
         "functions without specification cannot be tested"

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -132,9 +132,10 @@ let pp_kind ppf kind =
       pf ppf "Skipping %a:@ %a" W.quoted f text
         "functions are not supported yet as arguments"
   | Ghost_values (id, k) ->
-      pf ppf "Skipping function with a ghost %s %a"
+      pf ppf "Skipping %a:@ %a%a%a" W.quoted id text "functions with a ghost "
+        text
         (match k with `Arg -> "argument" | `Ret -> "returned value")
-        W.quoted id
+        text " are not supported"
   (* Errors *)
   | No_sut_type ty -> pf ppf "Type %a not declared in the module" W.quoted ty
   | No_init_function f ->

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -26,7 +26,7 @@ type W.kind +=
   | No_spec of string
   | Impossible_term_substitution of (string * [ `New | `Old | `NotModel ])
   | Ignored_modifies
-  | Ensures_not_found_for_next_state of string
+  | Ensures_not_found_for_next_state of (string * string)
   | Type_not_supported of string
   | Impossible_init_state_generation of init_state_error
   | Functional_argument of string
@@ -120,11 +120,10 @@ let pp_kind ppf kind =
   | Ignored_modifies ->
       pf ppf "Skipping unsupported `modifies` clause:@ %a" text
         "expected `modifies x` or `modifies x.model` where `x` is the SUT"
-  | Ensures_not_found_for_next_state m ->
-      pf ppf "Skipping function because its impact on model %a is unknown:@ %a"
-        W.quoted m text
-        "model is declared as modified by the function but no translatable \
-         `ensures` clause was found"
+  | Ensures_not_found_for_next_state (f, m) ->
+      pf ppf "Skipping %a:@ model@ %a@ %a" W.quoted f W.quoted m text
+        "is declared as modified by the function but no translatable `ensures` \
+         clause was found"
   (* TODO: This error message is broad and used in seemingly different contexts;
      we might turn it into more specific error messages *)
   | Type_not_supported ty -> pf ppf "Type %a not supported" W.quoted ty

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -26,7 +26,7 @@ type W.kind +=
   | Sut_type_not_specified of string
   | No_models of string
   | No_spec of string
-  | Impossible_term_substitution of (string * [ `New | `Old | `NotModel ])
+  | Impossible_term_substitution of [ `New | `Old | `NotModel ]
   | Ignored_modifies
   | Ensures_not_found_for_next_state of (string * string)
   | Type_not_supported of string
@@ -110,16 +110,22 @@ let pp_kind ppf kind =
   | No_spec fct ->
       pf ppf "Skipping %a:@ %a" W.quoted fct text
         "functions without specifications cannot be tested"
-  | Impossible_term_substitution (t, why) ->
+  | Impossible_term_substitution why ->
       let msg =
         match why with
-        | `Old -> "substitution supported only above `old` operator"
-        | `New -> "substitution supported only under `old` operator"
         | `NotModel ->
-            "substitution supported only when applied to one of the model \
-             fields"
+            "occurrences of the SUT in clauses are only supported to access \
+             its model fields"
+        (* The following cases should not be reported to the user at the moment
+           (because they should be caught at some other points) *)
+        | `Old ->
+            "occurrences of the SUT in clauses are not supported under `old` \
+             operator"
+        | `New ->
+            "occurrences of the SUT in clauses are not supported above `old` \
+             operator"
       in
-      pf ppf "Skipping clause with term %a:@ %a" W.quoted t text msg
+      pf ppf "Skipping clause:@ %a" text msg
   | Ignored_modifies ->
       pf ppf "Skipping unsupported `modifies` clause:@ %a" text
         "expected `modifies x` or `modifies x.model` where `x` is the SUT"

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -2,7 +2,9 @@ module W = Ortac_core.Warnings
 
 type init_state_error =
   | Not_a_function_call of string
-  | No_appropriate_specifications of string
+  | No_specification of string
+  | No_appropriate_specifications of string * string list
+  | No_translatable_specification of string
   | Not_returning_sut of string
   | Qualified_name of string
   | Mismatch_number_of_arguments of string
@@ -165,16 +167,29 @@ let pp_kind ppf kind =
         "the INIT expression is expected to be a function call (the \
          specification of that function is required to initialize the model \
          state)"
-  | Impossible_init_state_generation (No_appropriate_specifications fct) ->
-      pf ppf "Unsupported INIT expression %a:@ %a" W.quoted fct text
+  | Impossible_init_state_generation (No_specification fct) ->
+      pf ppf "Unsupported INIT function %a:@ %a" W.quoted fct text
         "the function called in the INIT expression must be specified to \
          initialize the model state"
+  | Impossible_init_state_generation
+      (No_appropriate_specifications (fct, models)) ->
+      pf ppf "Unsupported INIT function %a:@ %a:@ %a" W.quoted fct text
+        "the specification of the function called in the INIT expression does \
+         not specify the following fields of the model"
+        (Fmt.list ~sep:(Fmt.any ",@ ") Fmt.string)
+        models
+  | Impossible_init_state_generation (No_translatable_specification model) ->
+      pf ppf "Unsupported INIT function:@ %a:@ %s" text
+        "the specification of the function called in the INIT expression does \
+         not provide a translatable specification for the following field of \
+         the model"
+        model
   | Impossible_init_state_generation (Not_returning_sut fct) ->
       pf ppf "Unsupported INIT expression %a:@ %a" W.quoted fct text
         "the function called in the INIT expression must return a value of SUT \
          type"
   | Impossible_init_state_generation (Qualified_name fct) ->
-      pf ppf "Unsupported INIT expression %a:@ %a" W.quoted fct text
+      pf ppf "Unsupported INIT function %a:@ %a" W.quoted fct text
         "qualified names are not yet supported"
   | Impossible_init_state_generation (Mismatch_number_of_arguments fct) ->
       pf ppf "Error in INIT expression %a:@ %a" W.quoted fct text

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -25,7 +25,7 @@ type W.kind +=
   | No_models of string
   | No_spec of string
   | Impossible_term_substitution of (string * [ `New | `Old | `NotModel ])
-  | Ignored_modifies of string
+  | Ignored_modifies
   | Ensures_not_found_for_next_state of string
   | Type_not_supported of string
   | Impossible_init_state_generation of init_state_error
@@ -36,7 +36,7 @@ let level kind =
   match kind with
   | Constant_value _ | Returning_sut _ | No_sut_argument _
   | Multiple_sut_arguments _ | Incompatible_type _ | No_spec _
-  | Impossible_term_substitution _ | Ignored_modifies _
+  | Impossible_term_substitution _ | Ignored_modifies
   | Ensures_not_found_for_next_state _ | Type_not_supported _
   | Functional_argument _ | Ghost_values _ ->
       W.Warning
@@ -117,8 +117,8 @@ let pp_kind ppf kind =
              fields"
       in
       pf ppf "Skipping clause with term %a:@ %a" W.quoted t text msg
-  | Ignored_modifies m ->
-      pf ppf "Skipping unsupported `modifies` clause %a:@ %a" W.quoted m text
+  | Ignored_modifies ->
+      pf ppf "Skipping unsupported `modifies` clause:@ %a" text
         "expected `modifies x` or `modifies x.model` where `x` is the SUT"
   | Ensures_not_found_for_next_state m ->
       pf ppf "Skipping function because its impact on model %a is unknown:@ %a"

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -19,7 +19,6 @@ type W.kind +=
   | Syntax_error_in_type of string
   | Syntax_error_in_init_sut of string
   | Sut_type_not_supported of string
-  | Init_sut_not_supported of string
   | Type_parameter_not_instantiated of string
   | Type_not_supported_for_sut_parameter of string
   | Incompatible_type of (string * string)

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -26,7 +26,7 @@ type W.kind +=
   | Sut_type_not_specified of string
   | No_models of string
   | No_spec of string
-  | Impossible_term_substitution of (string * [ `New | `Old | `NotModel ])
+  | Impossible_term_substitution of [ `New | `Old | `NotModel ]
   | Ignored_modifies
   | Ensures_not_found_for_next_state of (string * string)
   | Type_not_supported of string

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -2,7 +2,9 @@ module W = Ortac_core.Warnings
 
 type init_state_error =
   | Not_a_function_call of string
-  | No_appropriate_specifications of string
+  | No_specification of string
+  | No_appropriate_specifications of string * string list
+  | No_translatable_specification of string
   | Not_returning_sut of string
   | Qualified_name of string
   | Mismatch_number_of_arguments of string

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -25,7 +25,7 @@ type W.kind +=
   | No_models of string
   | No_spec of string
   | Impossible_term_substitution of (string * [ `New | `Old | `NotModel ])
-  | Ignored_modifies of string
+  | Ignored_modifies
   | Ensures_not_found_for_next_state of string
   | Type_not_supported of string
   | Impossible_init_state_generation of init_state_error

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -26,7 +26,7 @@ type W.kind +=
   | No_spec of string
   | Impossible_term_substitution of (string * [ `New | `Old | `NotModel ])
   | Ignored_modifies
-  | Ensures_not_found_for_next_state of string
+  | Ensures_not_found_for_next_state of (string * string)
   | Type_not_supported of string
   | Impossible_init_state_generation of init_state_error
   | Functional_argument of string

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -20,7 +20,7 @@ type W.kind +=
   | Init_sut_not_supported of string
   | Type_parameter_not_instantiated of string
   | Type_not_supported_for_sut_parameter of string
-  | Incompatible_type of string
+  | Incompatible_type of (string * string)
   | Sut_type_not_specified of string
   | No_models of string
   | No_spec of string

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -350,7 +350,9 @@ let next_state_case state config state_ident nb_models value =
         (fun (id, loc) ->
           of_option
             ~default:
-              (Ensures_not_found_for_next_state (value.id.id_str, str_of_ident id), loc)
+              ( Ensures_not_found_for_next_state
+                  (value.id.id_str, id.Ident.id_str),
+                loc )
             (pick id))
         value.next_state.modifies
     in
@@ -707,7 +709,7 @@ let init_state config ir =
             |> of_option
                  ~default:
                    ( Impossible_init_state_generation
-                       (No_appropriate_specifications (Fmt.str "%a" Ident.pp id)),
+                       (No_translatable_specification id.Ident.id_str),
                      Ppxlib.Location.none )))
       ir.state
   in

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -347,10 +347,10 @@ let next_state_case state config state_ident nb_models value =
     in
     let* descriptions =
       map
-        (fun id ->
+        (fun (id, loc) ->
           of_option
             ~default:
-              (Ensures_not_found_for_next_state (str_of_ident id), id.id_loc)
+              (Ensures_not_found_for_next_state (value.id.id_str, str_of_ident id), loc)
             (pick id))
         value.next_state.modifies
     in

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -44,7 +44,7 @@ let subst_core_type inst ty =
       ty with
       ptyp_desc =
         (match ty.ptyp_desc with
-        | Ptyp_any -> Ptyp_any
+        | Ptyp_any -> ty_default
         | Ptyp_var x ->
             Option.fold ~none:ty_default
               ~some:(fun x -> x.ptyp_desc)
@@ -64,7 +64,7 @@ let subst_core_type inst ty =
         | Ptyp_variant (_, _, _)
         | Ptyp_poly (_, _)
         | Ptyp_package _ | Ptyp_extension _ ->
-            failwith "Case should not happen in `subst'");
+            failwith "Case should not happen in `subst_core_type'");
     }
   in
   aux ty
@@ -186,6 +186,7 @@ let pat_of_core_type inst typ =
   let rec aux ty =
     let open Reserr in
     match ty.ptyp_desc with
+    | Ptyp_any -> ok pat_default
     | Ptyp_var v -> (
         match List.assoc_opt v inst with
         | None -> ok pat_default
@@ -209,6 +210,7 @@ let exp_of_core_type inst typ =
   let rec aux ty =
     let open Reserr in
     match ty.ptyp_desc with
+    | Ptyp_any -> ok exp_default
     | Ptyp_var v -> (
         match List.assoc_opt v inst with
         | None -> ok exp_default

--- a/plugins/qcheck-stm/test/all_warnings.mli
+++ b/plugins/qcheck-stm/test/all_warnings.mli
@@ -1,6 +1,6 @@
 (*@ predicate p (x : 'a) = true *)
 
-type 'a t
+type 'a t = { v : 'a array }
 (*@ mutable model contents : 'a list *)
 
 type s
@@ -51,3 +51,7 @@ val ghost_returned_value : 'a t -> bool
 val unsupported_quantification : 'a t -> bool
 (*@ b = unsupported_quantification t
     ensures b = forall a. List.mem a t.contents -> p a *)
+
+val record_not_model_field : 'a t -> bool
+(*@ b = record_not_model_field t
+    requires Array.length t.v > 0 *)

--- a/plugins/qcheck-stm/test/all_warnings.mli
+++ b/plugins/qcheck-stm/test/all_warnings.mli
@@ -26,7 +26,7 @@ val incompatible_type : int t -> bool
 (*@ b = incompatible_type t *)
 
 val no_spec : 'a t -> bool
-(*@ b = no_spec t *)
+(**)
 
 val ignored_modified : 'a t -> unit
 (*@ ignored_modified t

--- a/plugins/qcheck-stm/test/all_warnings_errors.expected
+++ b/plugins/qcheck-stm/test/all_warnings_errors.expected
@@ -1,33 +1,53 @@
-File "all_warnings.mli", line 12, characters 0-130:
-Warning: `constant' is a constant.
-
+File "all_warnings.mli", line 12, characters 0-52:
+12 | val constant : unit
+13 | (*@ constant
+14 |     ensures true *)
+Warning: Skipping `constant': constants cannot be tested.
 File "all_warnings.mli", line 16, characters 26-30:
-Warning: `returning_sut' returns a sut.
-
+16 | val returning_sut : 'a -> 'a t
+                               ^^^^
+Warning: Skipping `returning_sut': functions returning a SUT value cannot be
+         tested.
 File "all_warnings.mli", line 19, characters 22-34:
-Warning: `no_sut_argument' have no sut argument.
-
+19 | val no_sut_argument : bool -> bool
+                           ^^^^^^^^^^^^
+Warning: Skipping `no_sut_argument': functions with no SUT argument cannot be
+         tested.
 File "all_warnings.mli", line 22, characters 28-48:
-Warning: `multiple_sut_argument' have multiple sut arguments.
-
+22 | val multiple_sut_argument : 'a t -> 'a t -> bool
+                                 ^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping `multiple_sut_argument': functions with multiple SUT
+         arguments cannot be tested.
 File "all_warnings.mli", line 25, characters 24-29:
-Warning: Type of system under test in `incompatible_type' is incompatible with command line argument.
-
+25 | val incompatible_type : int t -> bool
+                             ^^^^^
+Warning: Skipping `incompatible_type': the type of its SUT-type argument is
+         incompatible with command-line argument.
 File "all_warnings.mli", line 33, characters 13-15:
-Warning: Skipping `modifies` `(unit ):unit_1'.
-
+33 |     modifies () *)
+                  ^^
+Warning: Skipping unsupported `modifies` clause `(unit ):unit_1': expected
+         `modifies x` or `modifies x.model` where `x` is the SUT.
 File "all_warnings.mli", line 42, characters 27-37:
-Warning: Functional argument (`'a -> bool') are not tested.
-
+42 | val functional_argument : ('a -> bool) -> 'a t -> bool
+                                ^^^^^^^^^^
+Warning: Skipping function with argument of type `'a -> bool': functions are
+         not supported yet as arguments.
 File "all_warnings.mli", line 46, characters 24-25:
-Warning: Functions with a ghost argument (`x') are not tested.
-
+46 | (*@ b = ghost_argument [x : bool] t *)
+                             ^
+Warning: Skipping function with a ghost argument `x'.
 File "all_warnings.mli", line 49, characters 6-7:
-Warning: Functions with a ghost returned value (`x_1') are not tested.
-
+49 | (*@ [ x : bool ], b = ghost_returned_value t *)
+           ^
+Warning: Skipping function with a ghost returned value `x_1'.
 File "all_warnings.mli", line 4, characters 18-26:
-Warning: No translatable `ensures` clause found to generate `next_state` for model `contents'.
-
+4 | (*@ mutable model contents : 'a list *)
+                      ^^^^^^^^
+Warning: Skipping function because its impact on model `contents' is unknown:
+         model is declared as modified by the function but no translatable
+         `ensures` clause was found.
 File "all_warnings.mli", line 53, characters 16-54:
-Warning: unsupported quantification. The clause has not been translated
-
+53 |     ensures b = forall a. List.mem a t.contents -> p a *)
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping clause: unsupported quantification.

--- a/plugins/qcheck-stm/test/all_warnings_errors.expected
+++ b/plugins/qcheck-stm/test/all_warnings_errors.expected
@@ -2,32 +2,31 @@ File "all_warnings.mli", line 12, characters 0-52:
 12 | val constant : unit
 13 | (*@ constant
 14 |     ensures true *)
-Warning: Skipping `constant': constants cannot be tested.
+Warning: Skipping constant: constants cannot be tested.
 File "all_warnings.mli", line 16, characters 26-30:
 16 | val returning_sut : 'a -> 'a t
                                ^^^^
-Warning: Skipping `returning_sut': functions returning a SUT value cannot be
+Warning: Skipping returning_sut: functions returning a SUT value cannot be
          tested.
 File "all_warnings.mli", line 19, characters 22-34:
 19 | val no_sut_argument : bool -> bool
                            ^^^^^^^^^^^^
-Warning: Skipping `no_sut_argument': functions with no SUT argument cannot be
+Warning: Skipping no_sut_argument: functions with no SUT argument cannot be
          tested.
 File "all_warnings.mli", line 22, characters 28-48:
 22 | val multiple_sut_argument : 'a t -> 'a t -> bool
                                  ^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `multiple_sut_argument': functions with multiple SUT
+Warning: Skipping multiple_sut_argument: functions with multiple SUT
          arguments cannot be tested.
 File "all_warnings.mli", line 25, characters 24-29:
 25 | val incompatible_type : int t -> bool
                              ^^^^^
-Warning: Skipping `incompatible_type': the type of its SUT-type argument is
-         incompatible with the configured SUT type: `char t'.
+Warning: Skipping incompatible_type: the type of its SUT-type argument is
+         incompatible with the configured SUT type: char t.
 File "all_warnings.mli", line 28, characters 0-26:
 28 | val no_spec : 'a t -> bool
      ^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `no_spec': functions without specifications cannot be
-         tested.
+Warning: Skipping no_spec: functions without specifications cannot be tested.
 File "all_warnings.mli", line 33, characters 13-15:
 33 |     modifies () *)
                   ^^
@@ -36,22 +35,22 @@ Warning: Skipping unsupported `modifies` clause: expected `modifies x` or
 File "all_warnings.mli", line 42, characters 27-37:
 42 | val functional_argument : ('a -> bool) -> 'a t -> bool
                                 ^^^^^^^^^^
-Warning: Skipping `functional_argument': functions are not supported yet as
+Warning: Skipping functional_argument: functions are not supported yet as
          arguments.
 File "all_warnings.mli", line 46, characters 24-25:
 46 | (*@ b = ghost_argument [x : bool] t *)
                              ^
-Warning: Skipping `ghost_argument': functions with a ghost argument are not
+Warning: Skipping ghost_argument: functions with a ghost argument are not
          supported.
 File "all_warnings.mli", line 49, characters 6-7:
 49 | (*@ [ x : bool ], b = ghost_returned_value t *)
            ^
-Warning: Skipping `ghost_returned_value': functions with a ghost returned
-         value are not supported.
+Warning: Skipping ghost_returned_value: functions with a ghost returned value
+         are not supported.
 File "all_warnings.mli", line 37, characters 13-23:
 37 |     modifies t.contents *)
                   ^^^^^^^^^^
-Warning: Skipping `ensures_not_found_for_next_state': model `contents' is
+Warning: Skipping ensures_not_found_for_next_state: model contents is
          declared as modified by the function but no translatable `ensures`
          clause was found.
 File "all_warnings.mli", line 53, characters 16-54:

--- a/plugins/qcheck-stm/test/all_warnings_errors.expected
+++ b/plugins/qcheck-stm/test/all_warnings_errors.expected
@@ -36,11 +36,13 @@ Warning: Skipping `functional_argument': functions are not supported yet as
 File "all_warnings.mli", line 46, characters 24-25:
 46 | (*@ b = ghost_argument [x : bool] t *)
                              ^
-Warning: Skipping function with a ghost argument `x'.
+Warning: Skipping `ghost_argument': functions with a ghost argument are not
+         supported.
 File "all_warnings.mli", line 49, characters 6-7:
 49 | (*@ [ x : bool ], b = ghost_returned_value t *)
            ^
-Warning: Skipping function with a ghost returned value `x_1'.
+Warning: Skipping `ghost_returned_value': functions with a ghost returned
+         value are not supported.
 File "all_warnings.mli", line 4, characters 18-26:
 4 | (*@ mutable model contents : 'a list *)
                       ^^^^^^^^

--- a/plugins/qcheck-stm/test/all_warnings_errors.expected
+++ b/plugins/qcheck-stm/test/all_warnings_errors.expected
@@ -26,8 +26,8 @@ Warning: Skipping `incompatible_type': the type of its SUT-type argument is
 File "all_warnings.mli", line 33, characters 13-15:
 33 |     modifies () *)
                   ^^
-Warning: Skipping unsupported `modifies` clause `(unit ):unit_1': expected
-         `modifies x` or `modifies x.model` where `x` is the SUT.
+Warning: Skipping unsupported `modifies` clause: expected `modifies x` or
+         `modifies x.model` where `x` is the SUT.
 File "all_warnings.mli", line 42, characters 27-37:
 42 | val functional_argument : ('a -> bool) -> 'a t -> bool
                                 ^^^^^^^^^^

--- a/plugins/qcheck-stm/test/all_warnings_errors.expected
+++ b/plugins/qcheck-stm/test/all_warnings_errors.expected
@@ -23,6 +23,11 @@ File "all_warnings.mli", line 25, characters 24-29:
                              ^^^^^
 Warning: Skipping `incompatible_type': the type of its SUT-type argument is
          incompatible with the configured SUT type: `char t'.
+File "all_warnings.mli", line 28, characters 0-26:
+28 | val no_spec : 'a t -> bool
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping `no_spec': functions without specifications cannot be
+         tested.
 File "all_warnings.mli", line 33, characters 13-15:
 33 |     modifies () *)
                   ^^

--- a/plugins/qcheck-stm/test/all_warnings_errors.expected
+++ b/plugins/qcheck-stm/test/all_warnings_errors.expected
@@ -58,3 +58,8 @@ File "all_warnings.mli", line 53, characters 16-54:
 53 |     ensures b = forall a. List.mem a t.contents -> p a *)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning: Skipping clause: unsupported quantification.
+File "all_warnings.mli", line 57, characters 26-29:
+57 |     requires Array.length t.v > 0 *)
+                               ^^^
+Warning: Skipping clause: occurrences of the SUT in clauses are only
+         supported to access its model fields.

--- a/plugins/qcheck-stm/test/all_warnings_errors.expected
+++ b/plugins/qcheck-stm/test/all_warnings_errors.expected
@@ -30,8 +30,8 @@ Warning: Skipping no_spec: functions without specifications cannot be tested.
 File "all_warnings.mli", line 33, characters 13-15:
 33 |     modifies () *)
                   ^^
-Warning: Skipping unsupported `modifies` clause: expected `modifies x` or
-         `modifies x.model` where `x` is the SUT.
+Warning: Skipping unsupported modifies clause: expected "modifies x" or
+         "modifies x.model" where x is the SUT.
 File "all_warnings.mli", line 42, characters 27-37:
 42 | val functional_argument : ('a -> bool) -> 'a t -> bool
                                 ^^^^^^^^^^
@@ -51,7 +51,7 @@ File "all_warnings.mli", line 37, characters 13-23:
 37 |     modifies t.contents *)
                   ^^^^^^^^^^
 Warning: Skipping ensures_not_found_for_next_state: model contents is
-         declared as modified by the function but no translatable `ensures`
+         declared as modified by the function but no translatable ensures
          clause was found.
 File "all_warnings.mli", line 53, characters 16-54:
 53 |     ensures b = forall a. List.mem a t.contents -> p a *)

--- a/plugins/qcheck-stm/test/all_warnings_errors.expected
+++ b/plugins/qcheck-stm/test/all_warnings_errors.expected
@@ -43,12 +43,12 @@ File "all_warnings.mli", line 49, characters 6-7:
            ^
 Warning: Skipping `ghost_returned_value': functions with a ghost returned
          value are not supported.
-File "all_warnings.mli", line 4, characters 18-26:
-4 | (*@ mutable model contents : 'a list *)
-                      ^^^^^^^^
-Warning: Skipping function because its impact on model `contents' is unknown:
-         model is declared as modified by the function but no translatable
-         `ensures` clause was found.
+File "all_warnings.mli", line 37, characters 13-23:
+37 |     modifies t.contents *)
+                  ^^^^^^^^^^
+Warning: Skipping `ensures_not_found_for_next_state': model `contents' is
+         declared as modified by the function but no translatable `ensures`
+         clause was found.
 File "all_warnings.mli", line 53, characters 16-54:
 53 |     ensures b = forall a. List.mem a t.contents -> p a *)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/plugins/qcheck-stm/test/all_warnings_errors.expected
+++ b/plugins/qcheck-stm/test/all_warnings_errors.expected
@@ -31,8 +31,8 @@ Warning: Skipping unsupported `modifies` clause: expected `modifies x` or
 File "all_warnings.mli", line 42, characters 27-37:
 42 | val functional_argument : ('a -> bool) -> 'a t -> bool
                                 ^^^^^^^^^^
-Warning: Skipping function with argument of type `'a -> bool': functions are
-         not supported yet as arguments.
+Warning: Skipping `functional_argument': functions are not supported yet as
+         arguments.
 File "all_warnings.mli", line 46, characters 24-25:
 46 | (*@ b = ghost_argument [x : bool] t *)
                              ^

--- a/plugins/qcheck-stm/test/all_warnings_errors.expected
+++ b/plugins/qcheck-stm/test/all_warnings_errors.expected
@@ -22,7 +22,7 @@ File "all_warnings.mli", line 25, characters 24-29:
 25 | val incompatible_type : int t -> bool
                              ^^^^^
 Warning: Skipping `incompatible_type': the type of its SUT-type argument is
-         incompatible with command-line argument.
+         incompatible with the configured SUT type: `char t'.
 File "all_warnings.mli", line 33, characters 13-15:
 33 |     modifies () *)
                   ^^

--- a/plugins/qcheck-stm/test/hashtbl_errors.expected
+++ b/plugins/qcheck-stm/test/hashtbl_errors.expected
@@ -23,7 +23,7 @@ Warning: Skipping `randomize': functions with no SUT argument cannot be
 File "hashtbl.mli", line 78, characters 0-28:
 78 | val randomize : unit -> unit
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `randomize': functions without specification cannot be
+Warning: Skipping `randomize': functions without specifications cannot be
          tested.
 File "hashtbl.mli", line 79, characters 20-32:
 79 | val is_randomized : unit -> bool
@@ -33,7 +33,7 @@ Warning: Skipping `is_randomized': functions with no SUT argument cannot be
 File "hashtbl.mli", line 79, characters 0-32:
 79 | val is_randomized : unit -> bool
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `is_randomized': functions without specification cannot be
+Warning: Skipping `is_randomized': functions without specifications cannot be
          tested.
 File "hashtbl.mli", line 82, characters 68-78:
 82 |   ?random:(* thwart tools/sync_stdlib_docs *) bool -> ('a, 'b) t -> ('a, 'b) t
@@ -43,35 +43,36 @@ Warning: Skipping `rebuild': functions returning a SUT value cannot be
 File "hashtbl.mli", line 81, characters 0-92:
 81 | val rebuild :
 82 |   ?random:(* thwart tools/sync_stdlib_docs *) bool -> ('a, 'b) t -> ('a, 'b) t
-Warning: Skipping `rebuild': functions without specification cannot be
+Warning: Skipping `rebuild': functions without specifications cannot be
          tested.
 File "hashtbl.mli", line 96, characters 0-36:
 96 | val stats : ('a, 'b) t -> statistics
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `stats': functions without specification cannot be tested.
+Warning: Skipping `stats': functions without specifications cannot be tested.
 File "hashtbl.mli", line 97, characters 0-42:
 97 | val to_seq : ('a, 'b) t -> ('a * 'b) Seq.t
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `to_seq': functions without specification cannot be tested.
+Warning: Skipping `to_seq': functions without specifications cannot be
+         tested.
 File "hashtbl.mli", line 98, characters 0-39:
 98 | val to_seq_keys : ('a, _) t -> 'a Seq.t
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `to_seq_keys': functions without specification cannot be
+Warning: Skipping `to_seq_keys': functions without specifications cannot be
          tested.
 File "hashtbl.mli", line 99, characters 0-41:
 99 | val to_seq_values : (_, 'b) t -> 'b Seq.t
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `to_seq_values': functions without specification cannot be
+Warning: Skipping `to_seq_values': functions without specifications cannot be
          tested.
 File "hashtbl.mli", line 100, characters 0-51:
 100 | val add_seq : ('a, 'b) t -> ('a * 'b) Seq.t -> unit
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `add_seq': functions without specification cannot be
+Warning: Skipping `add_seq': functions without specifications cannot be
          tested.
 File "hashtbl.mli", line 101, characters 0-55:
 101 | val replace_seq : ('a, 'b) t -> ('a * 'b) Seq.t -> unit
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `replace_seq': functions without specification cannot be
+Warning: Skipping `replace_seq': functions without specifications cannot be
          tested.
 File "hashtbl.mli", line 102, characters 32-42:
 102 | val of_seq : ('a * 'b) Seq.t -> ('a, 'b) t
@@ -80,7 +81,8 @@ Warning: Skipping `of_seq': functions returning a SUT value cannot be tested.
 File "hashtbl.mli", line 102, characters 0-42:
 102 | val of_seq : ('a * 'b) Seq.t -> ('a, 'b) t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `of_seq': functions without specification cannot be tested.
+Warning: Skipping `of_seq': functions without specifications cannot be
+         tested.
 File "hashtbl.mli", line 103, characters 11-20:
 103 | val hash : 'a -> int
                  ^^^^^^^^^
@@ -88,7 +90,7 @@ Warning: Skipping `hash': functions with no SUT argument cannot be tested.
 File "hashtbl.mli", line 103, characters 0-20:
 103 | val hash : 'a -> int
       ^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `hash': functions without specification cannot be tested.
+Warning: Skipping `hash': functions without specifications cannot be tested.
 File "hashtbl.mli", line 104, characters 18-34:
 104 | val seeded_hash : int -> 'a -> int
                         ^^^^^^^^^^^^^^^^
@@ -97,7 +99,7 @@ Warning: Skipping `seeded_hash': functions with no SUT argument cannot be
 File "hashtbl.mli", line 104, characters 0-34:
 104 | val seeded_hash : int -> 'a -> int
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `seeded_hash': functions without specification cannot be
+Warning: Skipping `seeded_hash': functions without specifications cannot be
          tested.
 File "hashtbl.mli", line 105, characters 17-40:
 105 | val hash_param : int -> int -> 'a -> int
@@ -107,7 +109,7 @@ Warning: Skipping `hash_param': functions with no SUT argument cannot be
 File "hashtbl.mli", line 105, characters 0-40:
 105 | val hash_param : int -> int -> 'a -> int
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `hash_param': functions without specification cannot be
+Warning: Skipping `hash_param': functions without specifications cannot be
          tested.
 File "hashtbl.mli", line 106, characters 24-54:
 106 | val seeded_hash_param : int -> int -> int -> 'a -> int
@@ -117,8 +119,8 @@ Warning: Skipping `seeded_hash_param': functions with no SUT argument cannot
 File "hashtbl.mli", line 106, characters 0-54:
 106 | val seeded_hash_param : int -> int -> int -> 'a -> int
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `seeded_hash_param': functions without specification cannot
-         be tested.
+Warning: Skipping `seeded_hash_param': functions without specifications
+         cannot be tested.
 File "hashtbl.mli", line 30, characters 24-66:
 30 |     raises Not_found -> forall x. not (List.mem (a, x) h.contents)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/plugins/qcheck-stm/test/hashtbl_errors.expected
+++ b/plugins/qcheck-stm/test/hashtbl_errors.expected
@@ -5,18 +5,16 @@ Warning: Skipping `copy': functions returning a SUT value cannot be tested.
 File "hashtbl.mli", line 63, characters 12-28:
 63 | val iter : ('a -> 'b -> unit) -> ('a, 'b) t -> unit
                  ^^^^^^^^^^^^^^^^
-Warning: Skipping function with argument of type `'a -> 'b -> unit':
-         functions are not supported yet as arguments.
+Warning: Skipping `iter': functions are not supported yet as arguments.
 File "hashtbl.mli", line 64, characters 26-47:
 64 | val filter_map_inplace : ('a -> 'b -> 'b option) -> ('a, 'b) t -> unit
                                ^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping function with argument of type `'a -> 'b -> 'b option':
-         functions are not supported yet as arguments.
+Warning: Skipping `filter_map_inplace': functions are not supported yet as
+         arguments.
 File "hashtbl.mli", line 73, characters 12-32:
 73 | val fold : ('a -> 'b -> 'c -> 'c) -> ('a, 'b) t -> 'c -> 'c
                  ^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping function with argument of type `'a -> 'b -> 'c -> 'c':
-         functions are not supported yet as arguments.
+Warning: Skipping `fold': functions are not supported yet as arguments.
 File "hashtbl.mli", line 78, characters 16-28:
 78 | val randomize : unit -> unit
                      ^^^^^^^^^^^^

--- a/plugins/qcheck-stm/test/hashtbl_errors.expected
+++ b/plugins/qcheck-stm/test/hashtbl_errors.expected
@@ -1,81 +1,127 @@
 File "hashtbl.mli", line 19, characters 25-35:
-Warning: `copy' returns a sut.
-
+19 | val copy : ('a, 'b) t -> ('a, 'b) t
+                              ^^^^^^^^^^
+Warning: Skipping `copy': functions returning a SUT value cannot be tested.
 File "hashtbl.mli", line 63, characters 12-28:
-Warning: Functional argument (`'a -> 'b -> unit') are not tested.
-
+63 | val iter : ('a -> 'b -> unit) -> ('a, 'b) t -> unit
+                 ^^^^^^^^^^^^^^^^
+Warning: Skipping function with argument of type `'a -> 'b -> unit':
+         functions are not supported yet as arguments.
 File "hashtbl.mli", line 64, characters 26-47:
-Warning: Functional argument (`'a -> 'b -> 'b option') are not tested.
-
+64 | val filter_map_inplace : ('a -> 'b -> 'b option) -> ('a, 'b) t -> unit
+                               ^^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping function with argument of type `'a -> 'b -> 'b option':
+         functions are not supported yet as arguments.
 File "hashtbl.mli", line 73, characters 12-32:
-Warning: Functional argument (`'a -> 'b -> 'c -> 'c') are not tested.
-
+73 | val fold : ('a -> 'b -> 'c -> 'c) -> ('a, 'b) t -> 'c -> 'c
+                 ^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping function with argument of type `'a -> 'b -> 'c -> 'c':
+         functions are not supported yet as arguments.
 File "hashtbl.mli", line 78, characters 16-28:
-Warning: `randomize' have no sut argument.
-
+78 | val randomize : unit -> unit
+                     ^^^^^^^^^^^^
+Warning: Skipping `randomize': functions with no SUT argument cannot be
+         tested.
 File "hashtbl.mli", line 78, characters 0-28:
-Warning: The function `randomize' is not specified.
-
+78 | val randomize : unit -> unit
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping `randomize': functions without specification cannot be
+         tested.
 File "hashtbl.mli", line 79, characters 20-32:
-Warning: `is_randomized' have no sut argument.
-
+79 | val is_randomized : unit -> bool
+                         ^^^^^^^^^^^^
+Warning: Skipping `is_randomized': functions with no SUT argument cannot be
+         tested.
 File "hashtbl.mli", line 79, characters 0-32:
-Warning: The function `is_randomized' is not specified.
-
+79 | val is_randomized : unit -> bool
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping `is_randomized': functions without specification cannot be
+         tested.
 File "hashtbl.mli", line 82, characters 68-78:
-Warning: `rebuild' returns a sut.
-
+82 |   ?random:(* thwart tools/sync_stdlib_docs *) bool -> ('a, 'b) t -> ('a, 'b) t
+                                                                         ^^^^^^^^^^
+Warning: Skipping `rebuild': functions returning a SUT value cannot be
+         tested.
 File "hashtbl.mli", line 81, characters 0-92:
-Warning: The function `rebuild' is not specified.
-
+81 | val rebuild :
+82 |   ?random:(* thwart tools/sync_stdlib_docs *) bool -> ('a, 'b) t -> ('a, 'b) t
+Warning: Skipping `rebuild': functions without specification cannot be
+         tested.
 File "hashtbl.mli", line 96, characters 0-36:
-Warning: The function `stats' is not specified.
-
+96 | val stats : ('a, 'b) t -> statistics
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping `stats': functions without specification cannot be tested.
 File "hashtbl.mli", line 97, characters 0-42:
-Warning: The function `to_seq' is not specified.
-
+97 | val to_seq : ('a, 'b) t -> ('a * 'b) Seq.t
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping `to_seq': functions without specification cannot be tested.
 File "hashtbl.mli", line 98, characters 0-39:
-Warning: The function `to_seq_keys' is not specified.
-
+98 | val to_seq_keys : ('a, _) t -> 'a Seq.t
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping `to_seq_keys': functions without specification cannot be
+         tested.
 File "hashtbl.mli", line 99, characters 0-41:
-Warning: The function `to_seq_values' is not specified.
-
+99 | val to_seq_values : (_, 'b) t -> 'b Seq.t
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping `to_seq_values': functions without specification cannot be
+         tested.
 File "hashtbl.mli", line 100, characters 0-51:
-Warning: The function `add_seq' is not specified.
-
+100 | val add_seq : ('a, 'b) t -> ('a * 'b) Seq.t -> unit
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping `add_seq': functions without specification cannot be
+         tested.
 File "hashtbl.mli", line 101, characters 0-55:
-Warning: The function `replace_seq' is not specified.
-
+101 | val replace_seq : ('a, 'b) t -> ('a * 'b) Seq.t -> unit
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping `replace_seq': functions without specification cannot be
+         tested.
 File "hashtbl.mli", line 102, characters 32-42:
-Warning: `of_seq' returns a sut.
-
+102 | val of_seq : ('a * 'b) Seq.t -> ('a, 'b) t
+                                      ^^^^^^^^^^
+Warning: Skipping `of_seq': functions returning a SUT value cannot be tested.
 File "hashtbl.mli", line 102, characters 0-42:
-Warning: The function `of_seq' is not specified.
-
+102 | val of_seq : ('a * 'b) Seq.t -> ('a, 'b) t
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping `of_seq': functions without specification cannot be tested.
 File "hashtbl.mli", line 103, characters 11-20:
-Warning: `hash' have no sut argument.
-
+103 | val hash : 'a -> int
+                 ^^^^^^^^^
+Warning: Skipping `hash': functions with no SUT argument cannot be tested.
 File "hashtbl.mli", line 103, characters 0-20:
-Warning: The function `hash' is not specified.
-
+103 | val hash : 'a -> int
+      ^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping `hash': functions without specification cannot be tested.
 File "hashtbl.mli", line 104, characters 18-34:
-Warning: `seeded_hash' have no sut argument.
-
+104 | val seeded_hash : int -> 'a -> int
+                        ^^^^^^^^^^^^^^^^
+Warning: Skipping `seeded_hash': functions with no SUT argument cannot be
+         tested.
 File "hashtbl.mli", line 104, characters 0-34:
-Warning: The function `seeded_hash' is not specified.
-
+104 | val seeded_hash : int -> 'a -> int
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping `seeded_hash': functions without specification cannot be
+         tested.
 File "hashtbl.mli", line 105, characters 17-40:
-Warning: `hash_param' have no sut argument.
-
+105 | val hash_param : int -> int -> 'a -> int
+                       ^^^^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping `hash_param': functions with no SUT argument cannot be
+         tested.
 File "hashtbl.mli", line 105, characters 0-40:
-Warning: The function `hash_param' is not specified.
-
+105 | val hash_param : int -> int -> 'a -> int
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping `hash_param': functions without specification cannot be
+         tested.
 File "hashtbl.mli", line 106, characters 24-54:
-Warning: `seeded_hash_param' have no sut argument.
-
+106 | val seeded_hash_param : int -> int -> int -> 'a -> int
+                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping `seeded_hash_param': functions with no SUT argument cannot
+         be tested.
 File "hashtbl.mli", line 106, characters 0-54:
-Warning: The function `seeded_hash_param' is not specified.
-
+106 | val seeded_hash_param : int -> int -> int -> 'a -> int
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping `seeded_hash_param': functions without specification cannot
+         be tested.
 File "hashtbl.mli", line 30, characters 24-66:
-Warning: unsupported quantification. The clause has not been translated
-
+30 |     raises Not_found -> forall x. not (List.mem (a, x) h.contents)
+                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Warning: Skipping clause: unsupported quantification.

--- a/plugins/qcheck-stm/test/hashtbl_errors.expected
+++ b/plugins/qcheck-stm/test/hashtbl_errors.expected
@@ -1,126 +1,120 @@
 File "hashtbl.mli", line 19, characters 25-35:
 19 | val copy : ('a, 'b) t -> ('a, 'b) t
                               ^^^^^^^^^^
-Warning: Skipping `copy': functions returning a SUT value cannot be tested.
+Warning: Skipping copy: functions returning a SUT value cannot be tested.
 File "hashtbl.mli", line 63, characters 12-28:
 63 | val iter : ('a -> 'b -> unit) -> ('a, 'b) t -> unit
                  ^^^^^^^^^^^^^^^^
-Warning: Skipping `iter': functions are not supported yet as arguments.
+Warning: Skipping iter: functions are not supported yet as arguments.
 File "hashtbl.mli", line 64, characters 26-47:
 64 | val filter_map_inplace : ('a -> 'b -> 'b option) -> ('a, 'b) t -> unit
                                ^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `filter_map_inplace': functions are not supported yet as
+Warning: Skipping filter_map_inplace: functions are not supported yet as
          arguments.
 File "hashtbl.mli", line 73, characters 12-32:
 73 | val fold : ('a -> 'b -> 'c -> 'c) -> ('a, 'b) t -> 'c -> 'c
                  ^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `fold': functions are not supported yet as arguments.
+Warning: Skipping fold: functions are not supported yet as arguments.
 File "hashtbl.mli", line 78, characters 16-28:
 78 | val randomize : unit -> unit
                      ^^^^^^^^^^^^
-Warning: Skipping `randomize': functions with no SUT argument cannot be
-         tested.
+Warning: Skipping randomize: functions with no SUT argument cannot be tested.
 File "hashtbl.mli", line 78, characters 0-28:
 78 | val randomize : unit -> unit
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `randomize': functions without specifications cannot be
+Warning: Skipping randomize: functions without specifications cannot be
          tested.
 File "hashtbl.mli", line 79, characters 20-32:
 79 | val is_randomized : unit -> bool
                          ^^^^^^^^^^^^
-Warning: Skipping `is_randomized': functions with no SUT argument cannot be
+Warning: Skipping is_randomized: functions with no SUT argument cannot be
          tested.
 File "hashtbl.mli", line 79, characters 0-32:
 79 | val is_randomized : unit -> bool
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `is_randomized': functions without specifications cannot be
+Warning: Skipping is_randomized: functions without specifications cannot be
          tested.
 File "hashtbl.mli", line 82, characters 68-78:
 82 |   ?random:(* thwart tools/sync_stdlib_docs *) bool -> ('a, 'b) t -> ('a, 'b) t
                                                                          ^^^^^^^^^^
-Warning: Skipping `rebuild': functions returning a SUT value cannot be
-         tested.
+Warning: Skipping rebuild: functions returning a SUT value cannot be tested.
 File "hashtbl.mli", line 81, characters 0-92:
 81 | val rebuild :
 82 |   ?random:(* thwart tools/sync_stdlib_docs *) bool -> ('a, 'b) t -> ('a, 'b) t
-Warning: Skipping `rebuild': functions without specifications cannot be
-         tested.
+Warning: Skipping rebuild: functions without specifications cannot be tested.
 File "hashtbl.mli", line 96, characters 0-36:
 96 | val stats : ('a, 'b) t -> statistics
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `stats': functions without specifications cannot be tested.
+Warning: Skipping stats: functions without specifications cannot be tested.
 File "hashtbl.mli", line 97, characters 0-42:
 97 | val to_seq : ('a, 'b) t -> ('a * 'b) Seq.t
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `to_seq': functions without specifications cannot be
-         tested.
+Warning: Skipping to_seq: functions without specifications cannot be tested.
 File "hashtbl.mli", line 98, characters 0-39:
 98 | val to_seq_keys : ('a, _) t -> 'a Seq.t
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `to_seq_keys': functions without specifications cannot be
+Warning: Skipping to_seq_keys: functions without specifications cannot be
          tested.
 File "hashtbl.mli", line 99, characters 0-41:
 99 | val to_seq_values : (_, 'b) t -> 'b Seq.t
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `to_seq_values': functions without specifications cannot be
+Warning: Skipping to_seq_values: functions without specifications cannot be
          tested.
 File "hashtbl.mli", line 100, characters 0-51:
 100 | val add_seq : ('a, 'b) t -> ('a * 'b) Seq.t -> unit
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `add_seq': functions without specifications cannot be
-         tested.
+Warning: Skipping add_seq: functions without specifications cannot be tested.
 File "hashtbl.mli", line 101, characters 0-55:
 101 | val replace_seq : ('a, 'b) t -> ('a * 'b) Seq.t -> unit
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `replace_seq': functions without specifications cannot be
+Warning: Skipping replace_seq: functions without specifications cannot be
          tested.
 File "hashtbl.mli", line 102, characters 32-42:
 102 | val of_seq : ('a * 'b) Seq.t -> ('a, 'b) t
                                       ^^^^^^^^^^
-Warning: Skipping `of_seq': functions returning a SUT value cannot be tested.
+Warning: Skipping of_seq: functions returning a SUT value cannot be tested.
 File "hashtbl.mli", line 102, characters 0-42:
 102 | val of_seq : ('a * 'b) Seq.t -> ('a, 'b) t
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `of_seq': functions without specifications cannot be
-         tested.
+Warning: Skipping of_seq: functions without specifications cannot be tested.
 File "hashtbl.mli", line 103, characters 11-20:
 103 | val hash : 'a -> int
                  ^^^^^^^^^
-Warning: Skipping `hash': functions with no SUT argument cannot be tested.
+Warning: Skipping hash: functions with no SUT argument cannot be tested.
 File "hashtbl.mli", line 103, characters 0-20:
 103 | val hash : 'a -> int
       ^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `hash': functions without specifications cannot be tested.
+Warning: Skipping hash: functions without specifications cannot be tested.
 File "hashtbl.mli", line 104, characters 18-34:
 104 | val seeded_hash : int -> 'a -> int
                         ^^^^^^^^^^^^^^^^
-Warning: Skipping `seeded_hash': functions with no SUT argument cannot be
+Warning: Skipping seeded_hash: functions with no SUT argument cannot be
          tested.
 File "hashtbl.mli", line 104, characters 0-34:
 104 | val seeded_hash : int -> 'a -> int
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `seeded_hash': functions without specifications cannot be
+Warning: Skipping seeded_hash: functions without specifications cannot be
          tested.
 File "hashtbl.mli", line 105, characters 17-40:
 105 | val hash_param : int -> int -> 'a -> int
                        ^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `hash_param': functions with no SUT argument cannot be
+Warning: Skipping hash_param: functions with no SUT argument cannot be
          tested.
 File "hashtbl.mli", line 105, characters 0-40:
 105 | val hash_param : int -> int -> 'a -> int
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `hash_param': functions without specifications cannot be
+Warning: Skipping hash_param: functions without specifications cannot be
          tested.
 File "hashtbl.mli", line 106, characters 24-54:
 106 | val seeded_hash_param : int -> int -> int -> 'a -> int
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `seeded_hash_param': functions with no SUT argument cannot
-         be tested.
+Warning: Skipping seeded_hash_param: functions with no SUT argument cannot be
+         tested.
 File "hashtbl.mli", line 106, characters 0-54:
 106 | val seeded_hash_param : int -> int -> int -> 'a -> int
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Warning: Skipping `seeded_hash_param': functions without specifications
-         cannot be tested.
+Warning: Skipping seeded_hash_param: functions without specifications cannot
+         be tested.
 File "hashtbl.mli", line 30, characters 24-66:
 30 |     raises Not_found -> forall x. not (List.mem (a, x) h.contents)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/plugins/qcheck-stm/test/record_errors.expected
+++ b/plugins/qcheck-stm/test/record_errors.expected
@@ -1,3 +1,5 @@
 File "record.mli", line 13, characters 16-17:
-Warning: The term `r:t' can not be substituted (supported only when applied to one of its model fields).
-
+13 |     ensures i = r.c *)
+                     ^
+Warning: Skipping clause with term `r:t': substitution supported only when
+         applied to one of the model fields.

--- a/plugins/qcheck-stm/test/record_errors.expected
+++ b/plugins/qcheck-stm/test/record_errors.expected
@@ -1,5 +1,5 @@
-File "record.mli", line 13, characters 16-17:
+File "record.mli", line 13, characters 16-19:
 13 |     ensures i = r.c *)
-                     ^
-Warning: Skipping clause with term `r:t': substitution supported only when
-         applied to one of the model fields.
+                     ^^^
+Warning: Skipping clause: occurrences of the SUT in clauses are only
+         supported to access its model fields.

--- a/plugins/qcheck-stm/test/ref_errors.expected
+++ b/plugins/qcheck-stm/test/ref_errors.expected
@@ -1,3 +1,5 @@
 File "ref.mli", line 12, characters 26-27:
-Warning: The term `r:int ref' can not be substituted (supported only when applied to one of its model fields).
-
+12 |     ensures i + 1 = succ !r *)
+                               ^
+Warning: Skipping clause with term `r:int ref': substitution supported only
+         when applied to one of the model fields.

--- a/plugins/qcheck-stm/test/ref_errors.expected
+++ b/plugins/qcheck-stm/test/ref_errors.expected
@@ -1,5 +1,5 @@
 File "ref.mli", line 12, characters 26-27:
 12 |     ensures i + 1 = succ !r *)
                                ^
-Warning: Skipping clause with term `r:int ref': substitution supported only
-         when applied to one of the model fields.
+Warning: Skipping clause: occurrences of the SUT in clauses are only
+         supported to access its model fields.

--- a/plugins/qcheck-stm/test/test_errors.t
+++ b/plugins/qcheck-stm/test/test_errors.t
@@ -10,34 +10,32 @@ in the type declaration for the sytem under test:
   > val make : 'a -> 'a t
   > EOF
   $ ortac qcheck-stm foo.mli "" "int t"
-  Error: `' is not a well formed OCaml expression.
-  
+  Error: Syntax error in OCaml expression `'.
   $ ortac qcheck-stm foo.mli "make 42" ""
-  Error: `' is not a well formed type expression.
-  
+  Error: Syntax error in type `'.
 We can give a type that does not exist in the module as the system under test:
   $ cat > foo.mli << EOF
   > type 'a t
   > EOF
   $ ortac qcheck-stm foo.mli "()" "ty"
-  Error: Type `ty' is not declared in the module.
-  
+  Error: Type `ty' not declared in the module.
 We can forget to instatiate the type parameter of the system under test:
   $ cat > foo.mli << EOF
   > type 'a t
   > val make : 'a -> 'a t
   > EOF
   $ ortac qcheck-stm foo.mli "make 42" "'a t"
-  Error: Type parameter `'a' should be instantiated.
-  
+  Error: Unsupported type parameter `'a': SUT type should be fully
+         instantiated.
 We can forget to specify the type of the system under test:
   $ cat > foo.mli << EOF
   > type 'a t
   > EOF
   $ ortac qcheck-stm foo.mli "make 42" "int t"
   File "foo.mli", line 1, characters 0-9:
-  Error: The type `t' given for the system under test is not specified.
-  
+  1 | type 'a t
+      ^^^^^^^^^
+  Error: Missing specification for the SUT type `t'.
 Or specify it without any model:
   $ cat > foo.mli << EOF
   > type 'a t
@@ -45,16 +43,16 @@ Or specify it without any model:
   > EOF
   $ ortac qcheck-stm foo.mli "make 42" "int t"
   File "foo.mli", line 2, characters 3-14:
-  Error: The type `t' given for the system under test has no models.
-  
+  2 | (*@ ephemeral *)
+         ^^^^^^^^^^^
+  Error: Missing model(s) for the SUT type `t'.
 We can give a non-existing function for `init_state`:
   $ cat > foo.mli << EOF
   > type 'a t
   > (*@ mutable model value : 'a *)
   > EOF
   $ ortac qcheck-stm foo.mli "make 42" "int t"
-  Error: Function `make' is not declared in the module.
-  
+  Error: Function `make' not declared in the module.
 We can forget to specify the function used for the `init_state` function:
   $ cat > foo.mli << EOF
   > type 'a t
@@ -63,8 +61,10 @@ We can forget to specify the function used for the `init_state` function:
   > EOF
   $ ortac qcheck-stm foo.mli "make 42" "int t"
   File "foo.mli", line 3, characters 0-21:
-  Error: The function `make' used for `init_state` is not approriately specified.
-  
+  3 | val make : 'a -> 'a t
+      ^^^^^^^^^^^^^^^^^^^^^
+  Error: Unsupported INIT expression `make': the function called in the INIT
+         expression must be specified to initialize the model state.
 Or specify it in a manner that does not allow to deduce the value of `state`:
   $ cat > foo.mli << EOF
   > type 'a t
@@ -75,9 +75,12 @@ Or specify it in a manner that does not allow to deduce the value of `state`:
   > EOF
   $ ortac qcheck-stm foo.mli "make 42" "int t"
   File "foo.mli", line 4, characters 3-33:
-  Error: The function ` t = make a
-      requires true ' used for `init_state` is not approriately specified.
-  
+  4 | ... t = make a
+  5 |     requires true ..
+  Error: Unsupported INIT expression ` t = make a
+      requires true ': the
+         function called in the INIT expression must be specified to initialize
+         the model state.
 Or we van give a function that does not return the type of the system under test:
   $ cat > foo.mli << EOF
   > type 'a t
@@ -87,27 +90,31 @@ Or we van give a function that does not return the type of the system under test
   >     modifies () *)
   > EOF
   $ ortac qcheck-stm foo.mli "make 42" "int t"
-  File "foo.mli", line 3, characters 0-109:
-  Error: The function `make' used for `init_state` does not return `sut`.
-  
+  File "foo.mli", line 3, characters 0-52:
+  3 | val make : int -> unit
+  4 | (*@ make i
+  5 |     modifies () *)
+  Error: Unsupported INIT expression `make': the function called in the INIT
+         expression must return a value of SUT type.
 We are expected to give a function call as expression for the `init_state` function:
   $ cat > foo.mli << EOF
   > type 'a t
   > (*@ mutable model value : 'a *)
   > EOF
   $ ortac qcheck-stm foo.mli "42" "int t"
-  Error: The expression `42
-  ' given for `init_state` is not a function call.
-  
+  Error: Unsupported INIT expression `42
+  ': the INIT expression is expected to
+         be a function call (the specification of that function is required to
+         initialize the model state).
 It also does not support qualified names:
   $ cat > foo.mli << EOF
   > type 'a t
   > (*@ mutable model value : 'a *)
   > EOF
   $ ortac qcheck-stm foo.mli "Bar.make 42" "int t"
-  Error: Qualified name (`Bar.make
-  ') is not supported yet for generating `init_state`.
-  
+  Error: Unsupported INIT expression `Bar.make
+  ': qualified names are not yet
+         supported.
 It checks the number of argument in the function call:
   $ cat > foo.mli << EOF
   > type 'a t
@@ -117,6 +124,6 @@ It checks the number of argument in the function call:
   >     ensures t.value = a *)
   > EOF
   $ ortac qcheck-stm foo.mli "make 42 73" "int t"
-  Error: Mismatch number of arguments between `make 42 73
-  ' and the function specification.
-  
+  Error: Error in INIT expression `make 42 73
+  ': mismatch in the number of
+         arguments between the INIT expression and the function specification.

--- a/plugins/qcheck-stm/test/test_errors.t
+++ b/plugins/qcheck-stm/test/test_errors.t
@@ -5,6 +5,7 @@ command-line fail, so we load only the `qcheck-stm` plugin:
 
 We can make a syntax error in either the expression for the `init` function, or
 in the type declaration for the sytem under test:
+
   $ cat > foo.mli << EOF
   > type 'a t
   > val make : 'a -> 'a t
@@ -13,13 +14,17 @@ in the type declaration for the sytem under test:
   Error: Syntax error in OCaml expression `'.
   $ ortac qcheck-stm foo.mli "make 42" ""
   Error: Syntax error in type `'.
+
 We can give a type that does not exist in the module as the system under test:
+
   $ cat > foo.mli << EOF
   > type 'a t
   > EOF
   $ ortac qcheck-stm foo.mli "()" "ty"
   Error: Type `ty' not declared in the module.
-We can forget to instatiate the type parameter of the system under test:
+
+We can forget to instantiate the type parameter of the system under test:
+
   $ cat > foo.mli << EOF
   > type 'a t
   > val make : 'a -> 'a t
@@ -27,7 +32,9 @@ We can forget to instatiate the type parameter of the system under test:
   $ ortac qcheck-stm foo.mli "make 42" "'a t"
   Error: Unsupported type parameter `'a': SUT type should be fully
          instantiated.
+
 We can forget to specify the type of the system under test:
+
   $ cat > foo.mli << EOF
   > type 'a t
   > EOF
@@ -36,7 +43,9 @@ We can forget to specify the type of the system under test:
   1 | type 'a t
       ^^^^^^^^^
   Error: Missing specification for the SUT type `t'.
+
 Or specify it without any model:
+
   $ cat > foo.mli << EOF
   > type 'a t
   > (*@ ephemeral *)
@@ -46,14 +55,18 @@ Or specify it without any model:
   2 | (*@ ephemeral *)
          ^^^^^^^^^^^
   Error: Missing model(s) for the SUT type `t'.
+
 We can give a non-existing function for `init_state`:
+
   $ cat > foo.mli << EOF
   > type 'a t
   > (*@ mutable model value : 'a *)
   > EOF
   $ ortac qcheck-stm foo.mli "make 42" "int t"
   Error: Function `make' not declared in the module.
+
 We can forget to specify the function used for the `init_state` function:
+
   $ cat > foo.mli << EOF
   > type 'a t
   > (*@ mutable model value : 'a list *)
@@ -65,7 +78,9 @@ We can forget to specify the function used for the `init_state` function:
       ^^^^^^^^^^^^^^^^^^^^^
   Error: Unsupported INIT expression `make': the function called in the INIT
          expression must be specified to initialize the model state.
+
 Or specify it in a manner that does not allow to deduce the value of `state`:
+
   $ cat > foo.mli << EOF
   > type 'a t
   > (*@ mutable model value : 'a list *)
@@ -81,7 +96,9 @@ Or specify it in a manner that does not allow to deduce the value of `state`:
       requires true ': the
          function called in the INIT expression must be specified to initialize
          the model state.
-Or we van give a function that does not return the type of the system under test:
+
+Or we can give a function that does not return the type of the system under test:
+
   $ cat > foo.mli << EOF
   > type 'a t
   > (*@ mutable model value : 'a *)
@@ -96,7 +113,9 @@ Or we van give a function that does not return the type of the system under test
   5 |     modifies () *)
   Error: Unsupported INIT expression `make': the function called in the INIT
          expression must return a value of SUT type.
+
 We are expected to give a function call as expression for the `init_state` function:
+
   $ cat > foo.mli << EOF
   > type 'a t
   > (*@ mutable model value : 'a *)
@@ -106,7 +125,9 @@ We are expected to give a function call as expression for the `init_state` funct
   ': the INIT expression is expected to
          be a function call (the specification of that function is required to
          initialize the model state).
+
 It also does not support qualified names:
+
   $ cat > foo.mli << EOF
   > type 'a t
   > (*@ mutable model value : 'a *)
@@ -115,7 +136,9 @@ It also does not support qualified names:
   Error: Unsupported INIT expression `Bar.make
   ': qualified names are not yet
          supported.
-It checks the number of argument in the function call:
+
+It checks the number of arguments in the function call:
+
   $ cat > foo.mli << EOF
   > type 'a t
   > (*@ mutable model value : 'a *)

--- a/plugins/qcheck-stm/test/test_errors.t
+++ b/plugins/qcheck-stm/test/test_errors.t
@@ -11,20 +11,20 @@ in the type declaration for the sytem under test:
   > val make : 'a -> 'a t
   > EOF
   $ ortac qcheck-stm foo.mli "" "int t"
-  Error: Syntax error in OCaml expression `'.
+  Error: Syntax error in OCaml expression .
   $ ortac qcheck-stm foo.mli "make 42" ""
-  Error: Syntax error in type `'.
+  Error: Syntax error in type .
 
 We can give a pair as SUT type:
 
   $ ortac qcheck-stm foo.mli "make 42" "int * bool"
-  Error: Unsupported SUT type `(int * bool)': SUT type must be a type
+  Error: Unsupported SUT type (int * bool): SUT type must be a type
          constructor, possibly applied to type arguments.
 
 We can give a functional argument to the SUT type:
 
   $ ortac qcheck-stm foo.mli "make 42" "(int -> bool) t"
-  Error: Unsupported type parameter `int -> bool': only constructors and tuples
+  Error: Unsupported type parameter int -> bool: only constructors and tuples
          are supported in arguments for the SUT type.
 
 We can give a type that does not exist in the module as the system under test:
@@ -33,7 +33,7 @@ We can give a type that does not exist in the module as the system under test:
   > type 'a t
   > EOF
   $ ortac qcheck-stm foo.mli "()" "ty"
-  Error: Type `ty' not declared in the module.
+  Error: Type ty not declared in the module.
 
 We can forget to instantiate the type parameter of the system under test:
 
@@ -42,8 +42,7 @@ We can forget to instantiate the type parameter of the system under test:
   > val make : 'a -> 'a t
   > EOF
   $ ortac qcheck-stm foo.mli "make 42" "'a t"
-  Error: Unsupported type parameter `'a': SUT type should be fully
-         instantiated.
+  Error: Unsupported type parameter 'a: SUT type should be fully instantiated.
 
 We can forget to specify the type of the system under test:
 
@@ -54,7 +53,7 @@ We can forget to specify the type of the system under test:
   File "foo.mli", line 1, characters 0-9:
   1 | type 'a t
       ^^^^^^^^^
-  Error: Missing specification for the SUT type `t'.
+  Error: Missing specification for the SUT type t.
 
 Or specify it without any model:
 
@@ -66,7 +65,7 @@ Or specify it without any model:
   File "foo.mli", line 2, characters 3-14:
   2 | (*@ ephemeral *)
          ^^^^^^^^^^^
-  Error: Missing model(s) for the SUT type `t'.
+  Error: Missing model(s) for the SUT type t.
 
 We can give a non-existing function for `init_state`:
 
@@ -75,7 +74,7 @@ We can give a non-existing function for `init_state`:
   > (*@ mutable model value : 'a *)
   > EOF
   $ ortac qcheck-stm foo.mli "make 42" "int t"
-  Error: Function `make' not declared in the module.
+  Error: Function make not declared in the module.
 
 We can forget to specify the function used for the `init_state` function:
 
@@ -88,7 +87,7 @@ We can forget to specify the function used for the `init_state` function:
   File "foo.mli", line 3, characters 0-21:
   3 | val make : 'a -> 'a t
       ^^^^^^^^^^^^^^^^^^^^^
-  Error: Unsupported INIT function `make': the function called in the INIT
+  Error: Unsupported INIT function make: the function called in the INIT
          expression must be specified to initialize the model state.
 
 Or specify it in a manner that does not allow to deduce the complete `state`:
@@ -108,7 +107,7 @@ Or specify it in a manner that does not allow to deduce the complete `state`:
   6 | ... t = make a
   7 |     requires true
   8 |     ensures t.max_size = 123 ..
-  Error: Unsupported INIT function `make': the specification of the function
+  Error: Unsupported INIT function make: the specification of the function
          called in the INIT expression does not specify the following fields of
          the model: value, size.
 
@@ -145,7 +144,7 @@ Or we can give a function that does not return the type of the system under test
   3 | val make : int -> unit
   4 | (*@ make i
   5 |     modifies () *)
-  Error: Unsupported INIT expression `make': the function called in the INIT
+  Error: Unsupported INIT expression make: the function called in the INIT
          expression must return a value of SUT type.
 
 We are expected to give a function call as expression for the `init_state` function:
@@ -155,8 +154,8 @@ We are expected to give a function call as expression for the `init_state` funct
   > (*@ mutable model value : 'a *)
   > EOF
   $ ortac qcheck-stm foo.mli "42" "int t"
-  Error: Unsupported INIT expression `42': the INIT expression is expected to
-         be a function call (the specification of that function is required to
+  Error: Unsupported INIT expression 42: the INIT expression is expected to be
+         a function call (the specification of that function is required to
          initialize the model state).
 
 It also does not support qualified names:
@@ -166,7 +165,7 @@ It also does not support qualified names:
   > (*@ mutable model value : 'a *)
   > EOF
   $ ortac qcheck-stm foo.mli "Bar.make 42" "int t"
-  Error: Unsupported INIT function `Bar.make': qualified names are not yet
+  Error: Unsupported INIT function Bar.make: qualified names are not yet
          supported.
 
 It checks the number of arguments in the function call:
@@ -179,5 +178,5 @@ It checks the number of arguments in the function call:
   >     ensures t.value = a *)
   > EOF
   $ ortac qcheck-stm foo.mli "make 42 73" "int t"
-  Error: Error in INIT expression `make 42 73': mismatch in the number of
+  Error: Error in INIT expression make 42 73: mismatch in the number of
          arguments between the INIT expression and the function specification.

--- a/plugins/qcheck-stm/test/test_errors.t
+++ b/plugins/qcheck-stm/test/test_errors.t
@@ -15,6 +15,18 @@ in the type declaration for the sytem under test:
   $ ortac qcheck-stm foo.mli "make 42" ""
   Error: Syntax error in type `'.
 
+We can give a pair as SUT type:
+
+  $ ortac qcheck-stm foo.mli "make 42" "int * bool"
+  Error: Unsupported SUT type `(int * bool)': SUT type must be a type
+         constructor, possibly applied to type arguments.
+
+We can give a functional argument to the SUT type:
+
+  $ ortac qcheck-stm foo.mli "make 42" "(int -> bool) t"
+  Error: Unsupported type parameter `int -> bool': only constructors and tuples
+         are supported in arguments for the SUT type.
+
 We can give a type that does not exist in the module as the system under test:
 
   $ cat > foo.mli << EOF

--- a/plugins/wrapper/src/report.ml
+++ b/plugins/wrapper/src/report.ml
@@ -17,18 +17,15 @@ open Fmt
 
 let pp_kind ppf = function
   | Ghost_value name ->
-      pf ppf "%a is a ghost value. It was not translated." W.quoted name
-  | Ghost_type name ->
-      pf ppf "%a is a ghost type. It was not translated." W.quoted name
+      pf ppf "%s is a ghost value. It was not translated." name
+  | Ghost_type name -> pf ppf "%s is a ghost type. It was not translated." name
   | Unsupported_model (type_, name) ->
-      pf ppf "Model %a of type %a is not supported. It was not translated."
-        W.quoted name W.quoted type_
+      pf ppf "Model %s of type %s is not supported. It was not translated." name
+        type_
   | Function_without_definition name ->
-      pf ppf "The function %a has no definition. It was not translated."
-        W.quoted name
+      pf ppf "The function %s has no definition. It was not translated." name
   | Predicate_without_definition name ->
-      pf ppf "The predicate %a has no definition. It was not translated."
-        W.quoted name
+      pf ppf "The predicate %s has no definition. It was not translated." name
   | kind -> W.pp_kind ppf kind
 
 let pp = W.pp_param pp_kind level

--- a/plugins/wrapper/test/generated/errors.expected
+++ b/plugins/wrapper/test/generated/errors.expected
@@ -1,2 +1,4 @@
 File "lib.mli", line 20, characters 44-52:
-Warning: unsupported old operator. The clause has not been translated
+20 |                 mem j bv <-> i = j \/ mem j (old bv) *)
+                                                 ^^^^^^^^
+Warning: Skipping clause: unsupported old operator.

--- a/src/core/warnings.ml
+++ b/src/core/warnings.ml
@@ -22,8 +22,6 @@ let pp_level ppf = function
   | Warning -> GW.styled_list [ `Magenta; `Bold ] string ppf "Warning"
   | Error -> GW.styled_list [ `Red; `Bold ] string ppf "Error"
 
-let quoted ppf = pf ppf "`%s'"
-
 let pp_kind ppf = function
   | GospelError k -> pf ppf "Gospel error: %a" Gospel.Warnings.pp_kind k
   | Unsupported msg -> pf ppf "Skipping clause:@ unsupported %s" msg

--- a/src/core/warnings.ml
+++ b/src/core/warnings.ml
@@ -19,7 +19,7 @@ exception Error of t
 open Fmt
 
 let pp_level ppf = function
-  | Warning -> GW.styled_list [ `Yellow; `Bold ] string ppf "Warning"
+  | Warning -> GW.styled_list [ `Magenta; `Bold ] string ppf "Warning"
   | Error -> GW.styled_list [ `Red; `Bold ] string ppf "Error"
 
 let quoted ppf = pf ppf "`%s'"

--- a/src/core/warnings.ml
+++ b/src/core/warnings.ml
@@ -26,8 +26,7 @@ let quoted ppf = pf ppf "`%s'"
 
 let pp_kind ppf = function
   | GospelError k -> pf ppf "Gospel error: %a" Gospel.Warnings.pp_kind k
-  | Unsupported msg ->
-      pf ppf "unsupported %s. The clause has not been translated" msg
+  | Unsupported msg -> pf ppf "Skipping clause:@ unsupported %s" msg
   | _ -> raise Unkown_kind
 
 let pp_param pp_kind level ppf (k, loc) =

--- a/src/core/warnings.ml
+++ b/src/core/warnings.ml
@@ -1,4 +1,5 @@
 open Ppxlib
+module GW = Gospel.Warnings
 
 type level = Warning | Error
 type kind = ..
@@ -17,11 +18,9 @@ exception Error of t
 
 open Fmt
 
-let styled_list l pp = List.fold_left (fun acc x -> styled x acc) pp l
-
 let pp_level ppf = function
-  | Warning -> pf ppf "%a: " (styled_list [ `Yellow; `Bold ] string) "Warning"
-  | Error -> pf ppf "%a: " (styled_list [ `Red; `Bold ] string) "Error"
+  | Warning -> GW.styled_list [ `Yellow; `Bold ] string ppf "Warning"
+  | Error -> GW.styled_list [ `Red; `Bold ] string ppf "Error"
 
 let quoted ppf = pf ppf "`%s'"
 
@@ -31,14 +30,9 @@ let pp_kind ppf = function
       pf ppf "unsupported %s. The clause has not been translated" msg
   | _ -> raise Unkown_kind
 
-let is_fake_loc loc = loc.loc_start.pos_fname = "_none_"
-
 let pp_param pp_kind level ppf (k, loc) =
-  if is_fake_loc loc then pf ppf "%a@[%a@]@\n" pp_level (level k) pp_kind k
-  else
-    pf ppf "%a@\n%a@[%a@]@\n"
-      (styled `Bold Location.print)
-      loc pp_level (level k) pp_kind k
+  let pp_sort ppf k = pp_level ppf (level k) in
+  GW.pp_gen pp_sort pp_kind ppf loc k
 
 let pp = pp_param pp_kind level
 


### PR DESCRIPTION
These two parts could be seen as fairly independent but I think that using `pp_fix` has a deep impact on what we would like to see in the message: as `pp_loc` will quote the code extract, the extra information that the warning brings should usually be more about the context (such as in which function this is occurring).
So I propose to improve further this PR by modifying those, but it would be most helpful to have an example program for each of those warnings, to make sure the message does help understanding the problem.

It also contains a couple of other things to fix (`TODO` and one message that seems dead code).