### PR TITLE
Seperate monadic checks and assertion.

### DIFF
--- a/plugins/qcheck-stm/src/ir_of_gospel.ml
+++ b/plugins/qcheck-stm/src/ir_of_gospel.ml
@@ -184,9 +184,8 @@ let postcond spec =
 
 let val_desc config state vd =
   let open Reserr in
-  let* () = constant_test vd
-  and* () = higher_order_test vd
-  and* inst = ty_var_substitution config vd
+  let* () = constant_test vd and* () = higher_order_test vd in
+  let* inst = ty_var_substitution config vd
   and* spec =
     of_option ~default:(No_spec vd.vd_name.id_str, vd.vd_loc) vd.vd_spec
   in

--- a/plugins/qcheck-stm/test/hashtbl_errors.expected
+++ b/plugins/qcheck-stm/test/hashtbl_errors.expected
@@ -4,17 +4,11 @@ Warning: `copy' returns a sut.
 File "hashtbl.mli", line 63, characters 12-28:
 Warning: Functional argument (`'a -> 'b -> unit') are not tested.
 
-File "hashtbl.mli", line 63, characters 0-51:
-Warning: The function `iter' is not specified.
-
 File "hashtbl.mli", line 64, characters 26-47:
 Warning: Functional argument (`'a -> 'b -> 'b option') are not tested.
 
 File "hashtbl.mli", line 73, characters 12-32:
 Warning: Functional argument (`'a -> 'b -> 'c -> 'c') are not tested.
-
-File "hashtbl.mli", line 73, characters 0-59:
-Warning: The function `fold' is not specified.
 
 File "hashtbl.mli", line 78, characters 16-28:
 Warning: `randomize' have no sut argument.


### PR DESCRIPTION
Tested locally, automatic tests are comming in seperated PR testing all warnings.

Fix #123
