### PR TITLE
Use a better work-around for the `dune-site` dependency problem for tests

### DIFF
--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -1,4 +1,7 @@
-let () = Sites.Plugins.Plugins.load_all ()
+let () =
+  match Sys.getenv_opt "ORTAC_ONLY_PLUGIN" with
+  | None -> Sites.Plugins.Plugins.load_all ()
+  | Some plug -> Sites.Plugins.Plugins.load plug
 
 open Cmdliner
 

--- a/plugins/monolith/src/dune
+++ b/plugins/monolith/src/dune
@@ -14,7 +14,7 @@
   ppxlib.astlib))
 
 (plugin
- (name ortac-monolith)
+ (name monolith)
  (package ortac-monolith)
  (libraries ortac-monolith.plugin)
  (site

--- a/plugins/monolith/test/generated/dune
+++ b/plugins/monolith/test/generated/dune
@@ -30,9 +30,12 @@
   (package ortac-wrapper)
   (package ortac-monolith))
  (action
-  (with-stderr-to
-   errors
-   (run ortac monolith -o %{target} %{dep:lib.mli}))))
+  (setenv
+   ORTAC_ONLY_PLUGIN
+   monolith
+   (with-stderr-to
+    errors
+    (run ortac monolith -o %{target} %{dep:lib.mli})))))
 
 (rule
  (copy ../../../wrapper/test/generated/lib.mli lib.mli))

--- a/plugins/monolith/test/generated/dune
+++ b/plugins/monolith/test/generated/dune
@@ -28,8 +28,7 @@
  (deps
   (package ortac-core)
   (package ortac-wrapper)
-  (package ortac-monolith)
-  (package ortac-qcheck-stm))
+  (package ortac-monolith))
  (action
   (with-stderr-to
    errors

--- a/plugins/qcheck-stm/src/dune
+++ b/plugins/qcheck-stm/src/dune
@@ -13,7 +13,7 @@
   (pps ppxlib.metaquot)))
 
 (plugin
- (name ortac-qcheck-stm)
+ (name qcheck-stm)
  (package ortac-qcheck-stm)
  (libraries ortac-qcheck-stm.plugin)
  (site

--- a/plugins/qcheck-stm/test/dune
+++ b/plugins/qcheck-stm/test/dune
@@ -30,11 +30,14 @@
   (package ortac-core)
   (package ortac-qcheck-stm))
  (action
-  (with-stderr-to
-   array_errors
-   (with-stdout-to
-    %{target}
-    (run ortac qcheck-stm %{dep:array.mli} "make 16 'a'" "char t")))))
+  (setenv
+   ORTAC_ONLY_PLUGIN
+   qcheck-stm
+   (with-stderr-to
+    array_errors
+    (with-stdout-to
+     %{target}
+     (run ortac qcheck-stm %{dep:array.mli} "make 16 'a'" "char t"))))))
 
 (rule
  (alias runtest)
@@ -73,16 +76,19 @@
   (package ortac-core)
   (package ortac-qcheck-stm))
  (action
-  (with-stderr-to
-   hashtbl_errors
-   (with-stdout-to
-    %{target}
-    (run
-     ortac
-     qcheck-stm
-     %{dep:hashtbl.mli}
-     "create ~random:false 16"
-     "(char, int) t")))))
+  (setenv
+   ORTAC_ONLY_PLUGIN
+   qcheck-stm
+   (with-stderr-to
+    hashtbl_errors
+    (with-stdout-to
+     %{target}
+     (run
+      ortac
+      qcheck-stm
+      %{dep:hashtbl.mli}
+      "create ~random:false 16"
+      "(char, int) t"))))))
 
 (rule
  (alias runtest)

--- a/plugins/qcheck-stm/test/dune
+++ b/plugins/qcheck-stm/test/dune
@@ -28,8 +28,6 @@
  (package ortac-qcheck-stm)
  (deps
   (package ortac-core)
-  (package ortac-wrapper)
-  (package ortac-monolith)
   (package ortac-qcheck-stm))
  (action
   (with-stderr-to
@@ -73,8 +71,6 @@
  (package ortac-qcheck-stm)
  (deps
   (package ortac-core)
-  (package ortac-wrapper)
-  (package ortac-monolith)
   (package ortac-qcheck-stm))
  (action
   (with-stderr-to

--- a/plugins/wrapper/src/dune
+++ b/plugins/wrapper/src/dune
@@ -13,7 +13,7 @@
   (pps ppxlib.metaquot)))
 
 (plugin
- (name ortac-wrapper)
+ (name wrapper)
  (package ortac-wrapper)
  (libraries ortac-wrapper.plugin)
  (site

--- a/plugins/wrapper/test/generated/dune
+++ b/plugins/wrapper/test/generated/dune
@@ -11,9 +11,7 @@
  (package ortac-wrapper)
  (deps
   (package ortac-core)
-  (package ortac-wrapper)
-  (package ortac-monolith)
-  (package ortac-qcheck-stm))
+  (package ortac-wrapper))
  (action
   (with-stderr-to
    errors

--- a/plugins/wrapper/test/generated/dune
+++ b/plugins/wrapper/test/generated/dune
@@ -13,9 +13,12 @@
   (package ortac-core)
   (package ortac-wrapper))
  (action
-  (with-stderr-to
-   errors
-   (run ortac wrapper -o %{target} %{dep:lib.mli}))))
+  (setenv
+   ORTAC_ONLY_PLUGIN
+   wrapper
+   (with-stderr-to
+    errors
+    (run ortac wrapper -o %{target} %{dep:lib.mli})))))
 
 (rule
  (alias runtest)

--- a/plugins/wrapper/test/suite/dune.common
+++ b/plugins/wrapper/test/suite/dune.common
@@ -5,9 +5,12 @@
   (package ortac-core)
   (package ortac-wrapper))
  (action
-  (with-stdout-to
+  (setenv
+   ORTAC_ONLY_PLUGIN
+   wrapper
+   (with-stdout-to
     %{target}
-   (run ortac wrapper %{dep:lib.mli}))))
+    (run ortac wrapper %{dep:lib.mli})))))
 
 (rule
  (target lib_rtac.mli)

--- a/plugins/wrapper/test/suite/dune.common
+++ b/plugins/wrapper/test/suite/dune.common
@@ -3,9 +3,7 @@
  (package ortac-wrapper)
  (deps
   (package ortac-core)
-  (package ortac-wrapper)
-  (package ortac-monolith)
-  (package ortac-qcheck-stm))
+  (package ortac-wrapper))
  (action
   (with-stdout-to
     %{target}


### PR DESCRIPTION
The current work-around breaks `opam install --with-test ...` as the tests of each plugin depends on all plugins, from other packages (and but we really don't want to add an OPAM dependency on all plugins). So this PR introduces another work-around, inspired by a comment in ocaml/dune#8283: if `$ORTAC_ONLY_PLUGIN` is set up, load only the plugin of that name. This is using an environment variable rather than a command-line argument because the plugins provide the command-line parsers...