### PR TITLE
Use the core type to test the return type of `init_sut`

### DIFF
--- a/plugins/qcheck-stm/src/config.ml
+++ b/plugins/qcheck-stm/src/config.ml
@@ -27,15 +27,6 @@ let is_sut config ty =
   | Ptyp_constr (lid, _) -> lid.txt = sut_type_name
   | _ -> false
 
-let is_sut_gospel_ty config ty =
-  let sut_type_unqualified_name = get_sut_type_name_str config in
-  let open Gospel.Ttypes in
-  match ty.ty_node with
-  | Tyvar _ -> false
-  | Tyapp (ts, _) ->
-      Fmt.str "%a" Gospel.Identifier.Ident.pp ts.ts_ident
-      = sut_type_unqualified_name
-
 let dump ppf t =
   Fmt.(
     pf ppf "sut_core_type: %a; init_sut: %a@." Ppxlib_ast.Pprintast.expression

--- a/plugins/qcheck-stm/src/ir_of_gospel.ml
+++ b/plugins/qcheck-stm/src/ir_of_gospel.ml
@@ -321,11 +321,13 @@ let init_state config state sigs =
           Location.none )
   in
   let open Gospel.Symbols in
+  let rec return_type ty =
+    match ty.ptyp_desc with Ptyp_arrow (_, _, r) -> return_type r | _ -> ty
+  in
+  let ret_sut = Cfg.is_sut config (return_type value.vd_type) in
   let* sut =
     List.find_map
-      (function
-        | Lnone vs when Cfg.is_sut_gospel_ty config vs.vs_ty -> Some vs.vs_name
-        | _ -> None)
+      (function Lnone vs when ret_sut -> Some vs.vs_name | _ -> None)
       spec.sp_ret
     |> of_option
          ~default:


### PR DESCRIPTION
Use the source core type rather than the gospel type to check that the function provided by the user to initialize the SUT is indeed returning a value of the expected type

This makes the code more uniform: we are already testing the core type to detect SUT arguments. This also allows the SUT type to be concrete, as the Gospel type-checker will substitute all non-abstract types with their definitions in its AST

Closes #131