### PR TITLE
Translate Gospel `integer` as `Ortac_runtime.integer`

### DIFF
--- a/src/core/ocaml_of_gospel.ml
+++ b/src/core/ocaml_of_gospel.ml
@@ -165,7 +165,8 @@ and term ~context (t : Tterm.term) : expression =
 let core_type_of_ty_with_subst subst ty =
   let open Ttypes in
   let lident_of_tysymbol ts =
-    (if ty_equal ty_integer ty then "int" else Fmt.str "%a" Ident.pp ts.ts_ident)
+    (if ty_equal ty_integer ty then "Ortac_runtime.integer"
+     else Fmt.str "%a" Ident.pp ts.ts_ident)
     |> Builder.lident
   in
   let rec aux ty =


### PR DESCRIPTION
Translate Gospel type `integer` as `Ortac_runtime.integer` (so that the runtime can choose its implementation) rather than hard-coding it as `int`. Choosing `int` makes it inconsistent with all the implementations of the Gospel Stdlib in `Ortac_runtime` (where `Z.t` is used)