### PR TITLE
Restrict `subst_term` to `x.f` where `f` is a model field

### DIFF
--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -24,7 +24,7 @@ type W.kind +=
   | Sut_type_not_specified of string
   | No_models of string
   | No_spec of string
-  | Impossible_term_substitution of (string * [ `New | `Old ])
+  | Impossible_term_substitution of (string * [ `New | `Old | `NotModel ])
   | Ignored_modifies of string
   | Ensures_not_found_for_next_state of string
   | Type_not_supported of string
@@ -125,7 +125,13 @@ let pp_kind ppf kind =
       pf ppf "The type %a given for the system under test has no models."
         W.quoted ty
   | No_spec fct -> pf ppf "The function %a is not specified." W.quoted fct
-  | Impossible_term_substitution (t, no) ->
+  | Impossible_term_substitution (t, `NotModel) ->
+      pf ppf
+        "The term %a can not be substituted (supported only when applied to \
+         one of its model fields)."
+        W.quoted t
+  | Impossible_term_substitution (t, (`Old as no))
+  | Impossible_term_substitution (t, (`New as no)) ->
       let s = match no with `Old -> "under" | `New -> "above" in
       pf ppf
         "The term %a can not be substituted (supported only %s `old` operator)."

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -24,7 +24,7 @@ type W.kind +=
   | Sut_type_not_specified of string
   | No_models of string
   | No_spec of string
-  | Impossible_term_substitution of (string * [ `New | `Old ])
+  | Impossible_term_substitution of (string * [ `New | `Old | `NotModel ])
   | Ignored_modifies of string
   | Ensures_not_found_for_next_state of string
   | Type_not_supported of string

--- a/plugins/qcheck-stm/test/dune
+++ b/plugins/qcheck-stm/test/dune
@@ -129,3 +129,103 @@
  (alias launchtests)
  (action
   (run %{dep:hashtbl_stm_tests.exe} -v)))
+
+(library
+ (name record)
+ (modules record))
+
+(test
+ (name record_stm_tests)
+ (package ortac-qcheck-stm)
+ (modules record_stm_tests)
+ (libraries
+  qcheck-core
+  qcheck-core.runner
+  qcheck-stm.stm
+  qcheck-stm.sequential
+  qcheck-multicoretests-util
+  ortac-runtime
+  record)
+ (flags :standard -w -27)
+ (action
+  (echo
+   "\n%{dep:record_stm_tests.exe} has been generated with the ortac-qcheck-stm plugin.\n")))
+
+(rule
+ (target record_stm_tests.ml)
+ (package ortac-qcheck-stm)
+ (deps
+  (package ortac-core)
+  (package ortac-qcheck-stm))
+ (action
+  (setenv
+   ORTAC_ONLY_PLUGIN
+   qcheck-stm
+   (with-stderr-to
+    record_errors
+    (with-stdout-to
+     %{target}
+     (run ortac qcheck-stm %{dep:record.mli} "make 42" "t"))))))
+
+(rule
+ (alias runtest)
+ (package ortac-qcheck-stm)
+ (action
+  (progn
+   (diff record_errors.expected record_errors)
+   (diff record_stm_tests.expected.ml record_stm_tests.ml))))
+
+(rule
+ (alias launchtests)
+ (action
+  (run %{dep:record_stm_tests.exe} -v)))
+
+(library
+ (name ref)
+ (modules ref))
+
+(test
+ (name ref_stm_tests)
+ (package ortac-qcheck-stm)
+ (modules ref_stm_tests)
+ (libraries
+  qcheck-core
+  qcheck-core.runner
+  qcheck-stm.stm
+  qcheck-stm.sequential
+  qcheck-multicoretests-util
+  ortac-runtime
+  ref)
+ (flags :standard -w -27)
+ (action
+  (echo
+   "\n%{dep:ref_stm_tests.exe} has been generated with the ortac-qcheck-stm plugin.\n")))
+
+(rule
+ (target ref_stm_tests.ml)
+ (package ortac-qcheck-stm)
+ (deps
+  (package ortac-core)
+  (package ortac-qcheck-stm))
+ (action
+  (setenv
+   ORTAC_ONLY_PLUGIN
+   qcheck-stm
+   (with-stderr-to
+    ref_errors
+    (with-stdout-to
+     %{target}
+     (run ortac qcheck-stm %{dep:ref.mli} "make 42" "t"))))))
+
+(rule
+ (alias runtest)
+ (package ortac-qcheck-stm)
+ (action
+  (progn
+   (diff ref_errors.expected ref_errors)
+   (diff ref_stm_tests.expected.ml ref_stm_tests.ml))))
+
+(rule
+ (alias launchtests)
+ (action
+  (run %{dep:ref_stm_tests.exe} -v)))

--- a/plugins/qcheck-stm/test/record.ml
+++ b/plugins/qcheck-stm/test/record.ml
@@ -1,0 +1,4 @@
+type t = { c : int }
+
+let make i = { c = i }
+let get { c } = c

--- a/plugins/qcheck-stm/test/record.mli
+++ b/plugins/qcheck-stm/test/record.mli
@@ -1,0 +1,13 @@
+type t = private { c : int }
+(*@ model value : integer
+    with x invariant integer_of_int x.c = x.value *)
+
+val make : int -> t
+(*@ r = make i
+    ensures r.value = i *)
+
+val get : t -> int
+(*@ i = get r
+    pure
+    ensures i = r.value
+    ensures i = r.c *)

--- a/plugins/qcheck-stm/test/record_errors.expected
+++ b/plugins/qcheck-stm/test/record_errors.expected
@@ -1,0 +1,3 @@
+File "record.mli", line 13, characters 16-17:
+Warning: The term `r:t' can not be substituted (supported only when applied to one of its model fields).
+

--- a/plugins/qcheck-stm/test/record_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/record_stm_tests.expected.ml
@@ -1,0 +1,38 @@
+open Record
+module Spec =
+  struct
+    open STM
+    type sut = t
+    type cmd =
+      | Get 
+    let show_cmd cmd__001_ =
+      match cmd__001_ with | Get -> Format.asprintf "%s" "get"
+    type nonrec state = {
+      value: Ortac_runtime.integer }
+    let init_state =
+      let i_1 = 42 in
+      { value = (Ortac_runtime.Gospelstdlib.integer_of_int i_1) }
+    let init_sut () = make 42
+    let cleanup _ = ()
+    let arb_cmd _ =
+      let open QCheck in
+        make ~print:show_cmd (let open Gen in oneof [pure Get])
+    let next_state cmd__002_ state__003_ =
+      match cmd__002_ with | Get -> state__003_
+    let precond cmd__008_ state__009_ = match cmd__008_ with | Get -> true
+    let postcond cmd__004_ state__005_ res__006_ =
+      let new_state__007_ = lazy (next_state cmd__004_ state__005_) in
+      match (cmd__004_, res__006_) with
+      | (Get, Res ((Int, _), i)) ->
+          ((Ortac_runtime.Gospelstdlib.integer_of_int i) =
+             (Lazy.force new_state__007_).value)
+            && (i = (Lazy.force new_state__007_).c)
+      | _ -> true
+    let run cmd__010_ sut__011_ =
+      match cmd__010_ with | Get -> Res (int, (get sut__011_))
+  end
+module STMTests = (STM_sequential.Make)(Spec)
+let _ =
+  QCheck_base_runner.run_tests_main
+    (let count = 1000 in
+     [STMTests.agree_test ~count ~name:"STM Lib test sequential"])

--- a/plugins/qcheck-stm/test/record_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/record_stm_tests.expected.ml
@@ -24,9 +24,8 @@ module Spec =
       let new_state__007_ = lazy (next_state cmd__004_ state__005_) in
       match (cmd__004_, res__006_) with
       | (Get, Res ((Int, _), i)) ->
-          ((Ortac_runtime.Gospelstdlib.integer_of_int i) =
-             (Lazy.force new_state__007_).value)
-            && (i = (Lazy.force new_state__007_).c)
+          (Ortac_runtime.Gospelstdlib.integer_of_int i) =
+            (Lazy.force new_state__007_).value
       | _ -> true
     let run cmd__010_ sut__011_ =
       match cmd__010_ with | Get -> Res (int, (get sut__011_))

--- a/plugins/qcheck-stm/test/ref.ml
+++ b/plugins/qcheck-stm/test/ref.ml
@@ -1,0 +1,4 @@
+type t = int ref
+
+let make = ref
+let get r = !r

--- a/plugins/qcheck-stm/test/ref.mli
+++ b/plugins/qcheck-stm/test/ref.mli
@@ -1,0 +1,12 @@
+type t = private int ref
+(*@ mutable model value : integer *)
+
+val make : int -> t
+(*@ r = make i
+    ensures r.value = i *)
+
+val get : t -> int
+(*@ i = get r
+    pure
+    ensures i = r.value
+    ensures i + 1 = succ !r *)

--- a/plugins/qcheck-stm/test/ref_errors.expected
+++ b/plugins/qcheck-stm/test/ref_errors.expected
@@ -1,0 +1,3 @@
+File "ref.mli", line 12, characters 26-27:
+Warning: The term `r:int ref' can not be substituted (supported only when applied to one of its model fields).
+

--- a/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
@@ -24,17 +24,8 @@ module Spec =
       let new_state__007_ = lazy (next_state cmd__004_ state__005_) in
       match (cmd__004_, res__006_) with
       | (Get, Res ((Int, _), i)) ->
-          ((Ortac_runtime.Gospelstdlib.integer_of_int i) =
-             (Lazy.force new_state__007_).value)
-            &&
-            ((Ortac_runtime.Gospelstdlib.(+)
-                (Ortac_runtime.Gospelstdlib.integer_of_int i)
-                (Ortac_runtime.Gospelstdlib.integer_of_int 1))
-               =
-               (Ortac_runtime.Gospelstdlib.succ
-                  (Ortac_runtime.Gospelstdlib.integer_of_int
-                     (Ortac_runtime.Gospelstdlib.(~!)
-                        (Lazy.force new_state__007_)))))
+          (Ortac_runtime.Gospelstdlib.integer_of_int i) =
+            (Lazy.force new_state__007_).value
       | _ -> true
     let run cmd__010_ sut__011_ =
       match cmd__010_ with | Get -> Res (int, (get sut__011_))

--- a/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
@@ -1,0 +1,46 @@
+open Ref
+module Spec =
+  struct
+    open STM
+    type sut = t
+    type cmd =
+      | Get 
+    let show_cmd cmd__001_ =
+      match cmd__001_ with | Get -> Format.asprintf "%s" "get"
+    type nonrec state = {
+      value: Ortac_runtime.integer }
+    let init_state =
+      let i_1 = 42 in
+      { value = (Ortac_runtime.Gospelstdlib.integer_of_int i_1) }
+    let init_sut () = make 42
+    let cleanup _ = ()
+    let arb_cmd _ =
+      let open QCheck in
+        make ~print:show_cmd (let open Gen in oneof [pure Get])
+    let next_state cmd__002_ state__003_ =
+      match cmd__002_ with | Get -> state__003_
+    let precond cmd__008_ state__009_ = match cmd__008_ with | Get -> true
+    let postcond cmd__004_ state__005_ res__006_ =
+      let new_state__007_ = lazy (next_state cmd__004_ state__005_) in
+      match (cmd__004_, res__006_) with
+      | (Get, Res ((Int, _), i)) ->
+          ((Ortac_runtime.Gospelstdlib.integer_of_int i) =
+             (Lazy.force new_state__007_).value)
+            &&
+            ((Ortac_runtime.Gospelstdlib.(+)
+                (Ortac_runtime.Gospelstdlib.integer_of_int i)
+                (Ortac_runtime.Gospelstdlib.integer_of_int 1))
+               =
+               (Ortac_runtime.Gospelstdlib.succ
+                  (Ortac_runtime.Gospelstdlib.integer_of_int
+                     (Ortac_runtime.Gospelstdlib.(~!)
+                        (Lazy.force new_state__007_)))))
+      | _ -> true
+    let run cmd__010_ sut__011_ =
+      match cmd__010_ with | Get -> Res (int, (get sut__011_))
+  end
+module STMTests = (STM_sequential.Make)(Spec)
+let _ =
+  QCheck_base_runner.run_tests_main
+    (let count = 1000 in
+     [STMTests.agree_test ~count ~name:"STM Lib test sequential"])


### PR DESCRIPTION
In the QCheck-STM framework, the code generated to test whether clauses hold will be run with only the model state in scope, not the actual non-model values. `subst_term` will ensure that the substitution is indeed used in such a case instead of generating non-compiling code. This adds a new error case to report those impossible substitutions.
Add two simple tests (`ref` and record) that didn't compile before this PR.

This is based on #134 because it is using a `integer` in a model.