### PR TITLE
Bring Ortac up-to-date with the current development version of Gospel

### DIFF
--- a/ortac-core.opam
+++ b/ortac-core.opam
@@ -40,5 +40,5 @@ depends: [
 ]
 
 pin-depends: [
-  "gospel.dev" "git+https://github.com/ocaml-gospel/gospel#aed0e75996116f89184e70717966983b309aec15"
+  "gospel.dev" "git+https://github.com/ocaml-gospel/gospel#ef8f0d23f2df6f825355cfa27e38e904ddc3c3a3"
 ]

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -132,6 +132,7 @@ let subst_term state ~gos_t ?(old_lz = false) ~old_t ?(new_lz = false) ~new_t
                   brchs );
         }
     | Tquant (q, vs, t) -> { term with t_node = Tquant (q, vs, next t) }
+    | Tlambda (ps, t) -> { term with t_node = Tlambda (ps, next t) }
     | Tbinop (o, l, r) -> { term with t_node = Tbinop (o, next l, next r) }
     | Tnot t -> { term with t_node = Tnot (next t) }
     | Told t -> aux old_lz old_t t

--- a/plugins/qcheck-stm/test/all_warnings.mli
+++ b/plugins/qcheck-stm/test/all_warnings.mli
@@ -28,10 +28,6 @@ val incompatible_type : int t -> bool
 val no_spec : 'a t -> bool
 (*@ b = no_spec t *)
 
-val impossible_term_substitution : 'a t -> bool
-(*@ impossible_term_substitution t
-    requires old t.contents = [] *)
-
 val ignored_modified : 'a t -> unit
 (*@ ignored_modified t
     modifies () *)

--- a/plugins/qcheck-stm/test/all_warnings_errors.expected
+++ b/plugins/qcheck-stm/test/all_warnings_errors.expected
@@ -13,24 +13,21 @@ Warning: `multiple_sut_argument' have multiple sut arguments.
 File "all_warnings.mli", line 25, characters 24-29:
 Warning: Type of system under test in `incompatible_type' is incompatible with command line argument.
 
-File "all_warnings.mli", line 37, characters 13-15:
+File "all_warnings.mli", line 33, characters 13-15:
 Warning: Skipping `modifies` `(unit ):unit_1'.
 
-File "all_warnings.mli", line 46, characters 27-37:
+File "all_warnings.mli", line 42, characters 27-37:
 Warning: Functional argument (`'a -> bool') are not tested.
 
-File "all_warnings.mli", line 50, characters 24-25:
+File "all_warnings.mli", line 46, characters 24-25:
 Warning: Functions with a ghost argument (`x') are not tested.
 
-File "all_warnings.mli", line 53, characters 6-7:
+File "all_warnings.mli", line 49, characters 6-7:
 Warning: Functions with a ghost returned value (`x_1') are not tested.
 
 File "all_warnings.mli", line 4, characters 18-26:
 Warning: No translatable `ensures` clause found to generate `next_state` for model `contents'.
 
-File "all_warnings.mli", line 57, characters 16-54:
+File "all_warnings.mli", line 53, characters 16-54:
 Warning: unsupported quantification. The clause has not been translated
-
-File "all_warnings.mli", line 33, characters 17-18:
-Warning: The term `t_1:'a t' can not be substituted (supported only under `old` operator).
 

--- a/plugins/wrapper/src/ir_of_gospel.ml
+++ b/plugins/wrapper/src/ir_of_gospel.ml
@@ -73,6 +73,10 @@ let subst_invariant_fields var (t : Tterm.term) =
         let t = aux t in
         let t_node = Tterm.Tquant (q, vsl, t) in
         { t with t_node }
+    | Tlambda (ps, t) ->
+        let t = aux t in
+        let t_node = Tterm.Tlambda (ps, t) in
+        { t with t_node }
     | Tterm.Tbinop (op, t1, t2) ->
         let t1 = aux t1 in
         let t2 = aux t2 in

--- a/src/core/ocaml_of_gospel.ml
+++ b/src/core/ocaml_of_gospel.ml
@@ -102,15 +102,8 @@ and term ~context (t : Tterm.term) : expression =
           case ~guard:(Option.map term g) ~lhs:(pattern p) ~rhs:(term t))
         ptl
       |> pexp_match (term t)
-  | Tquant (Tterm.Tlambda, args, t) ->
-      let t = term t in
-      let args =
-        List.map
-          (fun (vs : Symbols.vsymbol) ->
-            (Nolabel, pvar (str "%a" Ident.pp vs.vs_name)))
-          args
-      in
-      efun args t
+  | Tlambda (ps, t) ->
+      efun (List.map (fun p -> (Nolabel, pattern p)) ps) (term t)
   | Tquant
       ( (Tterm.(Tforall | Texists) as quant),
         [ var ],


### PR DESCRIPTION
This PR:
- updates the pinned gospel version, to bring its latest compatibility-breaking changes,
- bring support for patterns as arguments of anonymous functions, following ocaml-gospel/gospel#309.

As soon as gospel 0.2 is released, the pin should be dropped and converted into a regular version dependency, but this will help transition smoothly until then.