### PR TITLE
Distinguish SUT-type unification errors

### DIFF
--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -32,6 +32,7 @@ type W.kind +=
   | Impossible_init_state_generation of init_state_error
   | Functional_argument of string
   | Ghost_values of (string * [ `Arg | `Ret ])
+  | Incompatible_sut of string
 
 let level kind =
   match kind with
@@ -45,7 +46,7 @@ let level kind =
   | Sut_type_not_supported _ | Type_not_supported_for_sut_parameter _
   | Syntax_error_in_init_sut _ | Type_parameter_not_instantiated _
   | Sut_type_not_specified _ | No_models _ | Impossible_init_state_generation _
-    ->
+  | Incompatible_sut _ ->
       W.Error
   | _ -> W.level kind
 
@@ -195,6 +196,11 @@ let pp_kind ppf kind =
       pf ppf "Error in INIT expression %s:@ %a" fct text
         "mismatch in the number of arguments between the INIT expression and \
          the function specification"
+  | Incompatible_sut t ->
+      pf ppf "Incompatible declaration of SUT type:@ %a%s" text
+        "the declaration of the SUT type is incompatible with the configured \
+         one: "
+        t
   | _ -> W.pp_kind ppf kind
 
 let pp_errors = W.pp_param pp_kind level |> Fmt.list

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -32,6 +32,7 @@ type W.kind +=
   | Impossible_init_state_generation of init_state_error
   | Functional_argument of string
   | Ghost_values of (string * [ `Arg | `Ret ])
+  | Incompatible_sut of string
 
 type 'a reserr
 

--- a/plugins/qcheck-stm/test/test_errors.t
+++ b/plugins/qcheck-stm/test/test_errors.t
@@ -35,6 +35,15 @@ We can give a type that does not exist in the module as the system under test:
   $ ortac qcheck-stm foo.mli "()" "ty"
   Error: Type ty not declared in the module.
 
+Or forget its argument:
+
+  $ ortac qcheck-stm foo.mli "()" "t"
+  File "foo.mli", line 1, characters 0-9:
+  1 | type 'a t
+      ^^^^^^^^^
+  Error: Incompatible declaration of SUT type: the declaration of the SUT type
+         is incompatible with the configured one: t.
+
 We can forget to instantiate the type parameter of the system under test:
 
   $ cat > foo.mli << EOF


### PR DESCRIPTION
Unification of the SUT type is used in two different contexts:
- when handling a value, to know if its SUT-type argument has a compatible type with the one currently configured;
- when handling the declaration of the SUT type itself.
In the first case, we just want to skip the value with a warning; in the second case, we need to error out

Consequently:
- Add a new kind of error
- Feed `unify` with the information to know in which case we are

I’m a bit unsure about the phrasing of the error message, though.

Closes #133