### PR TITLE
Display the name of the tested module in the test run

### DIFF
--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -836,15 +836,17 @@ let stm config ir =
               (pmod_ident (Ldot (Lident "STM_sequential", "Make") |> noloc))
               (pmod_ident (lident "Spec"))))
   in
+  let module_name = Ortac_core.Context.module_name config.context in
   let call_tests =
     let loc = Location.none in
+    let descr = estring (module_name ^ " STM tests") in
     [%stri
       let _ =
         QCheck_base_runner.run_tests_main
           (let count = 1000 in
-           [ STMTests.agree_test ~count ~name:"STM Lib test sequential" ])]
+           [ STMTests.agree_test ~count ~name:[%e descr] ])]
   in
   ok
-    ([ open_mod (Ortac_core.Context.module_name config.context) ]
+    ([ open_mod module_name ]
     @ ghost_functions
     @ [ stm_spec; tests; call_tests ])

--- a/plugins/qcheck-stm/test/array_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/array_stm_tests.expected.ml
@@ -592,5 +592,4 @@ module Spec =
 module STMTests = (STM_sequential.Make)(Spec)
 let _ =
   QCheck_base_runner.run_tests_main
-    (let count = 1000 in
-     [STMTests.agree_test ~count ~name:"STM Lib test sequential"])
+    (let count = 1000 in [STMTests.agree_test ~count ~name:"Array STM tests"])

--- a/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
@@ -122,4 +122,4 @@ module STMTests = (STM_sequential.Make)(Spec)
 let _ =
   QCheck_base_runner.run_tests_main
     (let count = 1000 in
-     [STMTests.agree_test ~count ~name:"STM Lib test sequential"])
+     [STMTests.agree_test ~count ~name:"Conjunctive_clauses STM tests"])

--- a/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
@@ -464,4 +464,4 @@ module STMTests = (STM_sequential.Make)(Spec)
 let _ =
   QCheck_base_runner.run_tests_main
     (let count = 1000 in
-     [STMTests.agree_test ~count ~name:"STM Lib test sequential"])
+     [STMTests.agree_test ~count ~name:"Hashtbl STM tests"])

--- a/plugins/qcheck-stm/test/record_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/record_stm_tests.expected.ml
@@ -160,4 +160,4 @@ module STMTests = (STM_sequential.Make)(Spec)
 let _ =
   QCheck_base_runner.run_tests_main
     (let count = 1000 in
-     [STMTests.agree_test ~count ~name:"STM Lib test sequential"])
+     [STMTests.agree_test ~count ~name:"Record STM tests"])

--- a/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
@@ -80,5 +80,4 @@ module Spec =
 module STMTests = (STM_sequential.Make)(Spec)
 let _ =
   QCheck_base_runner.run_tests_main
-    (let count = 1000 in
-     [STMTests.agree_test ~count ~name:"STM Lib test sequential"])
+    (let count = 1000 in [STMTests.agree_test ~count ~name:"Ref STM tests"])


### PR DESCRIPTION
Also drop the explicit `sequential`, so that users only have to change `STM_sequential` into `STM_domain` if they want to test their module in a parallel setting

This makes the display of `dune build @launchtests` a bit more useful.