### PR TITLE
Small documentation cleanup

### DIFF
--- a/plugins/qcheck-stm/doc/index.mld
+++ b/plugins/qcheck-stm/doc/index.mld
@@ -1,7 +1,5 @@
 {0 Ortac/QCheck-STM}
 
-{1 Content}
-
 {1 Overview}
 
 The [qcheck-stm] plugin for [ortac] (called Ortac/QCheck-STM in order to avoid


### PR DESCRIPTION
Content part was empty and pointing to the different modules'
documentation is not really relevant.
