### PR TITLE
Add an include option to `qcheck-stm` cli

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add an include option to qcheck-stm cli
+  [\#181](https://github.com/ocaml-gospel/ortac/pull/181)
 - Add a quiet flag
   [\#179](https://github.com/ocaml-gospel/ortac/pull/179)
 - Check for out of scope variables

--- a/plugins/qcheck-stm/src/ortac_qcheck_stm.ml
+++ b/plugins/qcheck-stm/src/ortac_qcheck_stm.ml
@@ -4,14 +4,14 @@ module Ir_of_gospel = Ir_of_gospel
 module Reserr = Reserr
 module Stm_of_ir = Stm_of_ir
 
-let main path init sut output quiet () =
+let main path init sut include_ output quiet () =
   let open Reserr in
   let fmt = Registration.get_out_formatter output in
   let pp = pp quiet Ppxlib_ast.Pprintast.structure fmt in
   pp
     (let* sigs, config = Config.init path init sut in
      let* ir = Ir_of_gospel.run sigs config in
-     Stm_of_ir.stm config ir)
+     Stm_of_ir.stm include_ config ir)
 
 open Cmdliner
 
@@ -38,10 +38,24 @@ end = struct
              system under test."
           ~docv:"INIT")
 
+  let include_ =
+    Arg.(
+      value
+      & opt (some string) None
+      & info [ "i"; "include" ] ~docv:"MODULE"
+          ~doc:"Include MODULE in the generated code.")
+
   let term =
     let open Registration in
     Term.(
-      const main $ ocaml_file $ init $ sut $ output_file $ quiet $ setup_log)
+      const main
+      $ ocaml_file
+      $ init
+      $ sut
+      $ include_
+      $ output_file
+      $ quiet
+      $ setup_log)
 
   let cmd = Cmd.v info term
 end

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -770,10 +770,22 @@ let ghost_functions config =
   in
   aux config []
 
-let stm config ir =
+let stm include_ config ir =
   let open Reserr in
   let* config, ghost_functions = ghost_functions config ir.ghost_functions in
   let warn = [%stri [@@@ocaml.warning "-26-27"]] in
+  let incl =
+    Option.map
+      (fun m ->
+        let open Ast_helper in
+        String.capitalize_ascii m
+        |> lident
+        |> Mod.ident
+        |> Incl.mk
+        |> pstr_include)
+      include_
+    |> Option.to_list
+  in
   let sut = sut_type config in
   let cmd = cmd_type ir in
   let* cmd_show = cmd_show ir in
@@ -797,22 +809,22 @@ let stm config ir =
   let open_mod m = pstr_open Ast_helper.(Opn.mk (Mod.ident (lident m))) in
   let spec_expr =
     pmod_structure
-      [
-        open_mod "STM";
-        warn;
-        sut;
-        cmd;
-        cmd_show;
-        state;
-        init_state;
-        init_sut;
-        cleanup;
-        arb_cmd;
-        next_state;
-        precond;
-        postcond;
-        run;
-      ]
+      ([ open_mod "STM"; warn ]
+      @ incl
+      @ [
+          sut;
+          cmd;
+          cmd_show;
+          state;
+          init_state;
+          init_sut;
+          cleanup;
+          arb_cmd;
+          next_state;
+          precond;
+          postcond;
+          run;
+        ])
   in
   let stm_spec =
     pstr_module (module_binding ~name:(noloc (Some "Spec")) ~expr:spec_expr)


### PR DESCRIPTION

This PR proposes to add an include option to the `qcheck-stm` cli. This will include the module passed as value of the option in the generated code. The idea is to allow the user to easily add `STM.ty` extensions and `STM.Utils.pp*`s without having to edit the generated file by hand.

This PR does not move the configuration in the included module (the `init_sut` expression and the `sut` type expression given by the user on the cli).