### PR TITLE
Varray example

### DIFF
--- a/.ocamlformat-ignore
+++ b/.ocamlformat-ignore
@@ -2,3 +2,4 @@ plugins/*/test/generated/*.expected.ml
 plugins/qcheck-stm/test/*.expected.ml
 examples/*spec.mli
 examples/*tests.ml
+examples/*sig.ml

--- a/dune-project
+++ b/dune-project
@@ -179,5 +179,6 @@
   ortac-qcheck-stm
   ortac-runtime
   qcheck-stm
-  lwt-dllist))
+  lwt-dllist
+  (varray (>= 0.2))))
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,8 +14,9 @@ specifically the `qcheck-stm` plugin.
 ## `lwt_dllist` library
 
 This is an example of relatively simple, yet not trivial, container library.
-The specifications make use of the Gospel `sequence` type (for more information,
-see [its documentation](https://ocaml-gospel.github.io/gospel/gospel/Gospelstdlib/Sequence/index.html).
+The specifications make use of the Gospel `sequence` type (for more
+information, see [its
+documentation](https://ocaml-gospel.github.io/gospel/gospel/Gospelstdlib/Sequence/index.html).
 
 Specifications for this library can be found in the edited copy of the
 interface `lwt_dllist_spec.mli`. There is one modification of the actual
@@ -27,9 +28,35 @@ need to be visible.
 The STM `postcond` function pattern match on the returned value encapsulated in
 a `STM.ty`. As functions `add_l` and `add_r` both return the node that has been
 added, we need to extend the `STM.ty` type with an encoding for
-`Lwt_dllist.node`. We add this extension in the external module `Lwt_dllist_incl`
-and pass it to the `--include` option of the `ortac qcheck-stm` command.
+`Lwt_dllist.node`. We add this extension in the external module
+`Lwt_dllist_incl` and pass it to the `--include` option of the `ortac
+qcheck-stm` command.
 
 The generated code can be found in `lwt_dllist_tests.ml`. You can run the test
 either with `dune runtest examples/` or by directly running the compiled
 executable that you will find in your `_build` directory.
+
+## `varray` library
+
+This is an example of a library exposing a Functor. In order to test a Functor,
+it is necessary to instantiate it. The
+[`varray`](https://github.com/art-w/varray) library already exposes some
+intantiations of its Functor. Here, we provide generated tests for two of them.
+
+The signature of the output of the Functor is originally placed in a `ml` file.
+`varray_sig.ml` is a copy of this file with some specifications. As Gospel
+doesn't process `ml` files, we extract the content of the module signature and
+place a copy in two files: `varray_spec.mli` and `varray_circular_spec.mli`,
+the former for the module exposed by `varray` as `Varray` and the latter for
+the module exposed by `varray` as `Varray.Circular`. The corresponding `ml`
+files are just the respective modules included. Note that we keep the two
+dune-generated `mli` files hidden in the `_build` folder.
+
+Here again, as for the previous example, we need to include some code. That is
+the extension of the `STM.ty` type. But also a `QCheck` generator for the `'a
+elt` type, as some functions of the library take arguments of this type. You
+can find these extensions in the `varray_incl.ml` file.
+
+The generated code can be found in the respective `varray*tests.ml` files. They
+have been promoted in the source tree in order to be easily accessible for
+reading and curiosity purposes, but this is not necessary for testing purposes.

--- a/examples/dune
+++ b/examples/dune
@@ -42,3 +42,110 @@
  (package ortac-examples)
  (action
   (run %{test} --verbose)))
+
+(library
+ (name varray_incl)
+ (modules varray_incl)
+ (libraries qcheck-stm.sequential qcheck-multicoretests-util varray_spec))
+
+(rule
+ (enabled_if %{bin-available:awk})
+ (deps
+  (:sig varray_sig.ml))
+ (targets varray_spec.mli)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run
+    awk
+    "/module type S = sig/,/^end/ { if ($0 != \"module type S = sig\" && $0 != \"end\") print }"
+    %{sig}))))
+
+(library
+ (name varray_spec)
+ (modules varray_spec)
+ (libraries varray)
+ (package ortac-examples))
+
+(rule
+ (mode promote)
+ (alias runtest)
+ (package ortac-examples)
+ (deps
+  (package ortac-qcheck-stm)
+  varray_incl.ml)
+ (targets varray_tests.ml)
+ (action
+  (setenv
+   ORTAC_ONLY_PLUGIN
+   qcheck-stm
+   (with-stdout-to
+    %{targets}
+    (run
+     ortac
+     qcheck-stm
+     varray_spec.mli
+     "make 42 'a'"
+     "char t"
+     --include=varray_incl
+     --quiet)))))
+
+(test
+ (name varray_tests)
+ (modules varray_tests)
+ (libraries
+  varray_incl
+  varray_spec
+  qcheck-stm.stm
+  qcheck-stm.sequential
+  qcheck-multicoretests-util
+  ortac-runtime)
+ (package ortac-examples)
+ (action
+  (run %{test} --verbose)))
+
+(rule
+ (copy varray_spec.mli varray_circular_spec.mli))
+
+(library
+ (name varray_circular_spec)
+ (modules varray_circular_spec)
+ (libraries varray)
+ (package ortac-examples))
+
+(rule
+ (mode promote)
+ (alias runtest)
+ (package ortac-examples)
+ (deps
+  (package ortac-qcheck-stm)
+  varray_incl.ml)
+ (targets varray_circular_tests.ml)
+ (action
+  (setenv
+   ORTAC_ONLY_PLUGIN
+   qcheck-stm
+   (with-stdout-to
+    %{targets}
+    (run
+     ortac
+     qcheck-stm
+     varray_circular_spec.mli
+     "make 42 'a'"
+     "char t"
+     --include=varray_incl
+     --quiet)))))
+
+(test
+ (name varray_circular_tests)
+ (modules varray_circular_tests)
+ (libraries
+  varray_incl
+  varray_circular_spec
+  qcheck-stm.stm
+  qcheck-stm.sequential
+  qcheck-multicoretests-util
+  ortac-runtime)
+ (package ortac-examples)
+ (action
+  (run %{test} --verbose)))

--- a/examples/varray_circular_spec.ml
+++ b/examples/varray_circular_spec.ml
@@ -1,0 +1,1 @@
+include Varray.Circular

--- a/examples/varray_circular_tests.ml
+++ b/examples/varray_circular_tests.ml
@@ -1,0 +1,1193 @@
+open Varray_circular_spec
+let inside i s =
+  try
+    if
+      let __t1__001_ =
+        Ortac_runtime.Gospelstdlib.(<=)
+          (Ortac_runtime.Gospelstdlib.integer_of_int 0) i in
+      let __t2__002_ =
+        Ortac_runtime.Gospelstdlib.(<) i
+          (Ortac_runtime.Gospelstdlib.Sequence.length s) in
+      __t1__001_ && __t2__002_
+    then true
+    else false
+  with
+  | e ->
+      raise
+        (Ortac_runtime.Partial_function
+           (e,
+             {
+               Ortac_runtime.start =
+                 {
+                   pos_fname = "varray_circular_spec.mli";
+                   pos_lnum = 4;
+                   pos_bol = 378;
+                   pos_cnum = 386
+                 };
+               Ortac_runtime.stop =
+                 {
+                   pos_fname = "varray_circular_spec.mli";
+                   pos_lnum = 4;
+                   pos_bol = 378;
+                   pos_cnum = 412
+                 }
+             }))
+let proj e =
+  try e
+  with
+  | e ->
+      raise
+        (Ortac_runtime.Partial_function
+           (e,
+             {
+               Ortac_runtime.start =
+                 {
+                   pos_fname = "varray_circular_spec.mli";
+                   pos_lnum = 14;
+                   pos_bol = 1130;
+                   pos_cnum = 1170
+                 };
+               Ortac_runtime.stop =
+                 {
+                   pos_fname = "varray_circular_spec.mli";
+                   pos_lnum = 14;
+                   pos_bol = 1130;
+                   pos_cnum = 1171
+                 }
+             }))
+module Spec =
+  struct
+    open STM
+    [@@@ocaml.warning "-26-27"]
+    include Varray_incl
+    type sut = char t
+    type cmd =
+      | Push_back of char elt 
+      | Pop_back 
+      | Push_front of char elt 
+      | Pop_front 
+      | Insert_at of int * char elt 
+      | Pop_at of int 
+      | Delete_at of int 
+      | Get of int 
+      | Set of int * char elt 
+      | Length 
+      | Is_empty 
+      | Fill of int * int * char elt 
+    let show_cmd cmd__003_ =
+      match cmd__003_ with
+      | Push_back x ->
+          Format.asprintf "%s %a" "push_back"
+            (Util.Pp.pp_elt Util.Pp.pp_char true) x
+      | Pop_back -> Format.asprintf "%s" "pop_back"
+      | Push_front x_1 ->
+          Format.asprintf "%s %a" "push_front"
+            (Util.Pp.pp_elt Util.Pp.pp_char true) x_1
+      | Pop_front -> Format.asprintf "%s" "pop_front"
+      | Insert_at (i_1, x_2) ->
+          Format.asprintf "%s %a %a" "insert_at" (Util.Pp.pp_int true) i_1
+            (Util.Pp.pp_elt Util.Pp.pp_char true) x_2
+      | Pop_at i_2 ->
+          Format.asprintf "%s %a" "pop_at" (Util.Pp.pp_int true) i_2
+      | Delete_at i_3 ->
+          Format.asprintf "%s %a" "delete_at" (Util.Pp.pp_int true) i_3
+      | Get i_4 -> Format.asprintf "%s %a" "get" (Util.Pp.pp_int true) i_4
+      | Set (i_5, v) ->
+          Format.asprintf "%s %a %a" "set" (Util.Pp.pp_int true) i_5
+            (Util.Pp.pp_elt Util.Pp.pp_char true) v
+      | Length -> Format.asprintf "%s" "length"
+      | Is_empty -> Format.asprintf "%s" "is_empty"
+      | Fill (pos, len, x_3) ->
+          Format.asprintf "%s %a %a %a" "fill" (Util.Pp.pp_int true) pos
+            (Util.Pp.pp_int true) len (Util.Pp.pp_elt Util.Pp.pp_char true)
+            x_3
+    type nonrec state = {
+      contents: char Ortac_runtime.Gospelstdlib.sequence }
+    let init_state =
+      let n = 42
+      and x_8 = 'a' in
+      {
+        contents =
+          (try
+             Ortac_runtime.Gospelstdlib.Sequence.init
+               (Ortac_runtime.Gospelstdlib.integer_of_int n)
+               (fun _ -> proj x_8)
+           with
+           | e ->
+               raise
+                 (Ortac_runtime.Partial_function
+                    (e,
+                      {
+                        Ortac_runtime.start =
+                          {
+                            pos_fname = "varray_circular_spec.mli";
+                            pos_lnum = 154;
+                            pos_bol = 9141;
+                            pos_cnum = 9168
+                          };
+                        Ortac_runtime.stop =
+                          {
+                            pos_fname = "varray_circular_spec.mli";
+                            pos_lnum = 154;
+                            pos_bol = 9141;
+                            pos_cnum = 9201
+                          }
+                      })))
+      }
+    let init_sut () = make 42 'a'
+    let cleanup _ = ()
+    let arb_cmd _ =
+      let open QCheck in
+        make ~print:show_cmd
+          (let open Gen in
+             oneof
+               [(pure (fun x -> Push_back x)) <*> (elt char);
+               pure Pop_back;
+               (pure (fun x_1 -> Push_front x_1)) <*> (elt char);
+               pure Pop_front;
+               ((pure (fun i_1 -> fun x_2 -> Insert_at (i_1, x_2))) <*> int)
+                 <*> (elt char);
+               (pure (fun i_2 -> Pop_at i_2)) <*> int;
+               (pure (fun i_3 -> Delete_at i_3)) <*> int;
+               (pure (fun i_4 -> Get i_4)) <*> int;
+               ((pure (fun i_5 -> fun v -> Set (i_5, v))) <*> int) <*>
+                 (elt char);
+               pure Length;
+               pure Is_empty;
+               (((pure
+                    (fun pos -> fun len -> fun x_3 -> Fill (pos, len, x_3)))
+                   <*> int)
+                  <*> int)
+                 <*> (elt char)])
+    let next_state cmd__004_ state__005_ =
+      match cmd__004_ with
+      | Push_back x ->
+          {
+            contents =
+              ((try
+                  Ortac_runtime.Gospelstdlib.Sequence.snoc
+                    state__005_.contents (proj x)
+                with
+                | e ->
+                    raise
+                      (Ortac_runtime.Partial_function
+                         (e,
+                           {
+                             Ortac_runtime.start =
+                               {
+                                 pos_fname = "varray_circular_spec.mli";
+                                 pos_lnum = 23;
+                                 pos_bol = 1629;
+                                 pos_cnum = 1656
+                               };
+                             Ortac_runtime.stop =
+                               {
+                                 pos_fname = "varray_circular_spec.mli";
+                                 pos_lnum = 23;
+                                 pos_bol = 1629;
+                                 pos_cnum = 1695
+                               }
+                           }))))
+          }
+      | Pop_back ->
+          {
+            contents =
+              ((try
+                  if
+                    state__005_.contents =
+                      Ortac_runtime.Gospelstdlib.Sequence.empty
+                  then Ortac_runtime.Gospelstdlib.Sequence.empty
+                  else
+                    Ortac_runtime.Gospelstdlib.__mix_Bddub
+                      state__005_.contents
+                      (Ortac_runtime.Gospelstdlib.(-)
+                         (Ortac_runtime.Gospelstdlib.Sequence.length
+                            state__005_.contents)
+                         (Ortac_runtime.Gospelstdlib.integer_of_int 2))
+                with
+                | e ->
+                    raise
+                      (Ortac_runtime.Partial_function
+                         (e,
+                           {
+                             Ortac_runtime.start =
+                               {
+                                 pos_fname = "varray_circular_spec.mli";
+                                 pos_lnum = 30;
+                                 pos_bol = 2142;
+                                 pos_cnum = 2169
+                               };
+                             Ortac_runtime.stop =
+                               {
+                                 pos_fname = "varray_circular_spec.mli";
+                                 pos_lnum = 32;
+                                 pos_bol = 2251;
+                                 pos_cnum = 2339
+                               }
+                           }))))
+          }
+      | Push_front x_1 ->
+          {
+            contents =
+              ((try
+                  Ortac_runtime.Gospelstdlib.Sequence.cons (proj x_1)
+                    state__005_.contents
+                with
+                | e ->
+                    raise
+                      (Ortac_runtime.Partial_function
+                         (e,
+                           {
+                             Ortac_runtime.start =
+                               {
+                                 pos_fname = "varray_circular_spec.mli";
+                                 pos_lnum = 44;
+                                 pos_bol = 3126;
+                                 pos_cnum = 3153
+                               };
+                             Ortac_runtime.stop =
+                               {
+                                 pos_fname = "varray_circular_spec.mli";
+                                 pos_lnum = 44;
+                                 pos_bol = 3126;
+                                 pos_cnum = 3192
+                               }
+                           }))))
+          }
+      | Pop_front ->
+          {
+            contents =
+              ((try
+                  if
+                    state__005_.contents =
+                      Ortac_runtime.Gospelstdlib.Sequence.empty
+                  then Ortac_runtime.Gospelstdlib.Sequence.empty
+                  else
+                    Ortac_runtime.Gospelstdlib.Sequence.tl
+                      state__005_.contents
+                with
+                | e ->
+                    raise
+                      (Ortac_runtime.Partial_function
+                         (e,
+                           {
+                             Ortac_runtime.start =
+                               {
+                                 pos_fname = "varray_circular_spec.mli";
+                                 pos_lnum = 53;
+                                 pos_bol = 3714;
+                                 pos_cnum = 3741
+                               };
+                             Ortac_runtime.stop =
+                               {
+                                 pos_fname = "varray_circular_spec.mli";
+                                 pos_lnum = 55;
+                                 pos_bol = 3823;
+                                 pos_cnum = 3883
+                               }
+                           }))))
+          }
+      | Insert_at (i_1, x_2) ->
+          if
+            (try
+               let __t1__008_ =
+                 Ortac_runtime.Gospelstdlib.(<=)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
+               let __t2__009_ =
+                 Ortac_runtime.Gospelstdlib.(<=)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
+                   (Ortac_runtime.Gospelstdlib.Sequence.length
+                      state__005_.contents) in
+               __t1__008_ && __t2__009_
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 72;
+                              pos_bol = 4784;
+                              pos_cnum = 4797
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 72;
+                              pos_bol = 4784;
+                              pos_cnum = 4833
+                            }
+                        })))
+          then
+            {
+              contents =
+                ((try
+                    if
+                      let __t1__006_ =
+                        Ortac_runtime.Gospelstdlib.(<=)
+                          (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                          (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
+                      let __t2__007_ =
+                        Ortac_runtime.Gospelstdlib.(<=)
+                          (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
+                          (Ortac_runtime.Gospelstdlib.Sequence.length
+                             state__005_.contents) in
+                      __t1__006_ && __t2__007_
+                    then
+                      Ortac_runtime.Gospelstdlib.(++)
+                        (Ortac_runtime.Gospelstdlib.__mix_Bddub
+                           state__005_.contents
+                           (Ortac_runtime.Gospelstdlib.(-)
+                              (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
+                              (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
+                        (Ortac_runtime.Gospelstdlib.Sequence.cons (proj x_2)
+                           (Ortac_runtime.Gospelstdlib.__mix_Buddb
+                              state__005_.contents
+                              (Ortac_runtime.Gospelstdlib.integer_of_int i_1)))
+                    else state__005_.contents
+                  with
+                  | e ->
+                      raise
+                        (Ortac_runtime.Partial_function
+                           (e,
+                             {
+                               Ortac_runtime.start =
+                                 {
+                                   pos_fname = "varray_circular_spec.mli";
+                                   pos_lnum = 74;
+                                   pos_bol = 4860;
+                                   pos_cnum = 4891
+                                 };
+                               Ortac_runtime.stop =
+                                 {
+                                   pos_fname = "varray_circular_spec.mli";
+                                   pos_lnum = 76;
+                                   pos_bol = 5033;
+                                   pos_cnum = 5081
+                                 }
+                             }))))
+            }
+          else state__005_
+      | Pop_at i_2 ->
+          if
+            (try
+               (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
+                  state__005_.contents)
+                 = true
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 89;
+                              pos_bol = 5727;
+                              pos_cnum = 5740
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 89;
+                              pos_bol = 5727;
+                              pos_cnum = 5759
+                            }
+                        })))
+          then
+            {
+              contents =
+                ((try
+                    Ortac_runtime.Gospelstdlib.(++)
+                      (Ortac_runtime.Gospelstdlib.__mix_Bddub
+                         state__005_.contents
+                         (Ortac_runtime.Gospelstdlib.(-)
+                            (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
+                            (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
+                      (Ortac_runtime.Gospelstdlib.__mix_Buddb
+                         state__005_.contents
+                         (Ortac_runtime.Gospelstdlib.(+)
+                            (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
+                            (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
+                  with
+                  | e ->
+                      raise
+                        (Ortac_runtime.Partial_function
+                           (e,
+                             {
+                               Ortac_runtime.start =
+                                 {
+                                   pos_fname = "varray_circular_spec.mli";
+                                   pos_lnum = 91;
+                                   pos_bol = 5786;
+                                   pos_cnum = 5838
+                                 };
+                               Ortac_runtime.stop =
+                                 {
+                                   pos_fname = "varray_circular_spec.mli";
+                                   pos_lnum = 91;
+                                   pos_bol = 5786;
+                                   pos_cnum = 5840
+                                 }
+                             }))))
+            }
+          else state__005_
+      | Delete_at i_3 ->
+          if
+            (try
+               (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
+                  state__005_.contents)
+                 = true
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 102;
+                              pos_bol = 6426;
+                              pos_cnum = 6439
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 102;
+                              pos_bol = 6426;
+                              pos_cnum = 6458
+                            }
+                        })))
+          then
+            {
+              contents =
+                ((try
+                    Ortac_runtime.Gospelstdlib.(++)
+                      (Ortac_runtime.Gospelstdlib.__mix_Bddub
+                         state__005_.contents
+                         (Ortac_runtime.Gospelstdlib.(-)
+                            (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
+                            (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
+                      (Ortac_runtime.Gospelstdlib.__mix_Buddb
+                         state__005_.contents
+                         (Ortac_runtime.Gospelstdlib.(+)
+                            (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
+                            (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
+                  with
+                  | e ->
+                      raise
+                        (Ortac_runtime.Partial_function
+                           (e,
+                             {
+                               Ortac_runtime.start =
+                                 {
+                                   pos_fname = "varray_circular_spec.mli";
+                                   pos_lnum = 104;
+                                   pos_bol = 6485;
+                                   pos_cnum = 6537
+                                 };
+                               Ortac_runtime.stop =
+                                 {
+                                   pos_fname = "varray_circular_spec.mli";
+                                   pos_lnum = 104;
+                                   pos_bol = 6485;
+                                   pos_cnum = 6539
+                                 }
+                             }))))
+            }
+          else state__005_
+      | Get i_4 -> state__005_
+      | Set (i_5, v) ->
+          if
+            (try
+               (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_5)
+                  state__005_.contents)
+                 = true
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 137;
+                              pos_bol = 8077;
+                              pos_cnum = 8090
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 137;
+                              pos_bol = 8077;
+                              pos_cnum = 8109
+                            }
+                        })))
+          then
+            {
+              contents =
+                ((try
+                    Ortac_runtime.Gospelstdlib.Sequence.set
+                      state__005_.contents
+                      (Ortac_runtime.Gospelstdlib.integer_of_int i_5)
+                      (proj v)
+                  with
+                  | e ->
+                      raise
+                        (Ortac_runtime.Partial_function
+                           (e,
+                             {
+                               Ortac_runtime.start =
+                                 {
+                                   pos_fname = "varray_circular_spec.mli";
+                                   pos_lnum = 139;
+                                   pos_bol = 8136;
+                                   pos_cnum = 8163
+                                 };
+                               Ortac_runtime.stop =
+                                 {
+                                   pos_fname = "varray_circular_spec.mli";
+                                   pos_lnum = 139;
+                                   pos_bol = 8136;
+                                   pos_cnum = 8203
+                                 }
+                             }))))
+            }
+          else state__005_
+      | Length -> state__005_
+      | Is_empty -> state__005_
+      | Fill (pos, len, x_3) ->
+          if
+            (try
+               let __t1__012_ =
+                 Ortac_runtime.Gospelstdlib.(<=)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int pos) in
+               let __t2__013_ =
+                 let __t1__014_ =
+                   Ortac_runtime.Gospelstdlib.(<=)
+                     (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                     (Ortac_runtime.Gospelstdlib.integer_of_int len) in
+                 let __t2__015_ =
+                   Ortac_runtime.Gospelstdlib.(<)
+                     (Ortac_runtime.Gospelstdlib.(+)
+                        (Ortac_runtime.Gospelstdlib.integer_of_int pos)
+                        (Ortac_runtime.Gospelstdlib.integer_of_int len))
+                     (Ortac_runtime.Gospelstdlib.Sequence.length
+                        state__005_.contents) in
+                 __t1__014_ && __t2__015_ in
+               __t1__012_ && __t2__013_
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 211;
+                              pos_bol = 12981;
+                              pos_cnum = 12994
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 211;
+                              pos_bol = 12981;
+                              pos_cnum = 13056
+                            }
+                        })))
+          then
+            {
+              contents =
+                ((try
+                    Ortac_runtime.Gospelstdlib.Sequence.init
+                      (Ortac_runtime.Gospelstdlib.Sequence.length
+                         state__005_.contents)
+                      (fun i_6 ->
+                         if
+                           let __t1__010_ =
+                             Ortac_runtime.Gospelstdlib.(<=)
+                               (Ortac_runtime.Gospelstdlib.integer_of_int pos)
+                               i_6 in
+                           let __t2__011_ =
+                             Ortac_runtime.Gospelstdlib.(<) i_6
+                               (Ortac_runtime.Gospelstdlib.(+)
+                                  (Ortac_runtime.Gospelstdlib.integer_of_int
+                                     pos)
+                                  (Ortac_runtime.Gospelstdlib.integer_of_int
+                                     len)) in
+                           __t1__010_ && __t2__011_
+                         then proj x_3
+                         else
+                           Ortac_runtime.Gospelstdlib.__mix_Bub
+                             state__005_.contents i_6)
+                  with
+                  | e ->
+                      raise
+                        (Ortac_runtime.Partial_function
+                           (e,
+                             {
+                               Ortac_runtime.start =
+                                 {
+                                   pos_fname = "varray_circular_spec.mli";
+                                   pos_lnum = 213;
+                                   pos_bol = 13083;
+                                   pos_cnum = 13110
+                                 };
+                               Ortac_runtime.stop =
+                                 {
+                                   pos_fname = "varray_circular_spec.mli";
+                                   pos_lnum = 213;
+                                   pos_bol = 13083;
+                                   pos_cnum = 13230
+                                 }
+                             }))))
+            }
+          else state__005_
+    let precond cmd__030_ state__031_ =
+      match cmd__030_ with
+      | Push_back x -> true
+      | Pop_back -> true
+      | Push_front x_1 -> true
+      | Pop_front -> true
+      | Insert_at (i_1, x_2) -> true
+      | Pop_at i_2 -> true
+      | Delete_at i_3 -> true
+      | Get i_4 -> true
+      | Set (i_5, v) -> true
+      | Length -> true
+      | Is_empty -> true
+      | Fill (pos, len, x_3) -> true
+    let postcond cmd__016_ state__017_ res__018_ =
+      let new_state__019_ = lazy (next_state cmd__016_ state__017_) in
+      match (cmd__016_, res__018_) with
+      | (Push_back x, Res ((Unit, _), _)) -> true
+      | (Pop_back, Res ((Result (Elt (Char), Exn), _), x_4)) ->
+          (match x_4 with
+           | Ok x_4 ->
+               (try
+                  if
+                    state__017_.contents =
+                      Ortac_runtime.Gospelstdlib.Sequence.empty
+                  then false
+                  else
+                    (proj x_4) =
+                      (Ortac_runtime.Gospelstdlib.__mix_Bub
+                         state__017_.contents
+                         (Ortac_runtime.Gospelstdlib.(-)
+                            (Ortac_runtime.Gospelstdlib.Sequence.length
+                               state__017_.contents)
+                            (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
+                with
+                | e ->
+                    raise
+                      (Ortac_runtime.Partial_function
+                         (e,
+                           {
+                             Ortac_runtime.start =
+                               {
+                                 pos_fname = "varray_circular_spec.mli";
+                                 pos_lnum = 33;
+                                 pos_bol = 2340;
+                                 pos_cnum = 2354
+                               };
+                             Ortac_runtime.stop =
+                               {
+                                 pos_fname = "varray_circular_spec.mli";
+                                 pos_lnum = 35;
+                                 pos_bol = 2414;
+                                 pos_cnum = 2496
+                               }
+                           })))
+           | Error (Not_found) ->
+               (try
+                  let __t1__020_ =
+                    (Lazy.force new_state__019_).contents =
+                      state__017_.contents in
+                  let __t2__021_ =
+                    state__017_.contents =
+                      Ortac_runtime.Gospelstdlib.Sequence.empty in
+                  __t1__020_ && __t2__021_
+                with
+                | e ->
+                    raise
+                      (Ortac_runtime.Partial_function
+                         (e,
+                           {
+                             Ortac_runtime.start =
+                               {
+                                 pos_fname = "varray_circular_spec.mli";
+                                 pos_lnum = 36;
+                                 pos_bol = 2497;
+                                 pos_cnum = 2523
+                               };
+                             Ortac_runtime.stop =
+                               {
+                                 pos_fname = "varray_circular_spec.mli";
+                                 pos_lnum = 36;
+                                 pos_bol = 2497;
+                                 pos_cnum = 2567
+                               }
+                           })))
+           | _ -> false)
+      | (Push_front x_1, Res ((Unit, _), _)) -> true
+      | (Pop_front, Res ((Result (Elt (Char), Exn), _), x_5)) ->
+          (match x_5 with
+           | Ok x_5 ->
+               (try
+                  if
+                    state__017_.contents =
+                      Ortac_runtime.Gospelstdlib.Sequence.empty
+                  then false
+                  else
+                    (proj x_5) =
+                      (Ortac_runtime.Gospelstdlib.Sequence.hd
+                         state__017_.contents)
+                with
+                | e ->
+                    raise
+                      (Ortac_runtime.Partial_function
+                         (e,
+                           {
+                             Ortac_runtime.start =
+                               {
+                                 pos_fname = "varray_circular_spec.mli";
+                                 pos_lnum = 56;
+                                 pos_bol = 3884;
+                                 pos_cnum = 3898
+                               };
+                             Ortac_runtime.stop =
+                               {
+                                 pos_fname = "varray_circular_spec.mli";
+                                 pos_lnum = 58;
+                                 pos_bol = 3958;
+                                 pos_cnum = 4014
+                               }
+                           })))
+           | Error (Not_found) ->
+               (try
+                  let __t1__022_ =
+                    (Lazy.force new_state__019_).contents =
+                      state__017_.contents in
+                  let __t2__023_ =
+                    state__017_.contents =
+                      Ortac_runtime.Gospelstdlib.Sequence.empty in
+                  __t1__022_ && __t2__023_
+                with
+                | e ->
+                    raise
+                      (Ortac_runtime.Partial_function
+                         (e,
+                           {
+                             Ortac_runtime.start =
+                               {
+                                 pos_fname = "varray_circular_spec.mli";
+                                 pos_lnum = 59;
+                                 pos_bol = 4015;
+                                 pos_cnum = 4041
+                               };
+                             Ortac_runtime.stop =
+                               {
+                                 pos_fname = "varray_circular_spec.mli";
+                                 pos_lnum = 59;
+                                 pos_bol = 4015;
+                                 pos_cnum = 4085
+                               }
+                           })))
+           | _ -> false)
+      | (Insert_at (i_1, x_2), Res ((Result (Unit, Exn), _), res)) ->
+          if
+            (try
+               let __t1__024_ =
+                 Ortac_runtime.Gospelstdlib.(<=)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
+               let __t2__025_ =
+                 Ortac_runtime.Gospelstdlib.(<=)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
+                   (Ortac_runtime.Gospelstdlib.Sequence.length
+                      state__017_.contents) in
+               __t1__024_ && __t2__025_
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 72;
+                              pos_bol = 4784;
+                              pos_cnum = 4797
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 72;
+                              pos_bol = 4784;
+                              pos_cnum = 4833
+                            }
+                        })))
+          then (match res with | Ok _ -> true | _ -> false)
+          else
+            (match res with | Error (Invalid_argument _) -> true | _ -> false)
+      | (Pop_at i_2, Res ((Result (Elt (Char), Exn), _), x_6)) ->
+          if
+            (try
+               (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
+                  state__017_.contents)
+                 = true
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 89;
+                              pos_bol = 5727;
+                              pos_cnum = 5740
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 89;
+                              pos_bol = 5727;
+                              pos_cnum = 5759
+                            }
+                        })))
+          then
+            (match x_6 with
+             | Ok x_6 ->
+                 (try
+                    (proj x_6) =
+                      (Ortac_runtime.Gospelstdlib.__mix_Bub
+                         state__017_.contents
+                         (Ortac_runtime.Gospelstdlib.integer_of_int i_2))
+                  with
+                  | e ->
+                      raise
+                        (Ortac_runtime.Partial_function
+                           (e,
+                             {
+                               Ortac_runtime.start =
+                                 {
+                                   pos_fname = "varray_circular_spec.mli";
+                                   pos_lnum = 92;
+                                   pos_bol = 5864;
+                                   pos_cnum = 5878
+                                 };
+                               Ortac_runtime.stop =
+                                 {
+                                   pos_fname = "varray_circular_spec.mli";
+                                   pos_lnum = 92;
+                                   pos_bol = 5864;
+                                   pos_cnum = 5906
+                                 }
+                             })))
+             | _ -> false)
+          else
+            (match x_6 with | Error (Invalid_argument _) -> true | _ -> false)
+      | (Delete_at i_3, Res ((Result (Unit, Exn), _), res)) ->
+          if
+            (try
+               (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
+                  state__017_.contents)
+                 = true
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 102;
+                              pos_bol = 6426;
+                              pos_cnum = 6439
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 102;
+                              pos_bol = 6426;
+                              pos_cnum = 6458
+                            }
+                        })))
+          then
+            (match res with
+             | Ok _ ->
+                 (try
+                    (Ortac_runtime.Gospelstdlib.Sequence.length
+                       (Lazy.force new_state__019_).contents)
+                      =
+                      (Ortac_runtime.Gospelstdlib.(-)
+                         (Ortac_runtime.Gospelstdlib.Sequence.length
+                            state__017_.contents)
+                         (Ortac_runtime.Gospelstdlib.integer_of_int 1))
+                  with
+                  | e ->
+                      raise
+                        (Ortac_runtime.Partial_function
+                           (e,
+                             {
+                               Ortac_runtime.start =
+                                 {
+                                   pos_fname = "varray_circular_spec.mli";
+                                   pos_lnum = 105;
+                                   pos_bol = 6563;
+                                   pos_cnum = 6577
+                                 };
+                               Ortac_runtime.stop =
+                                 {
+                                   pos_fname = "varray_circular_spec.mli";
+                                   pos_lnum = 105;
+                                   pos_bol = 6563;
+                                   pos_cnum = 6642
+                                 }
+                             })))
+             | _ -> false)
+          else
+            (match res with | Error (Invalid_argument _) -> true | _ -> false)
+      | (Get i_4, Res ((Result (Elt (Char), Exn), _), x_7)) ->
+          if
+            (try
+               (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_4)
+                  state__017_.contents)
+                 = true
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 128;
+                              pos_bol = 7616;
+                              pos_cnum = 7629
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 128;
+                              pos_bol = 7616;
+                              pos_cnum = 7648
+                            }
+                        })))
+          then
+            (match x_7 with
+             | Ok x_7 ->
+                 (try
+                    (proj x_7) =
+                      (Ortac_runtime.Gospelstdlib.__mix_Bub
+                         (Lazy.force new_state__019_).contents
+                         (Ortac_runtime.Gospelstdlib.integer_of_int i_4))
+                  with
+                  | e ->
+                      raise
+                        (Ortac_runtime.Partial_function
+                           (e,
+                             {
+                               Ortac_runtime.start =
+                                 {
+                                   pos_fname = "varray_circular_spec.mli";
+                                   pos_lnum = 127;
+                                   pos_bol = 7577;
+                                   pos_cnum = 7591
+                                 };
+                               Ortac_runtime.stop =
+                                 {
+                                   pos_fname = "varray_circular_spec.mli";
+                                   pos_lnum = 127;
+                                   pos_bol = 7577;
+                                   pos_cnum = 7615
+                                 }
+                             })))
+             | _ -> false)
+          else
+            (match x_7 with | Error (Invalid_argument _) -> true | _ -> false)
+      | (Set (i_5, v), Res ((Result (Unit, Exn), _), res)) ->
+          if
+            (try
+               (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_5)
+                  state__017_.contents)
+                 = true
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 137;
+                              pos_bol = 8077;
+                              pos_cnum = 8090
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 137;
+                              pos_bol = 8077;
+                              pos_cnum = 8109
+                            }
+                        })))
+          then (match res with | Ok _ -> true | _ -> false)
+          else
+            (match res with | Error (Invalid_argument _) -> true | _ -> false)
+      | (Length, Res ((Int, _), l)) ->
+          (try
+             (Ortac_runtime.Gospelstdlib.integer_of_int l) =
+               (Ortac_runtime.Gospelstdlib.Sequence.length
+                  (Lazy.force new_state__019_).contents)
+           with
+           | e ->
+               raise
+                 (Ortac_runtime.Partial_function
+                    (e,
+                      {
+                        Ortac_runtime.start =
+                          {
+                            pos_fname = "varray_circular_spec.mli";
+                            pos_lnum = 144;
+                            pos_bol = 8634;
+                            pos_cnum = 8648
+                          };
+                        Ortac_runtime.stop =
+                          {
+                            pos_fname = "varray_circular_spec.mli";
+                            pos_lnum = 144;
+                            pos_bol = 8634;
+                            pos_cnum = 8678
+                          }
+                      })))
+      | (Is_empty, Res ((Bool, _), b)) ->
+          (try
+             (b = true) =
+               ((Lazy.force new_state__019_).contents =
+                  Ortac_runtime.Gospelstdlib.Sequence.empty)
+           with
+           | e ->
+               raise
+                 (Ortac_runtime.Partial_function
+                    (e,
+                      {
+                        Ortac_runtime.start =
+                          {
+                            pos_fname = "varray_circular_spec.mli";
+                            pos_lnum = 171;
+                            pos_bol = 10238;
+                            pos_cnum = 10252
+                          };
+                        Ortac_runtime.stop =
+                          {
+                            pos_fname = "varray_circular_spec.mli";
+                            pos_lnum = 171;
+                            pos_bol = 10238;
+                            pos_cnum = 10285
+                          }
+                      })))
+      | (Fill (pos, len, x_3), Res ((Result (Unit, Exn), _), res)) ->
+          if
+            (try
+               let __t1__026_ =
+                 Ortac_runtime.Gospelstdlib.(<=)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int pos) in
+               let __t2__027_ =
+                 let __t1__028_ =
+                   Ortac_runtime.Gospelstdlib.(<=)
+                     (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                     (Ortac_runtime.Gospelstdlib.integer_of_int len) in
+                 let __t2__029_ =
+                   Ortac_runtime.Gospelstdlib.(<)
+                     (Ortac_runtime.Gospelstdlib.(+)
+                        (Ortac_runtime.Gospelstdlib.integer_of_int pos)
+                        (Ortac_runtime.Gospelstdlib.integer_of_int len))
+                     (Ortac_runtime.Gospelstdlib.Sequence.length
+                        state__017_.contents) in
+                 __t1__028_ && __t2__029_ in
+               __t1__026_ && __t2__027_
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 211;
+                              pos_bol = 12981;
+                              pos_cnum = 12994
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_circular_spec.mli";
+                              pos_lnum = 211;
+                              pos_bol = 12981;
+                              pos_cnum = 13056
+                            }
+                        })))
+          then (match res with | Ok _ -> true | _ -> false)
+          else
+            (match res with | Error (Invalid_argument _) -> true | _ -> false)
+      | _ -> true
+    let run cmd__032_ sut__033_ =
+      match cmd__032_ with
+      | Push_back x -> Res (unit, (push_back sut__033_ x))
+      | Pop_back ->
+          Res
+            ((result (elt char) exn),
+              (protect (fun () -> pop_back sut__033_) ()))
+      | Push_front x_1 -> Res (unit, (push_front sut__033_ x_1))
+      | Pop_front ->
+          Res
+            ((result (elt char) exn),
+              (protect (fun () -> pop_front sut__033_) ()))
+      | Insert_at (i_1, x_2) ->
+          Res
+            ((result unit exn),
+              (protect (fun () -> insert_at sut__033_ i_1 x_2) ()))
+      | Pop_at i_2 ->
+          Res
+            ((result (elt char) exn),
+              (protect (fun () -> pop_at sut__033_ i_2) ()))
+      | Delete_at i_3 ->
+          Res
+            ((result unit exn),
+              (protect (fun () -> delete_at sut__033_ i_3) ()))
+      | Get i_4 ->
+          Res
+            ((result (elt char) exn),
+              (protect (fun () -> get sut__033_ i_4) ()))
+      | Set (i_5, v) ->
+          Res
+            ((result unit exn), (protect (fun () -> set sut__033_ i_5 v) ()))
+      | Length -> Res (int, (length sut__033_))
+      | Is_empty -> Res (bool, (is_empty sut__033_))
+      | Fill (pos, len, x_3) ->
+          Res
+            ((result unit exn),
+              (protect (fun () -> fill sut__033_ pos len x_3) ()))
+  end
+module STMTests = (STM_sequential.Make)(Spec)
+let _ =
+  QCheck_base_runner.run_tests_main
+    (let count = 1000 in
+     [STMTests.agree_test ~count ~name:"Varray_circular_spec STM tests"])

--- a/examples/varray_incl.ml
+++ b/examples/varray_incl.ml
@@ -1,0 +1,27 @@
+module Util = struct
+  module Pp = struct
+    include Util.Pp
+
+    let pp_elt pp = pp
+  end
+end
+
+module QCheck = struct
+  include QCheck
+
+  module Gen = struct
+    include QCheck.Gen
+
+    let int = small_signed_int
+    let elt gen = gen
+  end
+end
+
+open STM
+open Varray_spec
+
+type _ ty += Elt : 'a ty -> 'a elt ty
+
+let elt spec =
+  let ty, show = spec in
+  (Elt ty, fun x -> Printf.sprintf "Elt %s" (show x))

--- a/examples/varray_sig.ml
+++ b/examples/varray_sig.ml
@@ -1,0 +1,465 @@
+module type ARRAY = sig
+  (** The array will be used partially, with some elements in an undefined
+      state.  It is guaranteed that all operations always use valid indexes.
+  *)
+
+  type 'a t
+  (** The type of an array. *)
+
+  type 'a elt
+  (** The type of elements contained in the array. *)
+
+  val length : 'a t -> int
+  (** The size of the array; the maximum number of elements that can be stored
+      inside. *)
+
+  val empty : unit -> 'a t
+  (** An empty array of length [0]. *)
+
+  val create : int -> 'a t
+  (** [create n] returns an array of length [n]. Its elements are all in
+      an undefined state and will not be accessed by {! get} before being
+      defined by {! set} or {! blit}. *)
+
+  val get : 'a t -> int -> 'a elt
+  (** [get t i] returns the [i]th element of the array.
+      The elements are numbered from [0] to [length t - 1] and the index [i] is
+      always within this bound: this function be implemented as an
+      [unsafe_get]) if available. *)
+
+  val set : 'a t -> int -> 'a elt -> unit
+  (** [set t i v] modifies [t] in place, replacing the element at position [i]
+      with the value [v]. From now on, the element at this index is defined.
+      Again, this can be implemented as an [unsafe_set] without bound checking.
+  *)
+
+  val erase_at : 'a t -> int -> unit
+  (** [erase_at t i] resets the element at position [i]. It is an opportunity
+      to free the memory of the value [t.(i)]. From now on, the element is
+      undefined and this index will not be accessed again until a write is
+      done. *)
+
+  val blit : 'a t -> int -> 'a t -> int -> int -> unit
+  (** [blit src i dst j n] copies the elements from the range [i,i+n-1] from
+      the array [src] to the range [j,j+n-1] of the array [dst]. All the
+      elements copied from [src] are guaranteed to be in a defined state.
+      After this operation, the corresponding range in [dst] will be defined.
+      The copied ranges will be valid for each array. Special care is required
+      during the copy since [src] will often be the same array as [dst] and the
+      ranges can overlap. *)
+end
+
+module type TIER = sig
+  module Array : ARRAY
+  type 'a elt = 'a Array.elt
+  type 'a array = 'a Array.t
+
+  type 'a t
+
+  val depth : int
+
+  val empty : unit -> 'a t
+  val is_empty : 'a t -> bool
+  val root_capacity : 'a t -> int
+
+  val create : capacity:int -> 'a t
+  val make : lc:int -> int -> 'a elt -> 'a t
+  val init : lc:int -> offset:int -> int -> (int -> 'a elt) -> 'a t
+
+  val length : 'a t -> int
+  val capacity : lc:int -> int
+
+  val get : lc:int -> 'a t -> int -> 'a elt
+  val set : lc:int -> 'a t -> int -> 'a elt -> unit
+
+  val pop_front : lc:int -> 'a t -> 'a elt
+  val pop_back : lc:int -> 'a t -> 'a elt
+  val pop_at : lc:int -> 'a t -> int -> 'a elt
+
+  val push_front : lc:int -> 'a t -> 'a elt -> unit
+  val push_back : lc:int -> 'a t -> 'a elt -> unit
+
+  val is_full : lc:int -> 'a t -> bool
+
+  val push_front_pop_back : lc:int -> 'a t -> 'a elt -> 'a elt
+  val push_back_pop_front : lc:int -> 'a t -> 'a elt -> 'a elt
+
+  val insert_at : lc:int -> 'a t -> int -> 'a elt -> unit
+end
+
+module type VARRAY = sig
+  type 'a t
+  type 'a elt
+  type 'a array
+
+  val push_back : 'a t -> 'a elt -> unit
+  val pop_back : 'a t -> 'a elt
+
+  val push_front : 'a t -> 'a elt -> unit
+  val pop_front : 'a t -> 'a elt
+
+  val insert_at : 'a t -> int -> 'a elt -> unit
+  val pop_at : 'a t -> int -> 'a elt
+  val delete_at : 'a t -> int -> unit
+
+  val get : 'a t -> int -> 'a elt
+  val set : 'a t -> int -> 'a elt -> unit
+
+  val length : 'a t -> int
+  val make : int -> 'a elt -> 'a t
+  val init : int -> (int -> 'a elt) -> 'a t
+  val empty : unit -> 'a t
+  val is_empty : 'a t -> bool
+
+  val protect : 'a t -> (unit -> 'b) -> 'b
+
+  module Tier : TIER with type 'a Array.elt = 'a elt
+                      and type 'a Array.t = 'a array
+end
+
+module type S = sig
+
+  (** inside is a helper function to check that an index is not out of bound *)
+  (*@ function inside (i : integer) (s : 'a sequence) : bool =
+        0 <= i < Sequence.length s *)
+
+  type 'a t
+  (** The type of a varray. *)
+  (*@ mutable model contents : 'a sequence *)
+
+  type 'a elt = 'a
+  (** The type of elements stored in the varray. *)
+
+  (** A projection function to read the element of the array *)
+  (*@ function proj (e : 'a elt) : 'a = e *)
+
+  (** {1 Dynamic collection} *)
+
+  val push_back : 'a t -> 'a elt -> unit
+  (** [push_back t x] adds a new element [x] at the end of the varray [t].
+      {b O(k)} amortized. *)
+  (*@ push_back t x
+      modifies t.contents
+      ensures t.contents = Sequence.snoc (old t.contents) (proj x) *)
+
+  val pop_back : 'a t -> 'a elt
+  (** [pop_back t] removes and returns the rightmost element of the varray [t].
+      {b O(k)} amortized. *)
+  (*@ x = pop_back t
+      modifies t.contents
+      ensures t.contents = if old t.contents = Sequence.empty
+                           then Sequence.empty
+                           else (old t.contents)[..Sequence.length (old t.contents) - 2]
+      ensures if old t.contents = Sequence.empty
+              then false
+              else proj x = (old t.contents)[Sequence.length (old t.contents) - 1]
+      raises Not_found -> t.contents = old t.contents = Sequence.empty *)
+
+  val push_front : 'a t -> 'a elt -> unit
+  (** [push_front t x] inserts a new element [x] at position [0], on the left
+      side of the varray [t]. Every previous element of [t] is shifted one to
+      the right. {b O(k)} amortized. *)
+  (*@ push_front t x
+      modifies t.contents
+      ensures t.contents = Sequence.cons (proj x) (old t.contents) *)
+
+
+  val pop_front : 'a t -> 'a elt
+  (** [pop_front t] removes and returns the leftmost element at position [0] of
+      the varray [t]. Every element of [t] is shifted one to the right.
+      {b O(k)} amortized. *)
+  (*@ x = pop_front t
+      modifies t.contents
+      ensures t.contents = if old t.contents = Sequence.empty
+                           then Sequence.empty
+                           else Sequence.tl (old t.contents)
+      ensures if old t.contents = Sequence.empty
+              then false
+              else proj x = Sequence.hd (old t.contents)
+      raises Not_found -> t.contents = old t.contents = Sequence.empty *)
+
+  val insert_at : 'a t -> int -> 'a elt -> unit
+  (** [insert_at t i x] inserts the element [x] at position [i] in the varray
+      [t]. Every element on the right of [i] is shifted by one.
+      {b O(k² × {%html:<sup>k</sup>%}√N)}
+
+      - [insert_at t 0 x] is the same as [push_front t x]
+      - [insert_at t (length t) x] is the same as [push_back t x]
+
+      @raise Invalid_arg if [i] is negative or larger than [length t].
+  *)
+  (*@ insert_at t i x
+      checks 0 <= i <= Sequence.length t.contents
+      modifies t.contents
+      ensures t.contents = old (if 0 <= i <= Sequence.length t.contents
+                                then t.contents[..i - 1] ++ (Sequence.cons (proj x) t.contents[i..])
+                                else t.contents) *)
+
+  val pop_at : 'a t -> int -> 'a elt
+  (** [pop_at t i] removes and returns the element [t.(i)]. Every element on
+      the right of [i] is shifted by one to the left.
+      {b O(k² × {%html:<sup>k</sup>%}√N)}
+
+      - [pop_at t 0] is the same as [pop_front t]
+      - [pop_at t (length t - 1)] is the same as [pop_back t]
+
+      @raise Invalid_arg if [i] is negative or larger than [length t - 1].
+  *)
+  (*@ x = pop_at t i
+      checks inside i t.contents
+      modifies t.contents
+      ensures t.contents = old (t.contents[..i - 1] ++ t.contents[(i + 1)..])
+      ensures (proj x) = old t.contents[i] *)
+
+  val delete_at : 'a t -> int -> unit
+  (** [delete_at t i] removes the element [t.(i)]. Every element on the right
+      of [i] is shifted by one to the left.
+      {b O(k² × {%html:<sup>k</sup>%}√N)}
+
+      @raise Invalid_arg if [i] is negative or larger than [length t - 1].
+  *)
+  (*@ delete_at t i
+      checks inside i t.contents
+      modifies t.contents
+      ensures t.contents = old (t.contents[..i - 1] ++ t.contents[(i + 1)..])
+      ensures Sequence.length t.contents = Sequence.length (old t.contents) - 1 *)
+
+  (** {1 Freeze during traversals} *)
+
+  (** The previous operations all fail when the varray is being traversed: *)
+
+  val protect : 'a t -> (unit -> 'b) -> 'b
+  (** [protect t fn] marks [t] as protected during the execution of [fn ()].
+      All operations that would update the length of [t] by pushing or poping
+      elements will raise a [Failure] indicating that the traversal is unsafe.
+  *)
+
+  (** {1 Array} *)
+
+  val get : 'a t -> int -> 'a elt
+  (** [get t i] returns the [i]th element of the varray. Indexing starts from
+      [0] upto [length t - 1]. {b O(k)}
+
+      @raise Invalid_argument if [i] is negative
+      or larger than [length t - 1].
+  *)
+  (*@ x = get t i
+      ensures (proj x) = t.contents[i]
+      checks inside i t.contents *)
+
+  val set : 'a t -> int -> 'a elt -> unit
+  (** [set t i v] updates the value of the [i]th element to [x]. {b O(k)}
+
+      @raise Invalid_argument if [i] is negative
+      or larger than [length t - 1].
+  *)
+  (*@ set t i v
+      checks inside i t.contents
+      modifies t.contents
+      ensures t.contents = Sequence.set (old t.contents) i (proj v) *)
+
+  val length : 'a t -> int
+  (** [length t] returns the number of elements stored in [t]. {b O(1)} *)
+  (*@ l = length t
+      ensures l = Sequence.length t.contents *)
+
+  val make : int -> 'a elt -> 'a t
+  (** [make n x] returns a new varray of length [n], where all the elements are
+      initialized to the value [x].
+
+      @raise Invalid_argument if [n] is negative.
+  *)
+  (*@ t = make n x
+      checks n >= 0
+      ensures t.contents = Sequence.init n (fun _ -> proj x) *)
+
+  val init : int -> (int -> 'a elt) -> 'a t
+  (** [init n f] returns a new array of length [n], where the element at
+      position [i] is initialized to [f i].
+
+      @raise Invalid_argument if [n] is negative.
+  *)
+
+  val empty : unit -> 'a t
+  (** [empty ()] is a new varray of length [0]. *)
+  (*@ t = empty ()
+      ensures t.contents = Sequence.empty *)
+
+  val is_empty : 'a t -> bool
+  (** [is_empty t] returns true when the varray [t] has length [0]. *)
+  (*@ b = is_empty t
+      ensures b <-> t.contents = Sequence.empty *)
+
+  (** {1 Copying elements} *)
+
+  val append : 'a t -> 'a t -> 'a t
+  (** [append a b] returns a new varray by concatening the elements of [a] with
+      those of [b]. *)
+  (*@ t = append a b
+      ensures t.contents = a.contents ++ b.contents *)
+
+  val concat : 'a t list -> 'a t
+  (** [concat ts] returns a new varray whose elements are in the same order as
+      the values from the list of varrays [ts]. *)
+  (*@ t = concat ts
+      ensures t.contents = List.fold_left (fun acc s -> acc ++ s.contents) Sequence.empty ts *)
+
+  val sub : 'a t -> int -> int -> 'a t
+  (** [sub t i n] returns a new varray of length [n], containing the elements
+      from the range [i, i+n-1] of the varray [t].
+
+      @raise Invalid_argument if the range [i, i + n - 1] is invalid for [t].
+  *)
+  (*@ r = sub t i n
+      checks 0 <= i < Sequence.length t.contents
+      checks n = 0 \/ i <= i + n - 1 < Sequence.length t.contents
+      ensures r.contents = if n = 0 then Sequence.empty else t.contents[i..i+n-1] *)
+
+  val copy : 'a t -> 'a t
+  (** [copy t] returns a new varray containing the same sequence of
+      elements as [t]. *)
+  (*@ r = copy t
+      ensures r.contents = t.contents *)
+
+  val fill : 'a t -> int -> int -> 'a elt -> unit
+  (** [fill t pos len x] modifies the varray [t] in place, by setting the value
+      [x] in the range [pos, pos + len - 1].
+
+      @raise Invalid_argument if the range [pos, pos + len -1] is invalid.
+  *)
+  (*@ fill t pos len x
+      checks 0 <= pos /\ 0 <= len /\ pos + len < Sequence.length t.contents
+      modifies t.contents
+      ensures t.contents = Sequence.init (Sequence.length (old t.contents)) (fun i -> if pos <= i < pos + len then proj x else (old t.contents)[i]) *)
+
+  val blit : 'a t -> int -> 'a t -> int -> int -> unit
+  (** [blit src src_pos dst dst_pos len] updates the varray [dst] in place, by
+      copying the range [src_pos, src_pos + len - 1] of values from [src] into
+      the destination range [dst_pos, dst_pos + len - 1] of [dst].
+
+      @raise Invalid_argument if the ranges are invalid for either varray.
+  *)
+  (*@ blit src src_pos dst dst_pos len
+      checks 0 <= src_pos < Sequence.length src.contents
+      checks len = 0 \/ src_pos < src_pos + len < Sequence.length src.contents
+      checks 0 <= dst_pos < Sequence.length dst.contents
+      checks len = 0 \/ dst_pos < dst_pos + len < Sequence.length dst.contents
+      modifies dst.contents
+      ensures dst.contents = old (dst.contents[..dst_pos] ++ src.contents[src_pos..src_pos + len - 1] ++ dst.contents[dst_pos + len..]) *)
+
+  (** {1 Traversals} *)
+
+  val iter : ('a elt -> unit) -> 'a t -> unit
+  (** [iter f t] calls the function [f] on all elements of [t], from left to
+      right. *)
+
+  val iteri : (int -> 'a elt -> unit) -> 'a t -> unit
+  (** [iteri f t] calls [f i t.(i)] on all the indexes [i] of [t],
+      from left to right. *)
+
+  val map : ('a elt -> 'b elt) -> 'a t -> 'b t
+  (** [map f t] returns a new varray, whose elements are [f x] for each [x]
+      from the varray [t]. *)
+
+  val mapi : (int -> 'a elt -> 'b elt) -> 'a t -> 'b t
+  (** [mapi f t] returns a new varray, whose elements are [f i t.(i)] for each
+      index [i] of the varray [t]. *)
+
+  val fold_left : ('a -> 'b elt -> 'a) -> 'a -> 'b t -> 'a
+  (** [fold_left f z t] computes
+      [f (... (f (f z t.(0)) t.(1)) ...) t.(length t - 1)]. *)
+
+  val fold_right : ('a elt -> 'b -> 'b) -> 'a t -> 'b -> 'b
+  (** [fold_right f t z] computes
+      [f t.(0) (f t.(1) (... (f z t.(length t - 1))))]. *)
+
+  val fold_left_map : ('a -> 'b elt -> 'a * 'c elt) -> 'a -> 'b t -> 'a * 'c t
+  (** [fold_left_map] is a combination of [fold_left] and [map],
+      that threads an accumulator. *)
+
+  (** {1 Iterators on two varrays} *)
+
+  val iter2 : ('a elt -> 'b elt -> unit) -> 'a t -> 'b t -> unit
+  (** [iter2 f xs ys] calls [f xs.(i) ys.(i)] for each index [i] from left to
+      right.
+
+      @raise Invalid_argument if the two varrays have different lengths.
+  *)
+
+  val map2 : ('a elt -> 'b elt -> 'c elt) -> 'a t -> 'b t -> 'c t
+  (** [map2 f xs ys] returns a new varray whose [i]th element is
+      [f xs.(i) ys.(i)].
+
+      @raise Invalid_argument if the two varrays have different lengths.
+  *)
+
+  (** {1 Predicates} *)
+
+  val for_all : ('a elt -> bool) -> 'a t -> bool
+  (** [for_all f t] holds when [f] is satisfied by all the elements of [t]. *)
+
+  val for_all2 : ('a elt -> 'b elt -> bool) -> 'a t -> 'b t -> bool
+  (** [for_all2 f xs ys] holds when [f xs.(i) ys.(i)] is satisfied by all
+      indexes [i].
+
+      @raise Invalid_argument if the two varrays have different lengths.
+  *)
+
+  val exists : ('a elt -> bool) -> 'a t -> bool
+  (** [exists f t] holds when [f] is satisfied by one of the elements of
+      [t]. *)
+
+  val exists2 : ('a elt -> 'b elt -> bool) -> 'a t -> 'b t -> bool
+  (** [exists2 f xs ys] holds when an index [i] exists such that
+      [f xs.(i) ys.(i)] is satisfied.
+
+      @raise Invalid_argument if the two varrays have different lengths.
+  *)
+
+  val find_opt : ('a elt -> bool) -> 'a t -> 'a elt option
+  (** [find_opt f t] returns the leftmost element of [t] that satisfies [f]. *)
+
+  val find_map : ('a elt -> 'b option) -> 'a t -> 'b option
+  (** [find_map f t] returns the first result of [f] of the form [Some v]. *)
+
+  val mem : 'a elt -> 'a t -> bool
+  (** [mem x t] is true when [x] is equal [( = )] to an element of the varray
+      [t]. *)
+
+  val memq : 'a elt -> 'a t -> bool
+  (** Same as [mem], but [memq x t] uses physical equality [( == )] for
+      comparison. *)
+
+  (** {1 Sort} *)
+
+  val sort : ('a elt -> 'a elt -> int) -> 'a t -> unit
+  (** [sort cmp t] updates [t] inplace by sorting the elements in increasing
+      order according to [cmp]. *)
+
+  val stable_sort : ('a elt -> 'a elt -> int) -> 'a t -> unit
+  (** Same as [sort], but equal elements are kept in the same relative
+      order. *)
+
+  val fast_sort : ('a elt -> 'a elt -> int) -> 'a t -> unit
+  (** Same as [sort]. *)
+
+  (** {1 Conversions} *)
+
+  type 'a array
+  (** The array type used behind the scene as a backend by the varray. *)
+
+  val of_array : 'a array -> 'a t
+  (** [of_array arr] returns a new varray containing all the elements of the
+      array [arr]. *)
+
+  val to_array : 'a t -> 'a array
+  (** [to_array t] returns a new array containing all the elements of the
+      varray [t]. *)
+
+  val of_list : 'a elt list -> 'a t
+  (** [of_list xs] returns a new varray containing all the elements of the list
+      [xs]. *)
+
+  val to_list : 'a t -> 'a elt list
+  (** [to_list t] returns a list of all the elements of [t]. *)
+end

--- a/examples/varray_spec.ml
+++ b/examples/varray_spec.ml
@@ -1,0 +1,1 @@
+include Varray

--- a/examples/varray_tests.ml
+++ b/examples/varray_tests.ml
@@ -1,0 +1,1193 @@
+open Varray_spec
+let inside i s =
+  try
+    if
+      let __t1__001_ =
+        Ortac_runtime.Gospelstdlib.(<=)
+          (Ortac_runtime.Gospelstdlib.integer_of_int 0) i in
+      let __t2__002_ =
+        Ortac_runtime.Gospelstdlib.(<) i
+          (Ortac_runtime.Gospelstdlib.Sequence.length s) in
+      __t1__001_ && __t2__002_
+    then true
+    else false
+  with
+  | e ->
+      raise
+        (Ortac_runtime.Partial_function
+           (e,
+             {
+               Ortac_runtime.start =
+                 {
+                   pos_fname = "varray_spec.mli";
+                   pos_lnum = 4;
+                   pos_bol = 342;
+                   pos_cnum = 350
+                 };
+               Ortac_runtime.stop =
+                 {
+                   pos_fname = "varray_spec.mli";
+                   pos_lnum = 4;
+                   pos_bol = 342;
+                   pos_cnum = 376
+                 }
+             }))
+let proj e =
+  try e
+  with
+  | e ->
+      raise
+        (Ortac_runtime.Partial_function
+           (e,
+             {
+               Ortac_runtime.start =
+                 {
+                   pos_fname = "varray_spec.mli";
+                   pos_lnum = 14;
+                   pos_bol = 1022;
+                   pos_cnum = 1062
+                 };
+               Ortac_runtime.stop =
+                 {
+                   pos_fname = "varray_spec.mli";
+                   pos_lnum = 14;
+                   pos_bol = 1022;
+                   pos_cnum = 1063
+                 }
+             }))
+module Spec =
+  struct
+    open STM
+    [@@@ocaml.warning "-26-27"]
+    include Varray_incl
+    type sut = char t
+    type cmd =
+      | Push_back of char elt 
+      | Pop_back 
+      | Push_front of char elt 
+      | Pop_front 
+      | Insert_at of int * char elt 
+      | Pop_at of int 
+      | Delete_at of int 
+      | Get of int 
+      | Set of int * char elt 
+      | Length 
+      | Is_empty 
+      | Fill of int * int * char elt 
+    let show_cmd cmd__003_ =
+      match cmd__003_ with
+      | Push_back x ->
+          Format.asprintf "%s %a" "push_back"
+            (Util.Pp.pp_elt Util.Pp.pp_char true) x
+      | Pop_back -> Format.asprintf "%s" "pop_back"
+      | Push_front x_1 ->
+          Format.asprintf "%s %a" "push_front"
+            (Util.Pp.pp_elt Util.Pp.pp_char true) x_1
+      | Pop_front -> Format.asprintf "%s" "pop_front"
+      | Insert_at (i_1, x_2) ->
+          Format.asprintf "%s %a %a" "insert_at" (Util.Pp.pp_int true) i_1
+            (Util.Pp.pp_elt Util.Pp.pp_char true) x_2
+      | Pop_at i_2 ->
+          Format.asprintf "%s %a" "pop_at" (Util.Pp.pp_int true) i_2
+      | Delete_at i_3 ->
+          Format.asprintf "%s %a" "delete_at" (Util.Pp.pp_int true) i_3
+      | Get i_4 -> Format.asprintf "%s %a" "get" (Util.Pp.pp_int true) i_4
+      | Set (i_5, v) ->
+          Format.asprintf "%s %a %a" "set" (Util.Pp.pp_int true) i_5
+            (Util.Pp.pp_elt Util.Pp.pp_char true) v
+      | Length -> Format.asprintf "%s" "length"
+      | Is_empty -> Format.asprintf "%s" "is_empty"
+      | Fill (pos, len, x_3) ->
+          Format.asprintf "%s %a %a %a" "fill" (Util.Pp.pp_int true) pos
+            (Util.Pp.pp_int true) len (Util.Pp.pp_elt Util.Pp.pp_char true)
+            x_3
+    type nonrec state = {
+      contents: char Ortac_runtime.Gospelstdlib.sequence }
+    let init_state =
+      let n = 42
+      and x_8 = 'a' in
+      {
+        contents =
+          (try
+             Ortac_runtime.Gospelstdlib.Sequence.init
+               (Ortac_runtime.Gospelstdlib.integer_of_int n)
+               (fun _ -> proj x_8)
+           with
+           | e ->
+               raise
+                 (Ortac_runtime.Partial_function
+                    (e,
+                      {
+                        Ortac_runtime.start =
+                          {
+                            pos_fname = "varray_spec.mli";
+                            pos_lnum = 154;
+                            pos_bol = 8637;
+                            pos_cnum = 8664
+                          };
+                        Ortac_runtime.stop =
+                          {
+                            pos_fname = "varray_spec.mli";
+                            pos_lnum = 154;
+                            pos_bol = 8637;
+                            pos_cnum = 8697
+                          }
+                      })))
+      }
+    let init_sut () = make 42 'a'
+    let cleanup _ = ()
+    let arb_cmd _ =
+      let open QCheck in
+        make ~print:show_cmd
+          (let open Gen in
+             oneof
+               [(pure (fun x -> Push_back x)) <*> (elt char);
+               pure Pop_back;
+               (pure (fun x_1 -> Push_front x_1)) <*> (elt char);
+               pure Pop_front;
+               ((pure (fun i_1 -> fun x_2 -> Insert_at (i_1, x_2))) <*> int)
+                 <*> (elt char);
+               (pure (fun i_2 -> Pop_at i_2)) <*> int;
+               (pure (fun i_3 -> Delete_at i_3)) <*> int;
+               (pure (fun i_4 -> Get i_4)) <*> int;
+               ((pure (fun i_5 -> fun v -> Set (i_5, v))) <*> int) <*>
+                 (elt char);
+               pure Length;
+               pure Is_empty;
+               (((pure
+                    (fun pos -> fun len -> fun x_3 -> Fill (pos, len, x_3)))
+                   <*> int)
+                  <*> int)
+                 <*> (elt char)])
+    let next_state cmd__004_ state__005_ =
+      match cmd__004_ with
+      | Push_back x ->
+          {
+            contents =
+              ((try
+                  Ortac_runtime.Gospelstdlib.Sequence.snoc
+                    state__005_.contents (proj x)
+                with
+                | e ->
+                    raise
+                      (Ortac_runtime.Partial_function
+                         (e,
+                           {
+                             Ortac_runtime.start =
+                               {
+                                 pos_fname = "varray_spec.mli";
+                                 pos_lnum = 23;
+                                 pos_bol = 1485;
+                                 pos_cnum = 1512
+                               };
+                             Ortac_runtime.stop =
+                               {
+                                 pos_fname = "varray_spec.mli";
+                                 pos_lnum = 23;
+                                 pos_bol = 1485;
+                                 pos_cnum = 1551
+                               }
+                           }))))
+          }
+      | Pop_back ->
+          {
+            contents =
+              ((try
+                  if
+                    state__005_.contents =
+                      Ortac_runtime.Gospelstdlib.Sequence.empty
+                  then Ortac_runtime.Gospelstdlib.Sequence.empty
+                  else
+                    Ortac_runtime.Gospelstdlib.__mix_Bddub
+                      state__005_.contents
+                      (Ortac_runtime.Gospelstdlib.(-)
+                         (Ortac_runtime.Gospelstdlib.Sequence.length
+                            state__005_.contents)
+                         (Ortac_runtime.Gospelstdlib.integer_of_int 2))
+                with
+                | e ->
+                    raise
+                      (Ortac_runtime.Partial_function
+                         (e,
+                           {
+                             Ortac_runtime.start =
+                               {
+                                 pos_fname = "varray_spec.mli";
+                                 pos_lnum = 30;
+                                 pos_bol = 1962;
+                                 pos_cnum = 1989
+                               };
+                             Ortac_runtime.stop =
+                               {
+                                 pos_fname = "varray_spec.mli";
+                                 pos_lnum = 32;
+                                 pos_bol = 2071;
+                                 pos_cnum = 2159
+                               }
+                           }))))
+          }
+      | Push_front x_1 ->
+          {
+            contents =
+              ((try
+                  Ortac_runtime.Gospelstdlib.Sequence.cons (proj x_1)
+                    state__005_.contents
+                with
+                | e ->
+                    raise
+                      (Ortac_runtime.Partial_function
+                         (e,
+                           {
+                             Ortac_runtime.start =
+                               {
+                                 pos_fname = "varray_spec.mli";
+                                 pos_lnum = 44;
+                                 pos_bol = 2910;
+                                 pos_cnum = 2937
+                               };
+                             Ortac_runtime.stop =
+                               {
+                                 pos_fname = "varray_spec.mli";
+                                 pos_lnum = 44;
+                                 pos_bol = 2910;
+                                 pos_cnum = 2976
+                               }
+                           }))))
+          }
+      | Pop_front ->
+          {
+            contents =
+              ((try
+                  if
+                    state__005_.contents =
+                      Ortac_runtime.Gospelstdlib.Sequence.empty
+                  then Ortac_runtime.Gospelstdlib.Sequence.empty
+                  else
+                    Ortac_runtime.Gospelstdlib.Sequence.tl
+                      state__005_.contents
+                with
+                | e ->
+                    raise
+                      (Ortac_runtime.Partial_function
+                         (e,
+                           {
+                             Ortac_runtime.start =
+                               {
+                                 pos_fname = "varray_spec.mli";
+                                 pos_lnum = 53;
+                                 pos_bol = 3462;
+                                 pos_cnum = 3489
+                               };
+                             Ortac_runtime.stop =
+                               {
+                                 pos_fname = "varray_spec.mli";
+                                 pos_lnum = 55;
+                                 pos_bol = 3571;
+                                 pos_cnum = 3631
+                               }
+                           }))))
+          }
+      | Insert_at (i_1, x_2) ->
+          if
+            (try
+               let __t1__008_ =
+                 Ortac_runtime.Gospelstdlib.(<=)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
+               let __t2__009_ =
+                 Ortac_runtime.Gospelstdlib.(<=)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
+                   (Ortac_runtime.Gospelstdlib.Sequence.length
+                      state__005_.contents) in
+               __t1__008_ && __t2__009_
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 72;
+                              pos_bol = 4496;
+                              pos_cnum = 4509
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 72;
+                              pos_bol = 4496;
+                              pos_cnum = 4545
+                            }
+                        })))
+          then
+            {
+              contents =
+                ((try
+                    if
+                      let __t1__006_ =
+                        Ortac_runtime.Gospelstdlib.(<=)
+                          (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                          (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
+                      let __t2__007_ =
+                        Ortac_runtime.Gospelstdlib.(<=)
+                          (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
+                          (Ortac_runtime.Gospelstdlib.Sequence.length
+                             state__005_.contents) in
+                      __t1__006_ && __t2__007_
+                    then
+                      Ortac_runtime.Gospelstdlib.(++)
+                        (Ortac_runtime.Gospelstdlib.__mix_Bddub
+                           state__005_.contents
+                           (Ortac_runtime.Gospelstdlib.(-)
+                              (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
+                              (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
+                        (Ortac_runtime.Gospelstdlib.Sequence.cons (proj x_2)
+                           (Ortac_runtime.Gospelstdlib.__mix_Buddb
+                              state__005_.contents
+                              (Ortac_runtime.Gospelstdlib.integer_of_int i_1)))
+                    else state__005_.contents
+                  with
+                  | e ->
+                      raise
+                        (Ortac_runtime.Partial_function
+                           (e,
+                             {
+                               Ortac_runtime.start =
+                                 {
+                                   pos_fname = "varray_spec.mli";
+                                   pos_lnum = 74;
+                                   pos_bol = 4572;
+                                   pos_cnum = 4603
+                                 };
+                               Ortac_runtime.stop =
+                                 {
+                                   pos_fname = "varray_spec.mli";
+                                   pos_lnum = 76;
+                                   pos_bol = 4745;
+                                   pos_cnum = 4793
+                                 }
+                             }))))
+            }
+          else state__005_
+      | Pop_at i_2 ->
+          if
+            (try
+               (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
+                  state__005_.contents)
+                 = true
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 89;
+                              pos_bol = 5403;
+                              pos_cnum = 5416
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 89;
+                              pos_bol = 5403;
+                              pos_cnum = 5435
+                            }
+                        })))
+          then
+            {
+              contents =
+                ((try
+                    Ortac_runtime.Gospelstdlib.(++)
+                      (Ortac_runtime.Gospelstdlib.__mix_Bddub
+                         state__005_.contents
+                         (Ortac_runtime.Gospelstdlib.(-)
+                            (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
+                            (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
+                      (Ortac_runtime.Gospelstdlib.__mix_Buddb
+                         state__005_.contents
+                         (Ortac_runtime.Gospelstdlib.(+)
+                            (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
+                            (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
+                  with
+                  | e ->
+                      raise
+                        (Ortac_runtime.Partial_function
+                           (e,
+                             {
+                               Ortac_runtime.start =
+                                 {
+                                   pos_fname = "varray_spec.mli";
+                                   pos_lnum = 91;
+                                   pos_bol = 5462;
+                                   pos_cnum = 5514
+                                 };
+                               Ortac_runtime.stop =
+                                 {
+                                   pos_fname = "varray_spec.mli";
+                                   pos_lnum = 91;
+                                   pos_bol = 5462;
+                                   pos_cnum = 5516
+                                 }
+                             }))))
+            }
+          else state__005_
+      | Delete_at i_3 ->
+          if
+            (try
+               (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
+                  state__005_.contents)
+                 = true
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 102;
+                              pos_bol = 6066;
+                              pos_cnum = 6079
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 102;
+                              pos_bol = 6066;
+                              pos_cnum = 6098
+                            }
+                        })))
+          then
+            {
+              contents =
+                ((try
+                    Ortac_runtime.Gospelstdlib.(++)
+                      (Ortac_runtime.Gospelstdlib.__mix_Bddub
+                         state__005_.contents
+                         (Ortac_runtime.Gospelstdlib.(-)
+                            (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
+                            (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
+                      (Ortac_runtime.Gospelstdlib.__mix_Buddb
+                         state__005_.contents
+                         (Ortac_runtime.Gospelstdlib.(+)
+                            (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
+                            (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
+                  with
+                  | e ->
+                      raise
+                        (Ortac_runtime.Partial_function
+                           (e,
+                             {
+                               Ortac_runtime.start =
+                                 {
+                                   pos_fname = "varray_spec.mli";
+                                   pos_lnum = 104;
+                                   pos_bol = 6125;
+                                   pos_cnum = 6177
+                                 };
+                               Ortac_runtime.stop =
+                                 {
+                                   pos_fname = "varray_spec.mli";
+                                   pos_lnum = 104;
+                                   pos_bol = 6125;
+                                   pos_cnum = 6179
+                                 }
+                             }))))
+            }
+          else state__005_
+      | Get i_4 -> state__005_
+      | Set (i_5, v) ->
+          if
+            (try
+               (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_5)
+                  state__005_.contents)
+                 = true
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 137;
+                              pos_bol = 7645;
+                              pos_cnum = 7658
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 137;
+                              pos_bol = 7645;
+                              pos_cnum = 7677
+                            }
+                        })))
+          then
+            {
+              contents =
+                ((try
+                    Ortac_runtime.Gospelstdlib.Sequence.set
+                      state__005_.contents
+                      (Ortac_runtime.Gospelstdlib.integer_of_int i_5)
+                      (proj v)
+                  with
+                  | e ->
+                      raise
+                        (Ortac_runtime.Partial_function
+                           (e,
+                             {
+                               Ortac_runtime.start =
+                                 {
+                                   pos_fname = "varray_spec.mli";
+                                   pos_lnum = 139;
+                                   pos_bol = 7704;
+                                   pos_cnum = 7731
+                                 };
+                               Ortac_runtime.stop =
+                                 {
+                                   pos_fname = "varray_spec.mli";
+                                   pos_lnum = 139;
+                                   pos_bol = 7704;
+                                   pos_cnum = 7771
+                                 }
+                             }))))
+            }
+          else state__005_
+      | Length -> state__005_
+      | Is_empty -> state__005_
+      | Fill (pos, len, x_3) ->
+          if
+            (try
+               let __t1__012_ =
+                 Ortac_runtime.Gospelstdlib.(<=)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int pos) in
+               let __t2__013_ =
+                 let __t1__014_ =
+                   Ortac_runtime.Gospelstdlib.(<=)
+                     (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                     (Ortac_runtime.Gospelstdlib.integer_of_int len) in
+                 let __t2__015_ =
+                   Ortac_runtime.Gospelstdlib.(<)
+                     (Ortac_runtime.Gospelstdlib.(+)
+                        (Ortac_runtime.Gospelstdlib.integer_of_int pos)
+                        (Ortac_runtime.Gospelstdlib.integer_of_int len))
+                     (Ortac_runtime.Gospelstdlib.Sequence.length
+                        state__005_.contents) in
+                 __t1__014_ && __t2__015_ in
+               __t1__012_ && __t2__013_
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 211;
+                              pos_bol = 12225;
+                              pos_cnum = 12238
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 211;
+                              pos_bol = 12225;
+                              pos_cnum = 12300
+                            }
+                        })))
+          then
+            {
+              contents =
+                ((try
+                    Ortac_runtime.Gospelstdlib.Sequence.init
+                      (Ortac_runtime.Gospelstdlib.Sequence.length
+                         state__005_.contents)
+                      (fun i_6 ->
+                         if
+                           let __t1__010_ =
+                             Ortac_runtime.Gospelstdlib.(<=)
+                               (Ortac_runtime.Gospelstdlib.integer_of_int pos)
+                               i_6 in
+                           let __t2__011_ =
+                             Ortac_runtime.Gospelstdlib.(<) i_6
+                               (Ortac_runtime.Gospelstdlib.(+)
+                                  (Ortac_runtime.Gospelstdlib.integer_of_int
+                                     pos)
+                                  (Ortac_runtime.Gospelstdlib.integer_of_int
+                                     len)) in
+                           __t1__010_ && __t2__011_
+                         then proj x_3
+                         else
+                           Ortac_runtime.Gospelstdlib.__mix_Bub
+                             state__005_.contents i_6)
+                  with
+                  | e ->
+                      raise
+                        (Ortac_runtime.Partial_function
+                           (e,
+                             {
+                               Ortac_runtime.start =
+                                 {
+                                   pos_fname = "varray_spec.mli";
+                                   pos_lnum = 213;
+                                   pos_bol = 12327;
+                                   pos_cnum = 12354
+                                 };
+                               Ortac_runtime.stop =
+                                 {
+                                   pos_fname = "varray_spec.mli";
+                                   pos_lnum = 213;
+                                   pos_bol = 12327;
+                                   pos_cnum = 12474
+                                 }
+                             }))))
+            }
+          else state__005_
+    let precond cmd__030_ state__031_ =
+      match cmd__030_ with
+      | Push_back x -> true
+      | Pop_back -> true
+      | Push_front x_1 -> true
+      | Pop_front -> true
+      | Insert_at (i_1, x_2) -> true
+      | Pop_at i_2 -> true
+      | Delete_at i_3 -> true
+      | Get i_4 -> true
+      | Set (i_5, v) -> true
+      | Length -> true
+      | Is_empty -> true
+      | Fill (pos, len, x_3) -> true
+    let postcond cmd__016_ state__017_ res__018_ =
+      let new_state__019_ = lazy (next_state cmd__016_ state__017_) in
+      match (cmd__016_, res__018_) with
+      | (Push_back x, Res ((Unit, _), _)) -> true
+      | (Pop_back, Res ((Result (Elt (Char), Exn), _), x_4)) ->
+          (match x_4 with
+           | Ok x_4 ->
+               (try
+                  if
+                    state__017_.contents =
+                      Ortac_runtime.Gospelstdlib.Sequence.empty
+                  then false
+                  else
+                    (proj x_4) =
+                      (Ortac_runtime.Gospelstdlib.__mix_Bub
+                         state__017_.contents
+                         (Ortac_runtime.Gospelstdlib.(-)
+                            (Ortac_runtime.Gospelstdlib.Sequence.length
+                               state__017_.contents)
+                            (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
+                with
+                | e ->
+                    raise
+                      (Ortac_runtime.Partial_function
+                         (e,
+                           {
+                             Ortac_runtime.start =
+                               {
+                                 pos_fname = "varray_spec.mli";
+                                 pos_lnum = 33;
+                                 pos_bol = 2160;
+                                 pos_cnum = 2174
+                               };
+                             Ortac_runtime.stop =
+                               {
+                                 pos_fname = "varray_spec.mli";
+                                 pos_lnum = 35;
+                                 pos_bol = 2234;
+                                 pos_cnum = 2316
+                               }
+                           })))
+           | Error (Not_found) ->
+               (try
+                  let __t1__020_ =
+                    (Lazy.force new_state__019_).contents =
+                      state__017_.contents in
+                  let __t2__021_ =
+                    state__017_.contents =
+                      Ortac_runtime.Gospelstdlib.Sequence.empty in
+                  __t1__020_ && __t2__021_
+                with
+                | e ->
+                    raise
+                      (Ortac_runtime.Partial_function
+                         (e,
+                           {
+                             Ortac_runtime.start =
+                               {
+                                 pos_fname = "varray_spec.mli";
+                                 pos_lnum = 36;
+                                 pos_bol = 2317;
+                                 pos_cnum = 2343
+                               };
+                             Ortac_runtime.stop =
+                               {
+                                 pos_fname = "varray_spec.mli";
+                                 pos_lnum = 36;
+                                 pos_bol = 2317;
+                                 pos_cnum = 2387
+                               }
+                           })))
+           | _ -> false)
+      | (Push_front x_1, Res ((Unit, _), _)) -> true
+      | (Pop_front, Res ((Result (Elt (Char), Exn), _), x_5)) ->
+          (match x_5 with
+           | Ok x_5 ->
+               (try
+                  if
+                    state__017_.contents =
+                      Ortac_runtime.Gospelstdlib.Sequence.empty
+                  then false
+                  else
+                    (proj x_5) =
+                      (Ortac_runtime.Gospelstdlib.Sequence.hd
+                         state__017_.contents)
+                with
+                | e ->
+                    raise
+                      (Ortac_runtime.Partial_function
+                         (e,
+                           {
+                             Ortac_runtime.start =
+                               {
+                                 pos_fname = "varray_spec.mli";
+                                 pos_lnum = 56;
+                                 pos_bol = 3632;
+                                 pos_cnum = 3646
+                               };
+                             Ortac_runtime.stop =
+                               {
+                                 pos_fname = "varray_spec.mli";
+                                 pos_lnum = 58;
+                                 pos_bol = 3706;
+                                 pos_cnum = 3762
+                               }
+                           })))
+           | Error (Not_found) ->
+               (try
+                  let __t1__022_ =
+                    (Lazy.force new_state__019_).contents =
+                      state__017_.contents in
+                  let __t2__023_ =
+                    state__017_.contents =
+                      Ortac_runtime.Gospelstdlib.Sequence.empty in
+                  __t1__022_ && __t2__023_
+                with
+                | e ->
+                    raise
+                      (Ortac_runtime.Partial_function
+                         (e,
+                           {
+                             Ortac_runtime.start =
+                               {
+                                 pos_fname = "varray_spec.mli";
+                                 pos_lnum = 59;
+                                 pos_bol = 3763;
+                                 pos_cnum = 3789
+                               };
+                             Ortac_runtime.stop =
+                               {
+                                 pos_fname = "varray_spec.mli";
+                                 pos_lnum = 59;
+                                 pos_bol = 3763;
+                                 pos_cnum = 3833
+                               }
+                           })))
+           | _ -> false)
+      | (Insert_at (i_1, x_2), Res ((Result (Unit, Exn), _), res)) ->
+          if
+            (try
+               let __t1__024_ =
+                 Ortac_runtime.Gospelstdlib.(<=)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
+               let __t2__025_ =
+                 Ortac_runtime.Gospelstdlib.(<=)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
+                   (Ortac_runtime.Gospelstdlib.Sequence.length
+                      state__017_.contents) in
+               __t1__024_ && __t2__025_
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 72;
+                              pos_bol = 4496;
+                              pos_cnum = 4509
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 72;
+                              pos_bol = 4496;
+                              pos_cnum = 4545
+                            }
+                        })))
+          then (match res with | Ok _ -> true | _ -> false)
+          else
+            (match res with | Error (Invalid_argument _) -> true | _ -> false)
+      | (Pop_at i_2, Res ((Result (Elt (Char), Exn), _), x_6)) ->
+          if
+            (try
+               (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
+                  state__017_.contents)
+                 = true
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 89;
+                              pos_bol = 5403;
+                              pos_cnum = 5416
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 89;
+                              pos_bol = 5403;
+                              pos_cnum = 5435
+                            }
+                        })))
+          then
+            (match x_6 with
+             | Ok x_6 ->
+                 (try
+                    (proj x_6) =
+                      (Ortac_runtime.Gospelstdlib.__mix_Bub
+                         state__017_.contents
+                         (Ortac_runtime.Gospelstdlib.integer_of_int i_2))
+                  with
+                  | e ->
+                      raise
+                        (Ortac_runtime.Partial_function
+                           (e,
+                             {
+                               Ortac_runtime.start =
+                                 {
+                                   pos_fname = "varray_spec.mli";
+                                   pos_lnum = 92;
+                                   pos_bol = 5540;
+                                   pos_cnum = 5554
+                                 };
+                               Ortac_runtime.stop =
+                                 {
+                                   pos_fname = "varray_spec.mli";
+                                   pos_lnum = 92;
+                                   pos_bol = 5540;
+                                   pos_cnum = 5582
+                                 }
+                             })))
+             | _ -> false)
+          else
+            (match x_6 with | Error (Invalid_argument _) -> true | _ -> false)
+      | (Delete_at i_3, Res ((Result (Unit, Exn), _), res)) ->
+          if
+            (try
+               (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
+                  state__017_.contents)
+                 = true
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 102;
+                              pos_bol = 6066;
+                              pos_cnum = 6079
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 102;
+                              pos_bol = 6066;
+                              pos_cnum = 6098
+                            }
+                        })))
+          then
+            (match res with
+             | Ok _ ->
+                 (try
+                    (Ortac_runtime.Gospelstdlib.Sequence.length
+                       (Lazy.force new_state__019_).contents)
+                      =
+                      (Ortac_runtime.Gospelstdlib.(-)
+                         (Ortac_runtime.Gospelstdlib.Sequence.length
+                            state__017_.contents)
+                         (Ortac_runtime.Gospelstdlib.integer_of_int 1))
+                  with
+                  | e ->
+                      raise
+                        (Ortac_runtime.Partial_function
+                           (e,
+                             {
+                               Ortac_runtime.start =
+                                 {
+                                   pos_fname = "varray_spec.mli";
+                                   pos_lnum = 105;
+                                   pos_bol = 6203;
+                                   pos_cnum = 6217
+                                 };
+                               Ortac_runtime.stop =
+                                 {
+                                   pos_fname = "varray_spec.mli";
+                                   pos_lnum = 105;
+                                   pos_bol = 6203;
+                                   pos_cnum = 6282
+                                 }
+                             })))
+             | _ -> false)
+          else
+            (match res with | Error (Invalid_argument _) -> true | _ -> false)
+      | (Get i_4, Res ((Result (Elt (Char), Exn), _), x_7)) ->
+          if
+            (try
+               (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_4)
+                  state__017_.contents)
+                 = true
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 128;
+                              pos_bol = 7220;
+                              pos_cnum = 7233
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 128;
+                              pos_bol = 7220;
+                              pos_cnum = 7252
+                            }
+                        })))
+          then
+            (match x_7 with
+             | Ok x_7 ->
+                 (try
+                    (proj x_7) =
+                      (Ortac_runtime.Gospelstdlib.__mix_Bub
+                         (Lazy.force new_state__019_).contents
+                         (Ortac_runtime.Gospelstdlib.integer_of_int i_4))
+                  with
+                  | e ->
+                      raise
+                        (Ortac_runtime.Partial_function
+                           (e,
+                             {
+                               Ortac_runtime.start =
+                                 {
+                                   pos_fname = "varray_spec.mli";
+                                   pos_lnum = 127;
+                                   pos_bol = 7181;
+                                   pos_cnum = 7195
+                                 };
+                               Ortac_runtime.stop =
+                                 {
+                                   pos_fname = "varray_spec.mli";
+                                   pos_lnum = 127;
+                                   pos_bol = 7181;
+                                   pos_cnum = 7219
+                                 }
+                             })))
+             | _ -> false)
+          else
+            (match x_7 with | Error (Invalid_argument _) -> true | _ -> false)
+      | (Set (i_5, v), Res ((Result (Unit, Exn), _), res)) ->
+          if
+            (try
+               (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_5)
+                  state__017_.contents)
+                 = true
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 137;
+                              pos_bol = 7645;
+                              pos_cnum = 7658
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 137;
+                              pos_bol = 7645;
+                              pos_cnum = 7677
+                            }
+                        })))
+          then (match res with | Ok _ -> true | _ -> false)
+          else
+            (match res with | Error (Invalid_argument _) -> true | _ -> false)
+      | (Length, Res ((Int, _), l)) ->
+          (try
+             (Ortac_runtime.Gospelstdlib.integer_of_int l) =
+               (Ortac_runtime.Gospelstdlib.Sequence.length
+                  (Lazy.force new_state__019_).contents)
+           with
+           | e ->
+               raise
+                 (Ortac_runtime.Partial_function
+                    (e,
+                      {
+                        Ortac_runtime.start =
+                          {
+                            pos_fname = "varray_spec.mli";
+                            pos_lnum = 144;
+                            pos_bol = 8166;
+                            pos_cnum = 8180
+                          };
+                        Ortac_runtime.stop =
+                          {
+                            pos_fname = "varray_spec.mli";
+                            pos_lnum = 144;
+                            pos_bol = 8166;
+                            pos_cnum = 8210
+                          }
+                      })))
+      | (Is_empty, Res ((Bool, _), b)) ->
+          (try
+             (b = true) =
+               ((Lazy.force new_state__019_).contents =
+                  Ortac_runtime.Gospelstdlib.Sequence.empty)
+           with
+           | e ->
+               raise
+                 (Ortac_runtime.Partial_function
+                    (e,
+                      {
+                        Ortac_runtime.start =
+                          {
+                            pos_fname = "varray_spec.mli";
+                            pos_lnum = 171;
+                            pos_bol = 9662;
+                            pos_cnum = 9676
+                          };
+                        Ortac_runtime.stop =
+                          {
+                            pos_fname = "varray_spec.mli";
+                            pos_lnum = 171;
+                            pos_bol = 9662;
+                            pos_cnum = 9709
+                          }
+                      })))
+      | (Fill (pos, len, x_3), Res ((Result (Unit, Exn), _), res)) ->
+          if
+            (try
+               let __t1__026_ =
+                 Ortac_runtime.Gospelstdlib.(<=)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                   (Ortac_runtime.Gospelstdlib.integer_of_int pos) in
+               let __t2__027_ =
+                 let __t1__028_ =
+                   Ortac_runtime.Gospelstdlib.(<=)
+                     (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+                     (Ortac_runtime.Gospelstdlib.integer_of_int len) in
+                 let __t2__029_ =
+                   Ortac_runtime.Gospelstdlib.(<)
+                     (Ortac_runtime.Gospelstdlib.(+)
+                        (Ortac_runtime.Gospelstdlib.integer_of_int pos)
+                        (Ortac_runtime.Gospelstdlib.integer_of_int len))
+                     (Ortac_runtime.Gospelstdlib.Sequence.length
+                        state__017_.contents) in
+                 __t1__028_ && __t2__029_ in
+               __t1__026_ && __t2__027_
+             with
+             | e ->
+                 raise
+                   (Ortac_runtime.Partial_function
+                      (e,
+                        {
+                          Ortac_runtime.start =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 211;
+                              pos_bol = 12225;
+                              pos_cnum = 12238
+                            };
+                          Ortac_runtime.stop =
+                            {
+                              pos_fname = "varray_spec.mli";
+                              pos_lnum = 211;
+                              pos_bol = 12225;
+                              pos_cnum = 12300
+                            }
+                        })))
+          then (match res with | Ok _ -> true | _ -> false)
+          else
+            (match res with | Error (Invalid_argument _) -> true | _ -> false)
+      | _ -> true
+    let run cmd__032_ sut__033_ =
+      match cmd__032_ with
+      | Push_back x -> Res (unit, (push_back sut__033_ x))
+      | Pop_back ->
+          Res
+            ((result (elt char) exn),
+              (protect (fun () -> pop_back sut__033_) ()))
+      | Push_front x_1 -> Res (unit, (push_front sut__033_ x_1))
+      | Pop_front ->
+          Res
+            ((result (elt char) exn),
+              (protect (fun () -> pop_front sut__033_) ()))
+      | Insert_at (i_1, x_2) ->
+          Res
+            ((result unit exn),
+              (protect (fun () -> insert_at sut__033_ i_1 x_2) ()))
+      | Pop_at i_2 ->
+          Res
+            ((result (elt char) exn),
+              (protect (fun () -> pop_at sut__033_ i_2) ()))
+      | Delete_at i_3 ->
+          Res
+            ((result unit exn),
+              (protect (fun () -> delete_at sut__033_ i_3) ()))
+      | Get i_4 ->
+          Res
+            ((result (elt char) exn),
+              (protect (fun () -> get sut__033_ i_4) ()))
+      | Set (i_5, v) ->
+          Res
+            ((result unit exn), (protect (fun () -> set sut__033_ i_5 v) ()))
+      | Length -> Res (int, (length sut__033_))
+      | Is_empty -> Res (bool, (is_empty sut__033_))
+      | Fill (pos, len, x_3) ->
+          Res
+            ((result unit exn),
+              (protect (fun () -> fill sut__033_ pos len x_3) ()))
+  end
+module STMTests = (STM_sequential.Make)(Spec)
+let _ =
+  QCheck_base_runner.run_tests_main
+    (let count = 1000 in
+     [STMTests.agree_test ~count ~name:"Varray_spec STM tests"])

--- a/ortac-examples.opam
+++ b/ortac-examples.opam
@@ -17,6 +17,7 @@ depends: [
   "ortac-runtime"
   "qcheck-stm"
   "lwt-dllist"
+  "varray" {>= "0.2"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION

This PR add the [varray](https://github.com/art-w/varray) example.
It is bassed on the not yet merged #177, please consider only the two last commits.

There were four challenges, of different importance:

- The specifications are in an `ml` file and Gospel does not read `ml` file. The proposed solution/workaround is to extract the content of the module signature we are interested in.
- Writing specifications with Gospel `sequence` type is not that easy (it is very possible that review reveals some off-by-one mistakes!)
- User have to write some dune machinery in order to test different Functor instantiations.
- The included module is a bit bigger than the one for the #177 example and need to be included in two different tests. We had to make it a library. The size of the included module is what triggered #181.