### PR TITLE
add missing dependencies for tests

### DIFF
--- a/examples/dune
+++ b/examples/dune
@@ -25,7 +25,7 @@
     (run
      ortac
      qcheck-stm
-     lwt_dllist_spec.mli
+     %{dep:lwt_dllist_spec.mli}
      "create ()"
      "int t"
      --include=lwt_dllist_incl
@@ -84,7 +84,7 @@
     (run
      ortac
      qcheck-stm
-     varray_spec.mli
+     %{dep:varray_spec.mli}
      "make 42 'a'"
      "char t"
      --include=varray_incl
@@ -130,7 +130,7 @@
     (run
      ortac
      qcheck-stm
-     varray_circular_spec.mli
+     %{dep:varray_circular_spec.mli}
      "make 42 'a'"
      "char t"
      --include=varray_incl


### PR DESCRIPTION
Editing the *_sig.ml files didn't cause the test to be rebuilt, unless a `dune clean && dune runtest --cache=disabled` was used.

`ortac` depends on the `mli` files (which are created by another rule from the `_sig.ml` files), this dependency can be turned into a hard failure by enabling sandboxing:
```
$ dune runtest --sandbox=hardlink --force
Entering directory '/var/home/edwin/git/ortac-qcheck-stm'
File "examples/dune", line 70, characters 0-368:
70 | (rule
71 |  (mode promote)
72 |  (alias runtest)
....
89 |      "char t"
90 |      --include=varray_incl
91 |      --quiet)))))
ortac: FILE argument: Error: `varray_spec.mli' not found
Usage: ortac qcheck-stm [OPTION]… FILE INIT SUT
Try 'ortac qcheck-stm --help' or 'ortac --help' for more information.

```

Add the missing dependencies and now the tests are properly rebuilt whenever the `*_sig.ml` files are changed, and there are no more failures with sandboxing on.