### PR TITLE
Remove dune-site dep for ortac-wrapper

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -74,7 +74,6 @@
  (maintainers "Clément Pascutto <clement@pascutto.fr>")
  (depends
   (ocaml (>= 4.11.0))
-  dune-site
   (cmdliner (>= 1.1.0))
   fmt
   (ppxlib (>= 0.26.0))

--- a/ortac-wrapper.opam
+++ b/ortac-wrapper.opam
@@ -20,7 +20,6 @@ bug-reports: "https://github.com/ocaml-gospel/ortac/issues"
 depends: [
   "dune" {>= "3.8"}
   "ocaml" {>= "4.11.0"}
-  "dune-site"
   "cmdliner" {>= "1.1.0"}
   "fmt"
   "ppxlib" {>= "0.26.0"}


### PR DESCRIPTION
Other plugins doesn't declare it and documentation doesn't say it is necessary.
