### PR TITLE
Grant the necessary permissions to deploy to github pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,7 +6,8 @@ on:
       - main
 
 permissions:
-  contents: write
+  pages: write
+  id-token: write
 
 jobs:
   deploy:


### PR DESCRIPTION
Follow-up to #191 which didn’t provide enough permissions for the deployment.