### PR TITLE
update to latest gospel

### DIFF
--- a/ortac-wrapper.opam
+++ b/ortac-wrapper.opam
@@ -46,3 +46,6 @@ build: [
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/ocaml-gospel/ortac.git"
+pin-depends: [
+  [ "gospel.0.2.0+dev" "git+https://github.com/ocaml-gospel/gospel#044f1d5b1f6eba47ee9ad001a5ce1dcb3b49c03a" ]
+]

--- a/ortac-wrapper.opam.template
+++ b/ortac-wrapper.opam.template
@@ -1,0 +1,3 @@
+pin-depends: [
+  [ "gospel.0.2.0+dev" "git+https://github.com/ocaml-gospel/gospel#044f1d5b1f6eba47ee9ad001a5ce1dcb3b49c03a" ]
+]


### PR DESCRIPTION
Gospel PR #374 modified how type invariants are stored in the typed ast.
This PR pin the new version (pin to be removed when a new version of Gospel is
released) and update Ortac/Wrapper code accordingly.
