### PR TITLE
Make ortac load a subset of plugins

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Change `ORTAC_ONLY_PLUGIN` to `ORTAC_PLUGINS`
+  [\#195](https://github.com/ocaml-gospel/ortac/pull/195)
 - Add an include option to qcheck-stm cli
   [\#181](https://github.com/ocaml-gospel/ortac/pull/181)
 - Add a quiet flag

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -1,7 +1,9 @@
 let () =
-  match Sys.getenv_opt "ORTAC_ONLY_PLUGIN" with
+  match Sys.getenv_opt "ORTAC_PLUGINS" with
   | None -> Sites.Plugins.Plugins.load_all ()
-  | Some plug -> Sites.Plugins.Plugins.load plug
+  | Some plug ->
+      let plugs = String.split_on_char ',' plug in
+      List.iter Sites.Plugins.Plugins.load plugs
 
 open Cmdliner
 

--- a/examples/dune
+++ b/examples/dune
@@ -18,7 +18,7 @@
  (targets lwt_dllist_tests.ml)
  (action
   (setenv
-   ORTAC_ONLY_PLUGIN
+   ORTAC_PLUGINS
    qcheck-stm
    (with-stdout-to
     %{targets}
@@ -77,7 +77,7 @@
  (targets varray_tests.ml)
  (action
   (setenv
-   ORTAC_ONLY_PLUGIN
+   ORTAC_PLUGINS
    qcheck-stm
    (with-stdout-to
     %{targets}
@@ -123,7 +123,7 @@
  (targets varray_circular_tests.ml)
  (action
   (setenv
-   ORTAC_ONLY_PLUGIN
+   ORTAC_PLUGINS
    qcheck-stm
    (with-stdout-to
     %{targets}

--- a/plugins/monolith/test/generated/dune
+++ b/plugins/monolith/test/generated/dune
@@ -31,7 +31,7 @@
   (package ortac-monolith))
  (action
   (setenv
-   ORTAC_ONLY_PLUGIN
+   ORTAC_PLUGINS
    monolith
    (with-stderr-to
     errors

--- a/plugins/qcheck-stm/doc/index.mld
+++ b/plugins/qcheck-stm/doc/index.mld
@@ -146,7 +146,7 @@ you indicate the file you want to test, the function call to build a value of
 the type indicated in the third argument. You can write the generated code into
 a file, using the [-o] option.
 
-{@sh set-ORTAC_ONLY_PLUGIN=qcheck-stm[
+{@sh set-ORTAC_PLUGINS=qcheck-stm[
 $ ortac qcheck-stm example.mli "make 42 'a'" "char t" -o stm_example.ml
 ]}
 

--- a/plugins/qcheck-stm/test/dune
+++ b/plugins/qcheck-stm/test/dune
@@ -14,7 +14,7 @@
   (package ortac-qcheck-stm))
  (action
   (setenv
-   ORTAC_ONLY_PLUGIN
+   ORTAC_PLUGINS
    qcheck-stm
    (ignore-stdout
     (with-stderr-to

--- a/plugins/qcheck-stm/test/dune.inc
+++ b/plugins/qcheck-stm/test/dune.inc
@@ -10,7 +10,7 @@
   (package ortac-qcheck-stm))
  (action
   (setenv
-   ORTAC_ONLY_PLUGIN
+   ORTAC_PLUGINS
    qcheck-stm
    (with-stderr-to
     array_errors
@@ -63,7 +63,7 @@
   (package ortac-qcheck-stm))
  (action
   (setenv
-   ORTAC_ONLY_PLUGIN
+   ORTAC_PLUGINS
    qcheck-stm
    (with-stderr-to
     hashtbl_errors
@@ -116,7 +116,7 @@
   (package ortac-qcheck-stm))
  (action
   (setenv
-   ORTAC_ONLY_PLUGIN
+   ORTAC_PLUGINS
    qcheck-stm
    (with-stderr-to
     record_errors
@@ -169,7 +169,7 @@
   (package ortac-qcheck-stm))
  (action
   (setenv
-   ORTAC_ONLY_PLUGIN
+   ORTAC_PLUGINS
    qcheck-stm
    (with-stderr-to
     ref_errors
@@ -222,7 +222,7 @@
   (package ortac-qcheck-stm))
  (action
   (setenv
-   ORTAC_ONLY_PLUGIN
+   ORTAC_PLUGINS
    qcheck-stm
    (with-stderr-to
     conjunctive_clauses_errors
@@ -275,7 +275,7 @@
   (package ortac-qcheck-stm))
  (action
   (setenv
-   ORTAC_ONLY_PLUGIN
+   ORTAC_PLUGINS
    qcheck-stm
    (with-stderr-to
     sequence_model_errors

--- a/plugins/qcheck-stm/test/dune_gen.ml
+++ b/plugins/qcheck-stm/test/dune_gen.ml
@@ -23,7 +23,7 @@ let rec print_rules pos =
   (package ortac-qcheck-stm))
  (action
   (setenv
-   ORTAC_ONLY_PLUGIN
+   ORTAC_PLUGINS
    qcheck-stm
    (with-stderr-to
     %s_errors

--- a/plugins/qcheck-stm/test/test_errors.t
+++ b/plugins/qcheck-stm/test/test_errors.t
@@ -1,7 +1,7 @@
 In this file, we test the different ways to make the `ortac qcheck-stm`
 command-line fail, so we load only the `qcheck-stm` plugin:
 
-  $ export ORTAC_ONLY_PLUGIN=qcheck-stm
+  $ export ORTAC_PLUGINS=qcheck-stm
 
 We can make a syntax error in either the expression for the `init` function, or
 in the type declaration for the sytem under test:

--- a/plugins/wrapper/test/generated/dune
+++ b/plugins/wrapper/test/generated/dune
@@ -14,7 +14,7 @@
   (package ortac-wrapper))
  (action
   (setenv
-   ORTAC_ONLY_PLUGIN
+   ORTAC_PLUGINS
    wrapper
    (with-stderr-to
     errors

--- a/plugins/wrapper/test/suite/dune.common
+++ b/plugins/wrapper/test/suite/dune.common
@@ -6,7 +6,7 @@
   (package ortac-wrapper))
  (action
   (setenv
-   ORTAC_ONLY_PLUGIN
+   ORTAC_PLUGINS
    wrapper
    (with-stdout-to
     %{target}


### PR DESCRIPTION
This PR is based on #194, please consider only the last commit.

This PR proposes to load the installed subset of plugins.
This will be useful for testing the dune plugin, and for generating dune file using the dune plugin when testing the other ones.

The adopted convention is to separate the plugins names with a comma.