### PR TITLE
Read gospel files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # 0.3.0
 
+- Read also `.gospel` files
+  [\#196](https://github.com/ocaml-gospel/ortac/pull/196)
 - Read an optional `cleanup` function from configuration module
   [\#226](https://github.com/ocaml-gospel/ortac/pull/226)
 - Fix field access translation

--- a/bin/registration.mli
+++ b/bin/registration.mli
@@ -1,5 +1,7 @@
 type plugins
+type input_file = MLI of string | GOSPEL of string
 
+val unwrap : input_file -> string
 val plugins : plugins
 val register : unit Cmdliner.Cmd.t -> unit
 val fold : ('a -> unit Cmdliner.Cmd.t -> 'a) -> 'a -> plugins -> 'a
@@ -7,5 +9,5 @@ val get_out_formatter : string option -> Format.formatter
 val setup_log : unit Cmdliner.Term.t
 val include_ : string option Cmdliner.Term.t
 val output_file : string option Cmdliner.Term.t
-val ocaml_file : string Cmdliner.Term.t
+val input_file : input_file Cmdliner.Term.t
 val quiet : bool Cmdliner.Term.t

--- a/plugins/monolith/src/ortac_monolith.ml
+++ b/plugins/monolith/src/ortac_monolith.ml
@@ -156,7 +156,7 @@ end = struct
     Cmd.info "monolith"
       ~doc:"Generate Monolith test file according to Gospel specifications."
 
-  let term = Term.(const main $ ocaml_file $ output_file $ setup_log)
+  let term = Term.(const main $ input_file $ output_file $ setup_log)
   let cmd = Cmd.v info term
 end
 

--- a/plugins/monolith/src/ortac_monolith.ml
+++ b/plugins/monolith/src/ortac_monolith.ml
@@ -132,12 +132,9 @@ let standalone module_name env s =
   :: specs
 
 let generate path fmt =
-  let module_name = Ortac_core.Utils.module_name_of_path path in
-  Gospel.Parser_frontend.parse_ocaml_gospel path
-  |> Ortac_core.Utils.type_check [] path
-  |> fun (env, sigs) ->
-  assert (List.length env = 1);
-  standalone module_name (List.hd env) sigs
+  let open Ortac_core.Utils in
+  let { module_name; namespace; ast } = check path in
+  standalone module_name namespace ast
   |> Fmt.pf fmt "%a@." Ppxlib_ast.Pprintast.structure;
   W.report ()
 

--- a/plugins/monolith/src/ortac_monolith.mli
+++ b/plugins/monolith/src/ortac_monolith.mli
@@ -1,4 +1,4 @@
-val generate : string -> Format.formatter -> unit
+val generate : Registration.input_file -> Format.formatter -> unit
 (** [generate path output] generate the code of the tests corresponding to the
     specifications present in [path] in the monolith configuration and print it
     on the [output] channel *)

--- a/plugins/qcheck-stm/src/config.ml
+++ b/plugins/qcheck-stm/src/config.ml
@@ -220,11 +220,8 @@ let scan_config cfg_uc config_mod =
 let init gospel config_module =
   let open Reserr in
   try
-    let module_name = Utils.module_name_of_path gospel in
-    Parser_frontend.parse_ocaml_gospel gospel |> Utils.type_check [] gospel
-    |> fun (env, sigs) ->
-    assert (List.length env = 1);
-    let namespace = List.hd env in
+    let open Utils in
+    let { module_name; namespace; ast } = Utils.check gospel in
     let context = Context.init module_name namespace in
     let add ctx s =
       (* we add to the context the pure OCaml values and the functions and
@@ -237,10 +234,10 @@ let init gospel config_module =
           Context.add_function fun_ls fun_ls.ls_name.id_str ctx
       | _ -> ctx
     in
-    let context = List.fold_left add context sigs in
+    let context = List.fold_left add context ast in
     let* config =
       scan_config config_under_construction config_module >>= mk_config context
     in
-    ok (sigs, config)
+    ok (ast, config)
   with Gospel.Warnings.Error (l, k) ->
     error (Ortac_core.Warnings.GospelError k, l)

--- a/plugins/qcheck-stm/src/ortac_qcheck_stm.ml
+++ b/plugins/qcheck-stm/src/ortac_qcheck_stm.ml
@@ -34,7 +34,7 @@ end = struct
 
   let term =
     let open Registration in
-    Term.(const main $ ocaml_file $ config $ output_file $ quiet $ setup_log)
+    Term.(const main $ input_file $ config $ output_file $ quiet $ setup_log)
 
   let cmd = Cmd.v info term
 end

--- a/plugins/qcheck-stm/test/dune.inc
+++ b/plugins/qcheck-stm/test/dune.inc
@@ -3,6 +3,14 @@
  (modules array))
 
 (rule
+ (target array.gospel)
+ (action
+  (run
+   gospel
+   check
+   %{dep:array.mli})))
+
+(rule
  (target array_stm_tests.ml)
  (package ortac-qcheck-stm)
  (deps
@@ -17,7 +25,7 @@
     (run
      ortac
      qcheck-stm
-     %{dep:array.mli}
+     %{dep:array.gospel}
      %{dep:array_config.ml}
      -o
      %{target})))))
@@ -56,6 +64,14 @@
  (modules hashtbl))
 
 (rule
+ (target hashtbl.gospel)
+ (action
+  (run
+   gospel
+   check
+   %{dep:hashtbl.mli})))
+
+(rule
  (target hashtbl_stm_tests.ml)
  (package ortac-qcheck-stm)
  (deps
@@ -70,7 +86,7 @@
     (run
      ortac
      qcheck-stm
-     %{dep:hashtbl.mli}
+     %{dep:hashtbl.gospel}
      %{dep:hashtbl_config.ml}
      -o
      %{target})))))
@@ -109,6 +125,14 @@
  (modules record))
 
 (rule
+ (target record.gospel)
+ (action
+  (run
+   gospel
+   check
+   %{dep:record.mli})))
+
+(rule
  (target record_stm_tests.ml)
  (package ortac-qcheck-stm)
  (deps
@@ -123,7 +147,7 @@
     (run
      ortac
      qcheck-stm
-     %{dep:record.mli}
+     %{dep:record.gospel}
      %{dep:record_config.ml}
      -o
      %{target})))))
@@ -162,6 +186,14 @@
  (modules ref))
 
 (rule
+ (target ref.gospel)
+ (action
+  (run
+   gospel
+   check
+   %{dep:ref.mli})))
+
+(rule
  (target ref_stm_tests.ml)
  (package ortac-qcheck-stm)
  (deps
@@ -176,7 +208,7 @@
     (run
      ortac
      qcheck-stm
-     %{dep:ref.mli}
+     %{dep:ref.gospel}
      %{dep:ref_config.ml}
      -o
      %{target})))))
@@ -215,6 +247,14 @@
  (modules conjunctive_clauses))
 
 (rule
+ (target conjunctive_clauses.gospel)
+ (action
+  (run
+   gospel
+   check
+   %{dep:conjunctive_clauses.mli})))
+
+(rule
  (target conjunctive_clauses_stm_tests.ml)
  (package ortac-qcheck-stm)
  (deps
@@ -229,7 +269,7 @@
     (run
      ortac
      qcheck-stm
-     %{dep:conjunctive_clauses.mli}
+     %{dep:conjunctive_clauses.gospel}
      %{dep:conjunctive_clauses_config.ml}
      -o
      %{target})))))
@@ -268,6 +308,14 @@
  (modules sequence_model))
 
 (rule
+ (target sequence_model.gospel)
+ (action
+  (run
+   gospel
+   check
+   %{dep:sequence_model.mli})))
+
+(rule
  (target sequence_model_stm_tests.ml)
  (package ortac-qcheck-stm)
  (deps
@@ -282,7 +330,7 @@
     (run
      ortac
      qcheck-stm
-     %{dep:sequence_model.mli}
+     %{dep:sequence_model.gospel}
      %{dep:sequence_model_config.ml}
      -o
      %{target})))))
@@ -321,6 +369,14 @@
  (modules invariants))
 
 (rule
+ (target invariants.gospel)
+ (action
+  (run
+   gospel
+   check
+   %{dep:invariants.mli})))
+
+(rule
  (target invariants_stm_tests.ml)
  (package ortac-qcheck-stm)
  (deps
@@ -335,7 +391,7 @@
     (run
      ortac
      qcheck-stm
-     %{dep:invariants.mli}
+     %{dep:invariants.gospel}
      %{dep:invariants_config.ml}
      -o
      %{target})))))
@@ -374,6 +430,14 @@
  (modules integer_in_model))
 
 (rule
+ (target integer_in_model.gospel)
+ (action
+  (run
+   gospel
+   check
+   %{dep:integer_in_model.mli})))
+
+(rule
  (target integer_in_model_stm_tests.ml)
  (package ortac-qcheck-stm)
  (deps
@@ -388,7 +452,7 @@
     (run
      ortac
      qcheck-stm
-     %{dep:integer_in_model.mli}
+     %{dep:integer_in_model.gospel}
      %{dep:integer_in_model_config.ml}
      -o
      %{target})))))
@@ -427,6 +491,14 @@
  (modules ghost_as_model))
 
 (rule
+ (target ghost_as_model.gospel)
+ (action
+  (run
+   gospel
+   check
+   %{dep:ghost_as_model.mli})))
+
+(rule
  (target ghost_as_model_stm_tests.ml)
  (package ortac-qcheck-stm)
  (deps
@@ -441,7 +513,7 @@
     (run
      ortac
      qcheck-stm
-     %{dep:ghost_as_model.mli}
+     %{dep:ghost_as_model.gospel}
      %{dep:ghost_as_model_config.ml}
      -o
      %{target})))))
@@ -480,6 +552,14 @@
  (modules custom_config))
 
 (rule
+ (target custom_config.gospel)
+ (action
+  (run
+   gospel
+   check
+   %{dep:custom_config.mli})))
+
+(rule
  (target custom_config_stm_tests.ml)
  (package ortac-qcheck-stm)
  (deps
@@ -494,7 +574,7 @@
     (run
      ortac
      qcheck-stm
-     %{dep:custom_config.mli}
+     %{dep:custom_config.gospel}
      %{dep:custom_config_config.ml}
      -o
      %{target})))))
@@ -533,6 +613,14 @@
  (modules test_without_sut))
 
 (rule
+ (target test_without_sut.gospel)
+ (action
+  (run
+   gospel
+   check
+   %{dep:test_without_sut.mli})))
+
+(rule
  (target test_without_sut_stm_tests.ml)
  (package ortac-qcheck-stm)
  (deps
@@ -547,7 +635,7 @@
     (run
      ortac
      qcheck-stm
-     %{dep:test_without_sut.mli}
+     %{dep:test_without_sut.gospel}
      %{dep:test_without_sut_config.ml}
      -o
      %{target})))))
@@ -586,6 +674,14 @@
  (modules tuples))
 
 (rule
+ (target tuples.gospel)
+ (action
+  (run
+   gospel
+   check
+   %{dep:tuples.mli})))
+
+(rule
  (target tuples_stm_tests.ml)
  (package ortac-qcheck-stm)
  (deps
@@ -600,7 +696,7 @@
     (run
      ortac
      qcheck-stm
-     %{dep:tuples.mli}
+     %{dep:tuples.gospel}
      %{dep:tuples_config.ml}
      -o
      %{target})))))
@@ -639,6 +735,14 @@
  (modules functional_model))
 
 (rule
+ (target functional_model.gospel)
+ (action
+  (run
+   gospel
+   check
+   %{dep:functional_model.mli})))
+
+(rule
  (target functional_model_stm_tests.ml)
  (package ortac-qcheck-stm)
  (deps
@@ -653,7 +757,7 @@
     (run
      ortac
      qcheck-stm
-     %{dep:functional_model.mli}
+     %{dep:functional_model.gospel}
      %{dep:functional_model_config.ml}
      -o
      %{target})))))
@@ -692,6 +796,14 @@
  (modules test_cleanup))
 
 (rule
+ (target test_cleanup.gospel)
+ (action
+  (run
+   gospel
+   check
+   %{dep:test_cleanup.mli})))
+
+(rule
  (target test_cleanup_stm_tests.ml)
  (package ortac-qcheck-stm)
  (deps
@@ -706,7 +818,7 @@
     (run
      ortac
      qcheck-stm
-     %{dep:test_cleanup.mli}
+     %{dep:test_cleanup.gospel}
      %{dep:test_cleanup_config.ml}
      -o
      %{target})))))

--- a/plugins/qcheck-stm/test/dune_gen.ml
+++ b/plugins/qcheck-stm/test/dune_gen.ml
@@ -17,6 +17,14 @@ let rec print_rules pos =
  (modules %s))
 
 (rule
+ (target %s.gospel)
+ (action
+  (run
+   gospel
+   check
+   %%{dep:%s.mli})))
+
+(rule
  (target %s_stm_tests.ml)
  (package ortac-qcheck-stm)
  (deps
@@ -31,7 +39,7 @@ let rec print_rules pos =
     (run
      ortac
      qcheck-stm
-     %%{dep:%s.mli}
+     %%{dep:%s.gospel}
      %%{dep:%s.ml}
      -o
      %%{target})))))
@@ -66,7 +74,7 @@ let rec print_rules pos =
   (run %%{dep:%s_stm_tests.exe} -v)))
 
 |}
-      m m m m m config m m m m m m m m m;
+      m m m m m m m config m m m m m m m m m;
     print_rules (pos + 2))
 
 let () =

--- a/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
@@ -6,8 +6,8 @@ module Ortac_runtime = Ortac_runtime_qcheck_stm
 let rec remove_first x xs_1 =
   try
     match xs_1 with
-    | (a_1, b_1)::xs ->
-        if a_1 = x then xs else (a_1, b_1) :: (remove_first x xs)
+    | (tuple2_1 (a_1, b_1))::xs ->
+        if a_1 = x then xs else (tuple2 (a_1, b_1)) :: (remove_first x xs)
     | [] -> []
   with
   | e ->
@@ -71,7 +71,7 @@ module Spec =
             (Util.Pp.pp_int true) b_3
       | Length -> Format.asprintf "%s sut" "length"
     type nonrec state = {
-      contents: (char * int) list }
+      contents: (char, int) tuple2 list }
     let init_state =
       let random = false
       and size = 16 in
@@ -176,7 +176,7 @@ module Spec =
       | Add (a_2, b_2) ->
           {
             contents =
-              ((try (a_2, b_2) :: state__003_.contents
+              ((try (tuple2 (a_2, b_2)) :: state__003_.contents
                 with
                 | e ->
                     raise
@@ -232,7 +232,9 @@ module Spec =
       | Replace (a_8, b_3) ->
           {
             contents =
-              ((try (a_8, b_3) :: (remove_first a_8 state__003_.contents)
+              ((try
+                  (tuple2 (a_8, b_3)) ::
+                    (remove_first a_8 state__003_.contents)
                 with
                 | e ->
                     raise
@@ -298,7 +300,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
            | Ok b_4 ->
                if
                  (try
-                    Ortac_runtime.Gospelstdlib.List.mem (a_3, b_4)
+                    Ortac_runtime.Gospelstdlib.List.mem (tuple2 (a_3, b_4))
                       (Lazy.force new_state__007_).contents
                   with
                   | e ->
@@ -343,7 +345,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
                                pos_cnum = 1398
                              }
                          })])
-           | Error (Not_found) ->
+           | Error (Not_found (tuple0)) ->
                if
                  (try
                     not
@@ -410,7 +412,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
                     else false
                 | Some b_5 ->
                     if
-                      Ortac_runtime.Gospelstdlib.List.mem (a_4, b_5)
+                      Ortac_runtime.Gospelstdlib.List.mem (tuple2 (a_4, b_5))
                         (Lazy.force new_state__007_).contents
                     then true
                     else false)
@@ -463,7 +465,8 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
             (try
                (Ortac_runtime.Gospelstdlib.List.to_seq bs) =
                  (Ortac_runtime.Gospelstdlib.Sequence.filter_map
-                    (fun (x_1, y) -> if x_1 = a_5 then Some y else None)
+                    (fun (tuple2_1 (x_1, y)) ->
+                       if x_1 = a_5 then Some y else None)
                     (Ortac_runtime.Gospelstdlib.List.to_seq
                        (Lazy.force new_state__007_).contents))
              with

--- a/plugins/qcheck-stm/test/tuples_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/tuples_stm_tests.expected.ml
@@ -51,7 +51,7 @@ module Spec =
       | Size_tup -> Format.asprintf "%s sut" "size_tup"
       | Size_tup' -> Format.asprintf "%s sut" "size_tup'"
     type nonrec state = {
-      contents: (char * int) list }
+      contents: (char, int) tuple2 list }
     let init_state =
       let () = () in
       {
@@ -126,7 +126,8 @@ module Spec =
             contents =
               ((try
                   match tup with
-                  | (a_1, b_1) -> (a_1, b_1) :: state__003_.contents
+                  | tuple2_1 (a_1, b_1) ->
+                      (tuple2 (a_1, b_1)) :: state__003_.contents
                 with
                 | e ->
                     raise
@@ -154,9 +155,9 @@ module Spec =
             contents =
               ((try
                   match tup_1 with
-                  | (c, a_2, b_2) ->
+                  | tuple3 (c, a_2, b_2) ->
                       if c = true
-                      then (a_2, b_2) :: state__003_.contents
+                      then (tuple2 (a_2, b_2)) :: state__003_.contents
                       else state__003_.contents
                 with
                 | e ->
@@ -185,9 +186,9 @@ module Spec =
             contents =
               ((try
                   match tup_2 with
-                  | (c_1, (a_3, b_3)) ->
+                  | tuple2_1 (c_1, tuple2_1 (a_3, b_3)) ->
                       if c_1 = true
-                      then (a_3, b_3) :: state__003_.contents
+                      then (tuple2 (a_3, b_3)) :: state__003_.contents
                       else state__003_.contents
                 with
                 | e ->

--- a/plugins/wrapper/src/generate.ml
+++ b/plugins/wrapper/src/generate.ml
@@ -236,10 +236,7 @@ let signature ~runtime ~module_name namespace s =
   structure runtime (Context.module_name context) ir
 
 let generate path fmt =
-  let module_name = Ortac_core.Utils.module_name_of_path path in
-  Gospel.Parser_frontend.parse_ocaml_gospel path
-  |> Ortac_core.Utils.type_check [] path
-  |> fun (env, sigs) ->
-  assert (List.length env = 1);
-  signature ~runtime:"Ortac_runtime" ~module_name (List.hd env) sigs
+  let open Ortac_core.Utils in
+  let { module_name; namespace; ast } = check path in
+  signature ~runtime:"Ortac_runtime" ~module_name namespace ast
   |> Fmt.pf fmt "%a@." Ppxlib_ast.Pprintast.structure

--- a/plugins/wrapper/src/generate.mli
+++ b/plugins/wrapper/src/generate.mli
@@ -5,7 +5,7 @@ val signature :
   Gospel.Tast.signature_item list ->
   Ppxlib.structure
 
-val generate : string -> Format.formatter -> unit
+val generate : Registration.input_file -> Format.formatter -> unit
 (** [generate path out] generate the code of the tests corresponding to the
     specifications present in [path] in the default configuration and print it
     on the [out] channel *)

--- a/plugins/wrapper/src/ortac_wrapper.ml
+++ b/plugins/wrapper/src/ortac_wrapper.ml
@@ -19,7 +19,7 @@ end = struct
       ~doc:
         "Wrap module functions with assertions to check their specifications."
 
-  let term = Term.(const main $ ocaml_file $ output_file $ setup_log)
+  let term = Term.(const main $ input_file $ output_file $ setup_log)
   let cmd = Cmd.v info term
 end
 

--- a/plugins/wrapper/test/suite/translation.ml
+++ b/plugins/wrapper/test/suite/translation.ml
@@ -3,7 +3,7 @@ module Utils = Ortac_core__Utils
 
 let translate path =
   let open Utils in
-  let { module_name; namespace; ast } = check path in
+  let { module_name; namespace; ast } = check (Registration.MLI path) in
   let context = Ortac_core.Context.init module_name namespace in
   Ortac_wrapper__Ir_of_gospel.signature ~context ast
 

--- a/plugins/wrapper/test/suite/translation.ml
+++ b/plugins/wrapper/test/suite/translation.ml
@@ -2,12 +2,10 @@ module Ir = Ortac_wrapper__Ir
 module Utils = Ortac_core__Utils
 
 let translate path =
-  let module_name = Utils.module_name_of_path path in
-  Gospel.Parser_frontend.parse_ocaml_gospel path |> Utils.type_check [] path
-  |> fun (env, sigs) ->
-  assert (List.length env = 1);
-  let context = Ortac_core.Context.init module_name (List.hd env) in
-  Ortac_wrapper__Ir_of_gospel.signature ~context sigs
+  let open Utils in
+  let { module_name; namespace; ast } = check path in
+  let context = Ortac_core.Context.init module_name namespace in
+  Ortac_wrapper__Ir_of_gospel.signature ~context ast
 
 let mutability =
   let open Ir in

--- a/src/core/dune
+++ b/src/core/dune
@@ -3,7 +3,7 @@
  (public_name ortac-core)
  (preprocess
   (pps ppxlib.metaquot))
- (libraries fmt gospel ppxlib.ast))
+ (libraries fmt registration gospel ppxlib.ast))
 
 (rule
  (enabled_if

--- a/src/core/utils.ml
+++ b/src/core/utils.ml
@@ -37,11 +37,11 @@ let read_gospel_file filename =
   (gfile.muc_import, sigs)
 
 let check filename =
-  let module_name = module_name_of_path filename
+  let open Registration in
+  let module_name = module_name_of_path (unwrap filename)
   and env, ast =
-    match Filename.extension filename with
-    | ".mli" -> type_check [] filename
-    | ".gospel" -> read_gospel_file filename
-    | _ -> invalid_arg "check"
+    match filename with
+    | MLI filename -> type_check [] filename
+    | GOSPEL filename -> read_gospel_file filename
   in
   { module_name; namespace = List.hd env; ast }

--- a/src/core/utils.ml
+++ b/src/core/utils.ml
@@ -12,11 +12,36 @@ let module_name_of_path p =
   let filename = Filename.basename p in
   String.index filename '.' |> String.sub filename 0 |> String.capitalize_ascii
 
-let type_check load_path name sigs =
-  let md = Tmodule.init_muc name in
-  let penv =
+open Gospel
+
+type checked = {
+  module_name : string;
+  namespace : Tmodule.namespace;
+  ast : Tast.signature;
+}
+
+let type_check load_path name =
+  let sigs = Parser_frontend.parse_ocaml_gospel name
+  and md = Tmodule.init_muc name
+  and penv =
     module_name_of_path name |> Utils.Sstr.singleton |> Typing.penv load_path
   in
   let gfile = List.fold_left (Typing.type_sig_item penv) md sigs in
   let sigs = Tmodule.wrap_up_muc gfile |> fun file -> file.fl_sigs in
   (gfile.muc_import, sigs)
+
+let read_gospel_file filename =
+  let open Tmodule in
+  let gfile : module_uc = read_gospel_file filename in
+  let sigs = Tmodule.wrap_up_muc gfile |> fun file -> file.fl_sigs in
+  (gfile.muc_import, sigs)
+
+let check filename =
+  let module_name = module_name_of_path filename
+  and env, ast =
+    match Filename.extension filename with
+    | ".mli" -> type_check [] filename
+    | ".gospel" -> read_gospel_file filename
+    | _ -> invalid_arg "check"
+  in
+  { module_name; namespace = List.hd env; ast }

--- a/src/core/utils.mli
+++ b/src/core/utils.mli
@@ -10,7 +10,7 @@ type checked = {
   ast : Gospel.Tast.signature;
 }
 
-val check : string -> checked
+val check : Registration.input_file -> checked
 (** [check filename] calls the Gospel type checker on [filename] with an empty
     load path if it is an interface and read its content if it is a [.gospel]
     file *)

--- a/src/core/utils.mli
+++ b/src/core/utils.mli
@@ -4,14 +4,13 @@ val term_printer : string -> Ppxlib.Location.t -> Gospel.Tterm.term -> string
     specification's location. Fall back on the Gospel term pretty printer if
     something goes wrong when extracting the substring. *)
 
-val module_name_of_path : string -> string
-(** [module_name_of_path p] turn the path to an OCaml file [p] into the
-    corresponding OCaml module identifier *)
+type checked = {
+  module_name : string;
+  namespace : Gospel.Tmodule.namespace;
+  ast : Gospel.Tast.signature;
+}
 
-val type_check :
-  string list ->
-  string ->
-  Gospel.Uast.s_signature_item list ->
-  Gospel.Tmodule.namespace list * Gospel.Tast.signature
-(** [type_check load_path name sigs] call the Gospel typechecker on the file
-    [name] *)
+val check : string -> checked
+(** [check filename] calls the Gospel type checker on [filename] with an empty
+    load path if it is an interface and read its content if it is a [.gospel]
+    file *)


### PR DESCRIPTION

This PR proposes to use the gospel (yet unmerged) new feature from [#376](https://github.com/ocaml-gospel/gospel/pull/376).

Some refactoring is done a  long the way (there may be room for more, but I was mainly interested - at least at first - in experimenting and see how to use the new features in the examples.

This PR only add reading the `.gospel` files for the `qcheck-stm` plugin, as it is an experimentation. But this allows to see how it goes with the dune rules in the `examples/` directory.

Note that this PR is also based on [#380](https://github.com/ocaml-gospel/gospel/pull/380).