### PR TITLE
Print runnable scenario in case of test failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 # Unreleased
 
 - Improve test-failure message
-  [\#202](https://github.com/ocaml-gospel/ortac/pull/202)
+  [\#202](https://github.com/ocaml-gospel/ortac/pull/202) and
+  [\#204](https://github.com/ocaml-gospel/ortac/pull/204)
 - Add a comment warning that the file is generated
   [\#198](https://github.com/ocaml-gospel/ortac/pull/198)
 - Add support for type invariants

--- a/examples/lwt_dllist_tests.ml
+++ b/examples/lwt_dllist_tests.ml
@@ -336,7 +336,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Lwt_dllist_spec"
+              (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
                  (Some (Res (Ortac_runtime.dummy, ()))) "is_empty"
                  [("b <-> s.contents = Sequence.empty",
                     {
@@ -385,7 +385,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Lwt_dllist_spec"
+              (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
                  (Some (Res (Ortac_runtime.dummy, ()))) "length"
                  [("l = Sequence.length s.contents",
                     {
@@ -443,7 +443,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Lwt_dllist_spec"
+                   (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
                       (Some (Res (Ortac_runtime.dummy, ()))) "take_l"
                       [("if old s.contents = Sequence.empty\n              then false\n              else a = Sequence.hd (old s.contents)",
                          {
@@ -496,7 +496,8 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Lwt_dllist_spec" None "take_l"
+                   (Ortac_runtime.report "Lwt_dllist_spec" "create ()" None
+                      "take_l"
                       [("old s.contents = Sequence.empty = s.contents",
                          {
                            Ortac_runtime.start =
@@ -556,7 +557,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Lwt_dllist_spec"
+                   (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
                       (Some (Res (Ortac_runtime.dummy, ()))) "take_r"
                       [("if old s.contents = Sequence.empty\n              then false\n              else a = (old s.contents)[Sequence.length (old s.contents) - 1]",
                          {
@@ -609,7 +610,8 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Lwt_dllist_spec" None "take_r"
+                   (Ortac_runtime.report "Lwt_dllist_spec" "create ()" None
+                      "take_r"
                       [("old s.contents = Sequence.empty = s.contents",
                          {
                            Ortac_runtime.start =
@@ -661,7 +663,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Lwt_dllist_spec"
+              (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
                  (Some (Res (Ortac_runtime.dummy, ()))) "take_opt_l"
                  [("old s.contents = match o with\n                                | None -> Sequence.empty\n                                | Some a -> Sequence.cons a s.contents",
                     {
@@ -713,7 +715,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Lwt_dllist_spec"
+              (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
                  (Some (Res (Ortac_runtime.dummy, ()))) "take_opt_r"
                  [("old s.contents = match o with\n                                | None -> Sequence.empty\n                                | Some a -> Sequence.snoc s.contents a",
                     {

--- a/examples/lwt_dllist_tests.ml
+++ b/examples/lwt_dllist_tests.ml
@@ -19,16 +19,16 @@ module Spec =
       | Take_opt_r 
     let show_cmd cmd__001_ =
       match cmd__001_ with
-      | Is_empty -> Format.asprintf "%s" "is_empty"
-      | Length -> Format.asprintf "%s" "length"
+      | Is_empty -> Format.asprintf "%s sut" "is_empty"
+      | Length -> Format.asprintf "%s sut" "length"
       | Add_l a_1 ->
-          Format.asprintf "%s %a" "add_l" (Util.Pp.pp_int true) a_1
+          Format.asprintf "%s %a sut" "add_l" (Util.Pp.pp_int true) a_1
       | Add_r a_2 ->
-          Format.asprintf "%s %a" "add_r" (Util.Pp.pp_int true) a_2
-      | Take_l -> Format.asprintf "%s" "take_l"
-      | Take_r -> Format.asprintf "%s" "take_r"
-      | Take_opt_l -> Format.asprintf "%s" "take_opt_l"
-      | Take_opt_r -> Format.asprintf "%s" "take_opt_r"
+          Format.asprintf "%s %a sut" "add_r" (Util.Pp.pp_int true) a_2
+      | Take_l -> Format.asprintf "%s sut" "take_l"
+      | Take_r -> Format.asprintf "%s sut" "take_r"
+      | Take_opt_l -> Format.asprintf "%s sut" "take_opt_l"
+      | Take_opt_r -> Format.asprintf "%s sut" "take_opt_r"
     type nonrec state = {
       contents: int Ortac_runtime.Gospelstdlib.sequence }
     let init_state =
@@ -336,7 +336,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
           then None
           else
             Some
-              (Ortac_runtime.report "is_empty"
+              (Ortac_runtime.report "Lwt_dllist_spec" "is_empty"
                  [("b <-> s.contents = Sequence.empty",
                     {
                       Ortac_runtime.start =
@@ -384,7 +384,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
           then None
           else
             Some
-              (Ortac_runtime.report "length"
+              (Ortac_runtime.report "Lwt_dllist_spec" "length"
                  [("l = Sequence.length s.contents",
                     {
                       Ortac_runtime.start =
@@ -441,7 +441,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "take_l"
+                   (Ortac_runtime.report "Lwt_dllist_spec" "take_l"
                       [("if old s.contents = Sequence.empty\n              then false\n              else a = Sequence.hd (old s.contents)",
                          {
                            Ortac_runtime.start =
@@ -493,7 +493,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "take_l"
+                   (Ortac_runtime.report "Lwt_dllist_spec" "take_l"
                       [("old s.contents = Sequence.empty = s.contents",
                          {
                            Ortac_runtime.start =
@@ -553,7 +553,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "take_r"
+                   (Ortac_runtime.report "Lwt_dllist_spec" "take_r"
                       [("if old s.contents = Sequence.empty\n              then false\n              else a = (old s.contents)[Sequence.length (old s.contents) - 1]",
                          {
                            Ortac_runtime.start =
@@ -605,7 +605,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "take_r"
+                   (Ortac_runtime.report "Lwt_dllist_spec" "take_r"
                       [("old s.contents = Sequence.empty = s.contents",
                          {
                            Ortac_runtime.start =
@@ -657,7 +657,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
           then None
           else
             Some
-              (Ortac_runtime.report "take_opt_l"
+              (Ortac_runtime.report "Lwt_dllist_spec" "take_opt_l"
                  [("old s.contents = match o with\n                                | None -> Sequence.empty\n                                | Some a -> Sequence.cons a s.contents",
                     {
                       Ortac_runtime.start =
@@ -708,7 +708,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
           then None
           else
             Some
-              (Ortac_runtime.report "take_opt_r"
+              (Ortac_runtime.report "Lwt_dllist_spec" "take_opt_r"
                  [("old s.contents = match o with\n                                | None -> Sequence.empty\n                                | Some a -> Sequence.snoc s.contents a",
                     {
                       Ortac_runtime.start =

--- a/examples/lwt_dllist_tests.ml
+++ b/examples/lwt_dllist_tests.ml
@@ -336,7 +336,8 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Lwt_dllist_spec" "is_empty"
+              (Ortac_runtime.report "Lwt_dllist_spec"
+                 (Some (Res (Ortac_runtime.dummy, ()))) "is_empty"
                  [("b <-> s.contents = Sequence.empty",
                     {
                       Ortac_runtime.start =
@@ -384,7 +385,8 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Lwt_dllist_spec" "length"
+              (Ortac_runtime.report "Lwt_dllist_spec"
+                 (Some (Res (Ortac_runtime.dummy, ()))) "length"
                  [("l = Sequence.length s.contents",
                     {
                       Ortac_runtime.start =
@@ -441,7 +443,8 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Lwt_dllist_spec" "take_l"
+                   (Ortac_runtime.report "Lwt_dllist_spec"
+                      (Some (Res (Ortac_runtime.dummy, ()))) "take_l"
                       [("if old s.contents = Sequence.empty\n              then false\n              else a = Sequence.hd (old s.contents)",
                          {
                            Ortac_runtime.start =
@@ -493,7 +496,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Lwt_dllist_spec" "take_l"
+                   (Ortac_runtime.report "Lwt_dllist_spec" None "take_l"
                       [("old s.contents = Sequence.empty = s.contents",
                          {
                            Ortac_runtime.start =
@@ -553,7 +556,8 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Lwt_dllist_spec" "take_r"
+                   (Ortac_runtime.report "Lwt_dllist_spec"
+                      (Some (Res (Ortac_runtime.dummy, ()))) "take_r"
                       [("if old s.contents = Sequence.empty\n              then false\n              else a = (old s.contents)[Sequence.length (old s.contents) - 1]",
                          {
                            Ortac_runtime.start =
@@ -605,7 +609,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Lwt_dllist_spec" "take_r"
+                   (Ortac_runtime.report "Lwt_dllist_spec" None "take_r"
                       [("old s.contents = Sequence.empty = s.contents",
                          {
                            Ortac_runtime.start =
@@ -657,7 +661,8 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Lwt_dllist_spec" "take_opt_l"
+              (Ortac_runtime.report "Lwt_dllist_spec"
+                 (Some (Res (Ortac_runtime.dummy, ()))) "take_opt_l"
                  [("old s.contents = match o with\n                                | None -> Sequence.empty\n                                | Some a -> Sequence.cons a s.contents",
                     {
                       Ortac_runtime.start =
@@ -708,7 +713,8 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Lwt_dllist_spec" "take_opt_r"
+              (Ortac_runtime.report "Lwt_dllist_spec"
+                 (Some (Res (Ortac_runtime.dummy, ()))) "take_opt_r"
                  [("old s.contents = match o with\n                                | None -> Sequence.empty\n                                | Some a -> Sequence.snoc s.contents a",
                     {
                       Ortac_runtime.start =

--- a/examples/varray_circular_tests.ml
+++ b/examples/varray_circular_tests.ml
@@ -80,28 +80,29 @@ module Spec =
     let show_cmd cmd__003_ =
       match cmd__003_ with
       | Push_back x ->
-          Format.asprintf "%s %a" "push_back"
+          Format.asprintf "%s sut %a" "push_back"
             (Util.Pp.pp_elt Util.Pp.pp_char true) x
-      | Pop_back -> Format.asprintf "%s" "pop_back"
+      | Pop_back -> Format.asprintf "%s sut" "pop_back"
       | Push_front x_1 ->
-          Format.asprintf "%s %a" "push_front"
+          Format.asprintf "%s sut %a" "push_front"
             (Util.Pp.pp_elt Util.Pp.pp_char true) x_1
-      | Pop_front -> Format.asprintf "%s" "pop_front"
+      | Pop_front -> Format.asprintf "%s sut" "pop_front"
       | Insert_at (i_1, x_2) ->
-          Format.asprintf "%s %a %a" "insert_at" (Util.Pp.pp_int true) i_1
-            (Util.Pp.pp_elt Util.Pp.pp_char true) x_2
+          Format.asprintf "%s sut %a %a" "insert_at" (Util.Pp.pp_int true)
+            i_1 (Util.Pp.pp_elt Util.Pp.pp_char true) x_2
       | Pop_at i_2 ->
-          Format.asprintf "%s %a" "pop_at" (Util.Pp.pp_int true) i_2
+          Format.asprintf "%s sut %a" "pop_at" (Util.Pp.pp_int true) i_2
       | Delete_at i_3 ->
-          Format.asprintf "%s %a" "delete_at" (Util.Pp.pp_int true) i_3
-      | Get i_4 -> Format.asprintf "%s %a" "get" (Util.Pp.pp_int true) i_4
+          Format.asprintf "%s sut %a" "delete_at" (Util.Pp.pp_int true) i_3
+      | Get i_4 ->
+          Format.asprintf "%s sut %a" "get" (Util.Pp.pp_int true) i_4
       | Set (i_5, v) ->
-          Format.asprintf "%s %a %a" "set" (Util.Pp.pp_int true) i_5
+          Format.asprintf "%s sut %a %a" "set" (Util.Pp.pp_int true) i_5
             (Util.Pp.pp_elt Util.Pp.pp_char true) v
-      | Length -> Format.asprintf "%s" "length"
-      | Is_empty -> Format.asprintf "%s" "is_empty"
+      | Length -> Format.asprintf "%s sut" "length"
+      | Is_empty -> Format.asprintf "%s sut" "is_empty"
       | Fill (pos, len, x_3) ->
-          Format.asprintf "%s %a %a %a" "fill" (Util.Pp.pp_int true) pos
+          Format.asprintf "%s sut %a %a %a" "fill" (Util.Pp.pp_int true) pos
             (Util.Pp.pp_int true) len (Util.Pp.pp_elt Util.Pp.pp_char true)
             x_3
     type nonrec state = {
@@ -757,7 +758,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "pop_back"
+                   (Ortac_runtime.report "Varray_circular_spec" "pop_back"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = (old t.contents)[Sequence.length (old t.contents) - 1]",
                          {
                            Ortac_runtime.start =
@@ -809,7 +810,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "pop_back"
+                   (Ortac_runtime.report "Varray_circular_spec" "pop_back"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -866,7 +867,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "pop_front"
+                   (Ortac_runtime.report "Varray_circular_spec" "pop_front"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = Sequence.hd (old t.contents)",
                          {
                            Ortac_runtime.start =
@@ -918,7 +919,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "pop_front"
+                   (Ortac_runtime.report "Varray_circular_spec" "pop_front"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -974,7 +975,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "insert_at"
+                     (Ortac_runtime.report "Varray_circular_spec" "insert_at"
                         [("0 <= i <= Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -1036,7 +1037,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "insert_at"
+                        (Ortac_runtime.report "Varray_circular_spec"
+                           "insert_at"
                            [("0 <= i <= Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1084,7 +1086,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "pop_at"
+                     (Ortac_runtime.report "Varray_circular_spec" "pop_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1138,7 +1140,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "pop_at"
+                        (Ortac_runtime.report "Varray_circular_spec" "pop_at"
                            [("(proj x) = old t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -1193,7 +1195,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "pop_at"
+                        (Ortac_runtime.report "Varray_circular_spec" "pop_at"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1241,7 +1243,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "delete_at"
+                     (Ortac_runtime.report "Varray_circular_spec" "delete_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1298,7 +1300,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "delete_at"
+                        (Ortac_runtime.report "Varray_circular_spec"
+                           "delete_at"
                            [("Sequence.length t.contents = Sequence.length (old t.contents) - 1",
                               {
                                 Ortac_runtime.start =
@@ -1353,7 +1356,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "delete_at"
+                        (Ortac_runtime.report "Varray_circular_spec"
+                           "delete_at"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1401,7 +1405,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "get"
+                     (Ortac_runtime.report "Varray_circular_spec" "get"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1455,7 +1459,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "get"
+                        (Ortac_runtime.report "Varray_circular_spec" "get"
                            [("(proj x) = t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -1510,7 +1514,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "get"
+                        (Ortac_runtime.report "Varray_circular_spec" "get"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1558,7 +1562,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "set"
+                     (Ortac_runtime.report "Varray_circular_spec" "set"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1614,7 +1618,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "set"
+                        (Ortac_runtime.report "Varray_circular_spec" "set"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1662,7 +1666,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
           then None
           else
             Some
-              (Ortac_runtime.report "length"
+              (Ortac_runtime.report "Varray_circular_spec" "length"
                  [("l = Sequence.length t.contents",
                     {
                       Ortac_runtime.start =
@@ -1710,7 +1714,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
           then None
           else
             Some
-              (Ortac_runtime.report "is_empty"
+              (Ortac_runtime.report "Varray_circular_spec" "is_empty"
                  [("b <-> t.contents = Sequence.empty",
                     {
                       Ortac_runtime.start =
@@ -1773,7 +1777,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "fill"
+                     (Ortac_runtime.report "Varray_circular_spec" "fill"
                         [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -1845,7 +1849,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "fill"
+                        (Ortac_runtime.report "Varray_circular_spec" "fill"
                            [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =

--- a/examples/varray_circular_tests.ml
+++ b/examples/varray_circular_tests.ml
@@ -758,7 +758,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_circular_spec" "pop_back"
+                   (Ortac_runtime.report "Varray_circular_spec"
+                      (Some (Res (Ortac_runtime.dummy, ()))) "pop_back"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = (old t.contents)[Sequence.length (old t.contents) - 1]",
                          {
                            Ortac_runtime.start =
@@ -810,7 +811,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_circular_spec" "pop_back"
+                   (Ortac_runtime.report "Varray_circular_spec" None
+                      "pop_back"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -867,7 +869,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_circular_spec" "pop_front"
+                   (Ortac_runtime.report "Varray_circular_spec"
+                      (Some (Res (Ortac_runtime.dummy, ()))) "pop_front"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = Sequence.hd (old t.contents)",
                          {
                            Ortac_runtime.start =
@@ -919,7 +922,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_circular_spec" "pop_front"
+                   (Ortac_runtime.report "Varray_circular_spec" None
+                      "pop_front"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -975,7 +979,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec" "insert_at"
+                     (Ortac_runtime.report "Varray_circular_spec" None
+                        "insert_at"
                         [("0 <= i <= Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -1037,7 +1042,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec"
+                        (Ortac_runtime.report "Varray_circular_spec" None
                            "insert_at"
                            [("0 <= i <= Sequence.length t.contents",
                               {
@@ -1086,7 +1091,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec" "pop_at"
+                     (Ortac_runtime.report "Varray_circular_spec" None
+                        "pop_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1140,7 +1146,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec" "pop_at"
+                        (Ortac_runtime.report "Varray_circular_spec"
+                           (Some (Res (Ortac_runtime.dummy, ()))) "pop_at"
                            [("(proj x) = old t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -1195,7 +1202,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec" "pop_at"
+                        (Ortac_runtime.report "Varray_circular_spec" None
+                           "pop_at"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1243,7 +1251,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec" "delete_at"
+                     (Ortac_runtime.report "Varray_circular_spec" None
+                        "delete_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1301,7 +1310,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "delete_at"
+                           (Some (Res (unit, ()))) "delete_at"
                            [("Sequence.length t.contents = Sequence.length (old t.contents) - 1",
                               {
                                 Ortac_runtime.start =
@@ -1356,7 +1365,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec"
+                        (Ortac_runtime.report "Varray_circular_spec" None
                            "delete_at"
                            [("inside i t.contents",
                               {
@@ -1405,7 +1414,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec" "get"
+                     (Ortac_runtime.report "Varray_circular_spec" None "get"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1459,7 +1468,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec" "get"
+                        (Ortac_runtime.report "Varray_circular_spec"
+                           (Some (Res (Ortac_runtime.dummy, ()))) "get"
                            [("(proj x) = t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -1514,7 +1524,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec" "get"
+                        (Ortac_runtime.report "Varray_circular_spec" None
+                           "get"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1562,7 +1573,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec" "set"
+                     (Ortac_runtime.report "Varray_circular_spec" None "set"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1618,7 +1629,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec" "set"
+                        (Ortac_runtime.report "Varray_circular_spec" None
+                           "set"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1666,7 +1678,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Varray_circular_spec" "length"
+              (Ortac_runtime.report "Varray_circular_spec"
+                 (Some (Res (Ortac_runtime.dummy, ()))) "length"
                  [("l = Sequence.length t.contents",
                     {
                       Ortac_runtime.start =
@@ -1714,7 +1727,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Varray_circular_spec" "is_empty"
+              (Ortac_runtime.report "Varray_circular_spec"
+                 (Some (Res (Ortac_runtime.dummy, ()))) "is_empty"
                  [("b <-> t.contents = Sequence.empty",
                     {
                       Ortac_runtime.start =
@@ -1777,7 +1791,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec" "fill"
+                     (Ortac_runtime.report "Varray_circular_spec" None "fill"
                         [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -1849,7 +1863,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec" "fill"
+                        (Ortac_runtime.report "Varray_circular_spec" None
+                           "fill"
                            [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =

--- a/examples/varray_circular_tests.ml
+++ b/examples/varray_circular_tests.ml
@@ -758,7 +758,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_circular_spec"
+                   (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
                       (Some (Res (Ortac_runtime.dummy, ()))) "pop_back"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = (old t.contents)[Sequence.length (old t.contents) - 1]",
                          {
@@ -811,8 +811,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_circular_spec" None
-                      "pop_back"
+                   (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
+                      None "pop_back"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -869,7 +869,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_circular_spec"
+                   (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
                       (Some (Res (Ortac_runtime.dummy, ()))) "pop_front"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = Sequence.hd (old t.contents)",
                          {
@@ -922,8 +922,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_circular_spec" None
-                      "pop_front"
+                   (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
+                      None "pop_front"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -979,8 +979,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec" None
-                        "insert_at"
+                     (Ortac_runtime.report "Varray_circular_spec"
+                        "make 42 'a'" None "insert_at"
                         [("0 <= i <= Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -1042,8 +1042,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec" None
-                           "insert_at"
+                        (Ortac_runtime.report "Varray_circular_spec"
+                           "make 42 'a'" None "insert_at"
                            [("0 <= i <= Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1091,8 +1091,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec" None
-                        "pop_at"
+                     (Ortac_runtime.report "Varray_circular_spec"
+                        "make 42 'a'" None "pop_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1147,6 +1147,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
+                           "make 42 'a'"
                            (Some (Res (Ortac_runtime.dummy, ()))) "pop_at"
                            [("(proj x) = old t.contents[i]",
                               {
@@ -1202,8 +1203,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec" None
-                           "pop_at"
+                        (Ortac_runtime.report "Varray_circular_spec"
+                           "make 42 'a'" None "pop_at"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1251,8 +1252,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec" None
-                        "delete_at"
+                     (Ortac_runtime.report "Varray_circular_spec"
+                        "make 42 'a'" None "delete_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1310,7 +1311,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           (Some (Res (unit, ()))) "delete_at"
+                           "make 42 'a'" (Some (Res (unit, ()))) "delete_at"
                            [("Sequence.length t.contents = Sequence.length (old t.contents) - 1",
                               {
                                 Ortac_runtime.start =
@@ -1365,8 +1366,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec" None
-                           "delete_at"
+                        (Ortac_runtime.report "Varray_circular_spec"
+                           "make 42 'a'" None "delete_at"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1414,7 +1415,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec" None "get"
+                     (Ortac_runtime.report "Varray_circular_spec"
+                        "make 42 'a'" None "get"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1469,6 +1471,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
+                           "make 42 'a'"
                            (Some (Res (Ortac_runtime.dummy, ()))) "get"
                            [("(proj x) = t.contents[i]",
                               {
@@ -1524,8 +1527,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec" None
-                           "get"
+                        (Ortac_runtime.report "Varray_circular_spec"
+                           "make 42 'a'" None "get"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1573,7 +1576,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec" None "set"
+                     (Ortac_runtime.report "Varray_circular_spec"
+                        "make 42 'a'" None "set"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1629,8 +1633,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec" None
-                           "set"
+                        (Ortac_runtime.report "Varray_circular_spec"
+                           "make 42 'a'" None "set"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1678,7 +1682,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Varray_circular_spec"
+              (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
                  (Some (Res (Ortac_runtime.dummy, ()))) "length"
                  [("l = Sequence.length t.contents",
                     {
@@ -1727,7 +1731,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Varray_circular_spec"
+              (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
                  (Some (Res (Ortac_runtime.dummy, ()))) "is_empty"
                  [("b <-> t.contents = Sequence.empty",
                     {
@@ -1791,7 +1795,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec" None "fill"
+                     (Ortac_runtime.report "Varray_circular_spec"
+                        "make 42 'a'" None "fill"
                         [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -1863,8 +1868,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec" None
-                           "fill"
+                        (Ortac_runtime.report "Varray_circular_spec"
+                           "make 42 'a'" None "fill"
                            [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =

--- a/examples/varray_tests.ml
+++ b/examples/varray_tests.ml
@@ -758,7 +758,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_spec"
+                   (Ortac_runtime.report "Varray_spec" "make 42 'a'"
                       (Some (Res (Ortac_runtime.dummy, ()))) "pop_back"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = (old t.contents)[Sequence.length (old t.contents) - 1]",
                          {
@@ -811,7 +811,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_spec" None "pop_back"
+                   (Ortac_runtime.report "Varray_spec" "make 42 'a'" None
+                      "pop_back"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -868,7 +869,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_spec"
+                   (Ortac_runtime.report "Varray_spec" "make 42 'a'"
                       (Some (Res (Ortac_runtime.dummy, ()))) "pop_front"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = Sequence.hd (old t.contents)",
                          {
@@ -921,7 +922,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_spec" None "pop_front"
+                   (Ortac_runtime.report "Varray_spec" "make 42 'a'" None
+                      "pop_front"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -977,7 +979,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_spec" None "insert_at"
+                     (Ortac_runtime.report "Varray_spec" "make 42 'a'" None
+                        "insert_at"
                         [("0 <= i <= Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -1037,7 +1040,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_spec" None "insert_at"
+                        (Ortac_runtime.report "Varray_spec" "make 42 'a'"
+                           None "insert_at"
                            [("0 <= i <= Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1085,7 +1089,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_spec" None "pop_at"
+                     (Ortac_runtime.report "Varray_spec" "make 42 'a'" None
+                        "pop_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1137,7 +1142,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_spec"
+                        (Ortac_runtime.report "Varray_spec" "make 42 'a'"
                            (Some (Res (Ortac_runtime.dummy, ()))) "pop_at"
                            [("(proj x) = old t.contents[i]",
                               {
@@ -1191,7 +1196,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_spec" None "pop_at"
+                        (Ortac_runtime.report "Varray_spec" "make 42 'a'"
+                           None "pop_at"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1239,7 +1245,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_spec" None "delete_at"
+                     (Ortac_runtime.report "Varray_spec" "make 42 'a'" None
+                        "delete_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1294,7 +1301,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_spec"
+                        (Ortac_runtime.report "Varray_spec" "make 42 'a'"
                            (Some (Res (unit, ()))) "delete_at"
                            [("Sequence.length t.contents = Sequence.length (old t.contents) - 1",
                               {
@@ -1348,7 +1355,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_spec" None "delete_at"
+                        (Ortac_runtime.report "Varray_spec" "make 42 'a'"
+                           None "delete_at"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1396,7 +1404,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_spec" None "get"
+                     (Ortac_runtime.report "Varray_spec" "make 42 'a'" None
+                        "get"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1448,7 +1457,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_spec"
+                        (Ortac_runtime.report "Varray_spec" "make 42 'a'"
                            (Some (Res (Ortac_runtime.dummy, ()))) "get"
                            [("(proj x) = t.contents[i]",
                               {
@@ -1502,7 +1511,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_spec" None "get"
+                        (Ortac_runtime.report "Varray_spec" "make 42 'a'"
+                           None "get"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1550,7 +1560,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_spec" None "set"
+                     (Ortac_runtime.report "Varray_spec" "make 42 'a'" None
+                        "set"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1604,7 +1615,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_spec" None "set"
+                        (Ortac_runtime.report "Varray_spec" "make 42 'a'"
+                           None "set"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1652,7 +1664,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Varray_spec"
+              (Ortac_runtime.report "Varray_spec" "make 42 'a'"
                  (Some (Res (Ortac_runtime.dummy, ()))) "length"
                  [("l = Sequence.length t.contents",
                     {
@@ -1701,7 +1713,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Varray_spec"
+              (Ortac_runtime.report "Varray_spec" "make 42 'a'"
                  (Some (Res (Ortac_runtime.dummy, ()))) "is_empty"
                  [("b <-> t.contents = Sequence.empty",
                     {
@@ -1765,7 +1777,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_spec" None "fill"
+                     (Ortac_runtime.report "Varray_spec" "make 42 'a'" None
+                        "fill"
                         [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -1835,7 +1848,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_spec" None "fill"
+                        (Ortac_runtime.report "Varray_spec" "make 42 'a'"
+                           None "fill"
                            [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =

--- a/examples/varray_tests.ml
+++ b/examples/varray_tests.ml
@@ -80,28 +80,29 @@ module Spec =
     let show_cmd cmd__003_ =
       match cmd__003_ with
       | Push_back x ->
-          Format.asprintf "%s %a" "push_back"
+          Format.asprintf "%s sut %a" "push_back"
             (Util.Pp.pp_elt Util.Pp.pp_char true) x
-      | Pop_back -> Format.asprintf "%s" "pop_back"
+      | Pop_back -> Format.asprintf "%s sut" "pop_back"
       | Push_front x_1 ->
-          Format.asprintf "%s %a" "push_front"
+          Format.asprintf "%s sut %a" "push_front"
             (Util.Pp.pp_elt Util.Pp.pp_char true) x_1
-      | Pop_front -> Format.asprintf "%s" "pop_front"
+      | Pop_front -> Format.asprintf "%s sut" "pop_front"
       | Insert_at (i_1, x_2) ->
-          Format.asprintf "%s %a %a" "insert_at" (Util.Pp.pp_int true) i_1
-            (Util.Pp.pp_elt Util.Pp.pp_char true) x_2
+          Format.asprintf "%s sut %a %a" "insert_at" (Util.Pp.pp_int true)
+            i_1 (Util.Pp.pp_elt Util.Pp.pp_char true) x_2
       | Pop_at i_2 ->
-          Format.asprintf "%s %a" "pop_at" (Util.Pp.pp_int true) i_2
+          Format.asprintf "%s sut %a" "pop_at" (Util.Pp.pp_int true) i_2
       | Delete_at i_3 ->
-          Format.asprintf "%s %a" "delete_at" (Util.Pp.pp_int true) i_3
-      | Get i_4 -> Format.asprintf "%s %a" "get" (Util.Pp.pp_int true) i_4
+          Format.asprintf "%s sut %a" "delete_at" (Util.Pp.pp_int true) i_3
+      | Get i_4 ->
+          Format.asprintf "%s sut %a" "get" (Util.Pp.pp_int true) i_4
       | Set (i_5, v) ->
-          Format.asprintf "%s %a %a" "set" (Util.Pp.pp_int true) i_5
+          Format.asprintf "%s sut %a %a" "set" (Util.Pp.pp_int true) i_5
             (Util.Pp.pp_elt Util.Pp.pp_char true) v
-      | Length -> Format.asprintf "%s" "length"
-      | Is_empty -> Format.asprintf "%s" "is_empty"
+      | Length -> Format.asprintf "%s sut" "length"
+      | Is_empty -> Format.asprintf "%s sut" "is_empty"
       | Fill (pos, len, x_3) ->
-          Format.asprintf "%s %a %a %a" "fill" (Util.Pp.pp_int true) pos
+          Format.asprintf "%s sut %a %a %a" "fill" (Util.Pp.pp_int true) pos
             (Util.Pp.pp_int true) len (Util.Pp.pp_elt Util.Pp.pp_char true)
             x_3
     type nonrec state = {
@@ -757,7 +758,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "pop_back"
+                   (Ortac_runtime.report "Varray_spec" "pop_back"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = (old t.contents)[Sequence.length (old t.contents) - 1]",
                          {
                            Ortac_runtime.start =
@@ -809,7 +810,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "pop_back"
+                   (Ortac_runtime.report "Varray_spec" "pop_back"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -866,7 +867,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "pop_front"
+                   (Ortac_runtime.report "Varray_spec" "pop_front"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = Sequence.hd (old t.contents)",
                          {
                            Ortac_runtime.start =
@@ -918,7 +919,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "pop_front"
+                   (Ortac_runtime.report "Varray_spec" "pop_front"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -974,7 +975,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "insert_at"
+                     (Ortac_runtime.report "Varray_spec" "insert_at"
                         [("0 <= i <= Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -1034,7 +1035,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "insert_at"
+                        (Ortac_runtime.report "Varray_spec" "insert_at"
                            [("0 <= i <= Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1082,7 +1083,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "pop_at"
+                     (Ortac_runtime.report "Varray_spec" "pop_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1134,7 +1135,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "pop_at"
+                        (Ortac_runtime.report "Varray_spec" "pop_at"
                            [("(proj x) = old t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -1187,7 +1188,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "pop_at"
+                        (Ortac_runtime.report "Varray_spec" "pop_at"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1235,7 +1236,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "delete_at"
+                     (Ortac_runtime.report "Varray_spec" "delete_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1290,7 +1291,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "delete_at"
+                        (Ortac_runtime.report "Varray_spec" "delete_at"
                            [("Sequence.length t.contents = Sequence.length (old t.contents) - 1",
                               {
                                 Ortac_runtime.start =
@@ -1343,7 +1344,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "delete_at"
+                        (Ortac_runtime.report "Varray_spec" "delete_at"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1391,7 +1392,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "get"
+                     (Ortac_runtime.report "Varray_spec" "get"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1443,7 +1444,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "get"
+                        (Ortac_runtime.report "Varray_spec" "get"
                            [("(proj x) = t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -1496,7 +1497,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "get"
+                        (Ortac_runtime.report "Varray_spec" "get"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1544,7 +1545,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "set"
+                     (Ortac_runtime.report "Varray_spec" "set"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1598,7 +1599,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "set"
+                        (Ortac_runtime.report "Varray_spec" "set"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1646,7 +1647,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
           then None
           else
             Some
-              (Ortac_runtime.report "length"
+              (Ortac_runtime.report "Varray_spec" "length"
                  [("l = Sequence.length t.contents",
                     {
                       Ortac_runtime.start =
@@ -1694,7 +1695,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
           then None
           else
             Some
-              (Ortac_runtime.report "is_empty"
+              (Ortac_runtime.report "Varray_spec" "is_empty"
                  [("b <-> t.contents = Sequence.empty",
                     {
                       Ortac_runtime.start =
@@ -1757,7 +1758,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "fill"
+                     (Ortac_runtime.report "Varray_spec" "fill"
                         [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -1827,7 +1828,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "fill"
+                        (Ortac_runtime.report "Varray_spec" "fill"
                            [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =

--- a/examples/varray_tests.ml
+++ b/examples/varray_tests.ml
@@ -758,7 +758,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_spec" "pop_back"
+                   (Ortac_runtime.report "Varray_spec"
+                      (Some (Res (Ortac_runtime.dummy, ()))) "pop_back"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = (old t.contents)[Sequence.length (old t.contents) - 1]",
                          {
                            Ortac_runtime.start =
@@ -810,7 +811,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_spec" "pop_back"
+                   (Ortac_runtime.report "Varray_spec" None "pop_back"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -867,7 +868,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_spec" "pop_front"
+                   (Ortac_runtime.report "Varray_spec"
+                      (Some (Res (Ortac_runtime.dummy, ()))) "pop_front"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = Sequence.hd (old t.contents)",
                          {
                            Ortac_runtime.start =
@@ -919,7 +921,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_spec" "pop_front"
+                   (Ortac_runtime.report "Varray_spec" None "pop_front"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -975,7 +977,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_spec" "insert_at"
+                     (Ortac_runtime.report "Varray_spec" None "insert_at"
                         [("0 <= i <= Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -1035,7 +1037,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_spec" "insert_at"
+                        (Ortac_runtime.report "Varray_spec" None "insert_at"
                            [("0 <= i <= Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1083,7 +1085,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_spec" "pop_at"
+                     (Ortac_runtime.report "Varray_spec" None "pop_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1135,7 +1137,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_spec" "pop_at"
+                        (Ortac_runtime.report "Varray_spec"
+                           (Some (Res (Ortac_runtime.dummy, ()))) "pop_at"
                            [("(proj x) = old t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -1188,7 +1191,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_spec" "pop_at"
+                        (Ortac_runtime.report "Varray_spec" None "pop_at"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1236,7 +1239,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_spec" "delete_at"
+                     (Ortac_runtime.report "Varray_spec" None "delete_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1291,7 +1294,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_spec" "delete_at"
+                        (Ortac_runtime.report "Varray_spec"
+                           (Some (Res (unit, ()))) "delete_at"
                            [("Sequence.length t.contents = Sequence.length (old t.contents) - 1",
                               {
                                 Ortac_runtime.start =
@@ -1344,7 +1348,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_spec" "delete_at"
+                        (Ortac_runtime.report "Varray_spec" None "delete_at"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1392,7 +1396,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_spec" "get"
+                     (Ortac_runtime.report "Varray_spec" None "get"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1444,7 +1448,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_spec" "get"
+                        (Ortac_runtime.report "Varray_spec"
+                           (Some (Res (Ortac_runtime.dummy, ()))) "get"
                            [("(proj x) = t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -1497,7 +1502,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_spec" "get"
+                        (Ortac_runtime.report "Varray_spec" None "get"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1545,7 +1550,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_spec" "set"
+                     (Ortac_runtime.report "Varray_spec" None "set"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1599,7 +1604,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_spec" "set"
+                        (Ortac_runtime.report "Varray_spec" None "set"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1647,7 +1652,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Varray_spec" "length"
+              (Ortac_runtime.report "Varray_spec"
+                 (Some (Res (Ortac_runtime.dummy, ()))) "length"
                  [("l = Sequence.length t.contents",
                     {
                       Ortac_runtime.start =
@@ -1695,7 +1701,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Varray_spec" "is_empty"
+              (Ortac_runtime.report "Varray_spec"
+                 (Some (Res (Ortac_runtime.dummy, ()))) "is_empty"
                  [("b <-> t.contents = Sequence.empty",
                     {
                       Ortac_runtime.start =
@@ -1758,7 +1765,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_spec" "fill"
+                     (Ortac_runtime.report "Varray_spec" None "fill"
                         [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -1828,7 +1835,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_spec" "fill"
+                        (Ortac_runtime.report "Varray_spec" None "fill"
                            [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =

--- a/plugins/qcheck-stm/doc/index.mld
+++ b/plugins/qcheck-stm/doc/index.mld
@@ -263,6 +263,10 @@ val type_not_supported : new_type -> 'a t -> new_type
 
 {@sh[
 $ ortac qcheck-stm example_unknown_type.mli "make 42 'a'" "char t" -o foo.ml
+File "example_unknown_type.mli", line 15, characters 0-87:
+15 | val type_not_supported : new_type -> 'a t -> new_type
+16 | (*@ y = type_not_supported x t *)
+Warning: Incomplete computation of the returned value in the specification of type_not_supported. Failure message won't be able to display the expected returned value.
 $ grep -A 1 "type cmd" foo.ml
     type cmd =
       | Type_not_supported of new_type
@@ -348,6 +352,11 @@ the command will generate the following warning:
 
 {@sh[
 $ ortac qcheck-stm example_ill_formed_quantification.mli "make 42 'a'" "char t" -o foo.ml
+File "example_ill_formed_quantification.mli", line 13, characters 0-142:
+13 | val unsupported_quantification : 'a t -> bool
+14 | (*@ b = unsupported_quantification t
+15 |     ensures b = forall a. List.mem a t.contents -> a = a *)
+Warning: Incomplete computation of the returned value in the specification of unsupported_quantification. Failure message won't be able to display the expected returned value.
 File "example_ill_formed_quantification.mli", line 15, characters 16-56:
 15 |     ensures b = forall a. List.mem a t.contents -> a = a *)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -422,6 +431,10 @@ File "example_limitations.mli", line 28, characters 15-25:
 28 | val for_all : ('a -> bool) -> 'a t -> bool
                     ^^^^^^^^^^
 Warning: Skipping for_all: functions are not supported yet as arguments.
+File "example_limitations.mli", line 22, characters 0-50:
+22 | val g : int * int -> 'a t -> bool
+23 | (*@ b = g x t *)
+Warning: Incomplete computation of the returned value in the specification of g. Failure message won't be able to display the expected returned value.
 File "example_limitations.mli", line 22, characters 8-17:
 22 | val g : int * int -> 'a t -> bool
              ^^^^^^^^^

--- a/plugins/qcheck-stm/src/config.ml
+++ b/plugins/qcheck-stm/src/config.ml
@@ -6,6 +6,7 @@ type t = {
   context : Context.t;
   sut_core_type : Ppxlib.core_type;
   init_sut : Ppxlib.expression;
+  init_sut_txt : string;
 }
 
 let get_sut_type_name config =
@@ -74,7 +75,7 @@ let init_sut_from_string str =
   try Parse.expression (Lexing.from_string str) |> Reserr.ok
   with _ -> Reserr.(error (Syntax_error_in_init_sut str, Location.none))
 
-let init path init_sut sut_str =
+let init path init_sut_txt sut_str =
   let open Reserr in
   try
     let module_name = Utils.module_name_of_path path in
@@ -96,7 +97,7 @@ let init path init_sut sut_str =
     in
     let context = List.fold_left add context sigs in
     let* sut_core_type = sut_core_type sut_str
-    and* init_sut = init_sut_from_string init_sut in
-    ok (sigs, { context; sut_core_type; init_sut })
+    and* init_sut = init_sut_from_string init_sut_txt in
+    ok (sigs, { context; sut_core_type; init_sut; init_sut_txt })
   with Gospel.Warnings.Error (l, k) ->
     error (Ortac_core.Warnings.GospelError k, l)

--- a/plugins/qcheck-stm/src/ir.ml
+++ b/plugins/qcheck-stm/src/ir.ml
@@ -45,6 +45,7 @@ type value = {
   args : (Ppxlib.core_type * Ident.t option) list;
       (* arguments of unit types can be nameless *)
   ret : Ident.t list;
+  ret_values : term list list;
   next_state : next_state;
   precond : Tterm.term list;
   postcond : postcond;
@@ -63,8 +64,19 @@ let get_return_type value =
   in
   aux value.ty
 
-let value id ty inst sut_var args ret next_state precond postcond =
-  { id; ty; inst; sut_var; args; ret; next_state; precond; postcond }
+let value id ty inst sut_var args ret ret_values next_state precond postcond =
+  {
+    id;
+    ty;
+    inst;
+    sut_var;
+    args;
+    ret;
+    ret_values;
+    next_state;
+    precond;
+    postcond;
+  }
 
 type t = {
   state : (Ident.t * Ppxlib.core_type) list;

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -35,6 +35,7 @@ type W.kind +=
   | Returned_tuple of string
   | Ghost_values of (string * [ `Arg | `Ret ])
   | Incompatible_sut of string
+  | Incomplete_ret_val_computation of string
 
 let level kind =
   match kind with
@@ -42,7 +43,8 @@ let level kind =
   | Multiple_sut_arguments _ | Incompatible_type _ | No_spec _
   | Impossible_term_substitution _ | Ignored_modifies
   | Ensures_not_found_for_next_state _ | Type_not_supported _
-  | Functional_argument _ | Returned_tuple _ | Ghost_values _ ->
+  | Functional_argument _ | Returned_tuple _ | Ghost_values _
+  | Incomplete_ret_val_computation _ ->
       W.Warning
   | No_sut_type _ | No_init_function _ | Syntax_error_in_type _
   | Sut_type_not_supported _ | Type_not_supported_for_sut_parameter _
@@ -216,6 +218,12 @@ let pp_kind ppf kind =
         "the declaration of the SUT type is incompatible with the configured \
          one: "
         t
+  | Incomplete_ret_val_computation fct ->
+      pf ppf
+        "Incomplete computation of the returned value in the specification of \
+         %s. Failure message won't be able to display the expected returned \
+         value"
+        fct
   | _ -> W.pp_kind ppf kind
 
 let pp_errors = W.pp_param pp_kind level |> Fmt.list

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -35,6 +35,7 @@ type W.kind +=
   | Returned_tuple of string
   | Ghost_values of (string * [ `Arg | `Ret ])
   | Incompatible_sut of string
+  | Incomplete_ret_val_computation of string
 
 type 'a reserr
 

--- a/plugins/qcheck-stm/src/runtime/ortac_runtime_qcheck_stm.ml
+++ b/plugins/qcheck-stm/src/runtime/ortac_runtime_qcheck_stm.ml
@@ -3,12 +3,14 @@ include Ortac_runtime
 
 type report = {
   mod_name : string;
+  init_sut : string;
   ret : res option;
   cmd : string;
   terms : (string * location) list;
 }
 
-let report mod_name ret cmd terms = { mod_name; ret; cmd; terms }
+let report mod_name init_sut ret cmd terms =
+  { mod_name; init_sut; ret; cmd; terms }
 
 let append a b =
   match (a, b) with
@@ -28,7 +30,7 @@ module Make (Spec : Spec) = struct
   open QCheck
   module Internal = Internal.Make (Spec) [@alert "-internal"]
 
-  let pp_trace ppf (trace, mod_name, ret) =
+  let pp_trace ppf (trace, mod_name, init_sut, ret) =
     let open Fmt in
     let pp_expected ppf = function
       | Some ret when not @@ is_dummy ret ->
@@ -45,7 +47,7 @@ module Make (Spec : Spec) = struct
           aux ppf xs
       | _ -> assert false
     in
-    pf ppf "@[open %s@\nlet sut = init_sut@\n%a@]" mod_name aux trace
+    pf ppf "@[open %s@\nlet sut = %s@\n%a@]" mod_name init_sut aux trace
 
   let pp_terms ppf err =
     let open Fmt in
@@ -60,7 +62,7 @@ module Make (Spec : Spec) = struct
        when executing the following sequence of operations:@\n\
        @;\
       \  @[%a@]@." report.cmd pp_terms report.terms pp_trace
-      (trace, report.mod_name, report.ret)
+      (trace, report.mod_name, report.init_sut, report.ret)
 
   let rec check_disagree postcond s sut cs =
     match cs with

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -485,6 +485,7 @@ let postcond_case config state invariants idx state_ident new_state_ident value
               [
                 ( Nolabel,
                   estring @@ Ortac_core.Context.module_name config.context );
+                (Nolabel, estring config.init_sut_txt);
                 (* we report the expected returned value only for normal behaviour *)
                 (Nolabel, if normal then ret_val else enone);
                 (Nolabel, cmd);

--- a/plugins/qcheck-stm/test/all_warnings_errors.expected
+++ b/plugins/qcheck-stm/test/all_warnings_errors.expected
@@ -68,10 +68,32 @@ Warning: Skipping term_refer_to_returned_value_next_state: model contents is
          was found. Specifications should contain at least one "ensures
          x.contents = expr" where x is the SUT and expr can refer to the SUT
          only under an old operator and can't refer to the returned value.
+File "all_warnings.mli", line 39, characters 0-66:
+39 | val type_not_supported : 'a t -> s
+40 | (*@ s = type_not_supported t *)
+Warning: Incomplete computation of the returned value in the specification of type_not_supported. Failure message won't be able to display the expected returned value.
+File "all_warnings.mli", line 51, characters 0-140:
+51 | val unsupported_quantification : 'a t -> bool
+52 | (*@ b = unsupported_quantification t
+53 |     ensures b = forall a. List.mem a t.contents -> p a *)
+Warning: Incomplete computation of the returned value in the specification of unsupported_quantification. Failure message won't be able to display the expected returned value.
 File "all_warnings.mli", line 53, characters 16-54:
 53 |     ensures b = forall a. List.mem a t.contents -> p a *)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning: Skipping clause: unsupported quantification.
+File "all_warnings.mli", line 55, characters 0-111:
+55 | val record_not_model_field : 'a t -> bool
+56 | (*@ b = record_not_model_field t
+57 |     requires Array.length t.v > 0 *)
+Warning: Incomplete computation of the returned value in the specification of record_not_model_field. Failure message won't be able to display the expected returned value.
+File "all_warnings.mli", line 62, characters 0-278:
+62 | val term_refer_to_returned_value_next_state : 'a t -> 'a option
+63 | (*@ o = term_refer_to_returned_value_next_state t
+64 |     modifies t.contents
+65 |     ensures t.contents = match o with
+66 |                         | None -> old t.contents
+67 |                         | Some _ -> old t.contents *)
+Warning: Incomplete computation of the returned value in the specification of term_refer_to_returned_value_next_state. Failure message won't be able to display the expected returned value.
 File "all_warnings.mli", line 57, characters 26-29:
 57 |     requires Array.length t.v > 0 *)
                                ^^^

--- a/plugins/qcheck-stm/test/array_errors.expected
+++ b/plugins/qcheck-stm/test/array_errors.expected
@@ -1,0 +1,5 @@
+File "array.mli", line 38, characters 0-85:
+38 | val mem : 'a -> 'a t -> bool
+39 | (*@ b = mem a t
+40 |     ensures b = List.mem a t.contents *)
+Warning: Incomplete computation of the returned value in the specification of mem. Failure message won't be able to display the expected returned value.

--- a/plugins/qcheck-stm/test/array_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/array_stm_tests.expected.ml
@@ -16,16 +16,17 @@ module Spec =
       | Mem of char 
     let show_cmd cmd__001_ =
       match cmd__001_ with
-      | Length -> Format.asprintf "%s" "length"
-      | Get i -> Format.asprintf "%s %a" "get" (Util.Pp.pp_int true) i
+      | Length -> Format.asprintf "%s sut" "length"
+      | Get i -> Format.asprintf "%s sut %a" "get" (Util.Pp.pp_int true) i
       | Set (i_1, a_1) ->
-          Format.asprintf "%s %a %a" "set" (Util.Pp.pp_int true) i_1
+          Format.asprintf "%s sut %a %a" "set" (Util.Pp.pp_int true) i_1
             (Util.Pp.pp_char true) a_1
       | Fill (i_2, j, a_2) ->
-          Format.asprintf "%s %a %a %a" "fill" (Util.Pp.pp_int true) i_2
+          Format.asprintf "%s sut %a %a %a" "fill" (Util.Pp.pp_int true) i_2
             (Util.Pp.pp_int true) j (Util.Pp.pp_char true) a_2
-      | To_list -> Format.asprintf "%s" "to_list"
-      | Mem a_3 -> Format.asprintf "%s %a" "mem" (Util.Pp.pp_char true) a_3
+      | To_list -> Format.asprintf "%s sut" "to_list"
+      | Mem a_3 ->
+          Format.asprintf "%s %a sut" "mem" (Util.Pp.pp_char true) a_3
     type nonrec state = {
       size: int ;
       contents: char list }
@@ -363,7 +364,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
           then None
           else
             Some
-              (Ortac_runtime.report "length"
+              (Ortac_runtime.report "Array" "length"
                  [("i = t.size",
                     {
                       Ortac_runtime.start =
@@ -418,7 +419,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "get"
+                     (Ortac_runtime.report "Array" "get"
                         [("0 <= i < t.size",
                            {
                              Ortac_runtime.start =
@@ -470,7 +471,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "get"
+                        (Ortac_runtime.report "Array" "get"
                            [("a = List.nth t.contents i",
                               {
                                 Ortac_runtime.start =
@@ -529,7 +530,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "get"
+                        (Ortac_runtime.report "Array" "get"
                            [("0 <= i < t.size",
                               {
                                 Ortac_runtime.start =
@@ -584,7 +585,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "set"
+                     (Ortac_runtime.report "Array" "set"
                         [("0 <= i < t.size",
                            {
                              Ortac_runtime.start =
@@ -644,7 +645,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "set"
+                        (Ortac_runtime.report "Array" "set"
                            [("0 <= i < t.size",
                               {
                                 Ortac_runtime.start =
@@ -693,7 +694,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "fill"
+                        (Ortac_runtime.report "Array" "fill"
                            [("0 <= i",
                               {
                                 Ortac_runtime.start =
@@ -741,7 +742,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "fill"
+                           (Ortac_runtime.report "Array" "fill"
                               [("0 <= j",
                                  {
                                    Ortac_runtime.start =
@@ -792,7 +793,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "fill"
+                           (Ortac_runtime.report "Array" "fill"
                               [("i + j <= t.size",
                                  {
                                    Ortac_runtime.start =
@@ -846,7 +847,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "fill"
+                           (Ortac_runtime.report "Array" "fill"
                               [("0 <= i",
                                  {
                                    Ortac_runtime.start =
@@ -894,7 +895,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                           then None
                           else
                             Some
-                              (Ortac_runtime.report "fill"
+                              (Ortac_runtime.report "Array" "fill"
                                  [("0 <= j",
                                     {
                                       Ortac_runtime.start =
@@ -946,7 +947,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                           then None
                           else
                             Some
-                              (Ortac_runtime.report "fill"
+                              (Ortac_runtime.report "Array" "fill"
                                  [("i + j <= t.size",
                                     {
                                       Ortac_runtime.start =
@@ -991,7 +992,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
           then None
           else
             Some
-              (Ortac_runtime.report "to_list"
+              (Ortac_runtime.report "Array" "to_list"
                  [("l = t.contents",
                     {
                       Ortac_runtime.start =
@@ -1039,7 +1040,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
           then None
           else
             Some
-              (Ortac_runtime.report "mem"
+              (Ortac_runtime.report "Array" "mem"
                  [("b = List.mem a t.contents",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/array_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/array_stm_tests.expected.ml
@@ -364,7 +364,32 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Array" "length"
+              (Ortac_runtime.report "Array"
+                 (Some
+                    (Res
+                       (int,
+                         (try (Lazy.force new_state__011_).size
+                          with
+                          | e ->
+                              raise
+                                (Ortac_runtime.Partial_function
+                                   (e,
+                                     {
+                                       Ortac_runtime.start =
+                                         {
+                                           pos_fname = "array.mli";
+                                           pos_lnum = 7;
+                                           pos_bol = 238;
+                                           pos_cnum = 254
+                                         };
+                                       Ortac_runtime.stop =
+                                         {
+                                           pos_fname = "array.mli";
+                                           pos_lnum = 7;
+                                           pos_bol = 238;
+                                           pos_cnum = 260
+                                         }
+                                     })))))) "length"
                  [("i = t.size",
                     {
                       Ortac_runtime.start =
@@ -419,7 +444,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Array" "get"
+                     (Ortac_runtime.report "Array" None "get"
                         [("0 <= i < t.size",
                            {
                              Ortac_runtime.start =
@@ -471,7 +496,36 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Array" "get"
+                        (Ortac_runtime.report "Array"
+                           (Some
+                              (Res
+                                 (char,
+                                   (try
+                                      Ortac_runtime.Gospelstdlib.List.nth
+                                        (Lazy.force new_state__011_).contents
+                                        (Ortac_runtime.Gospelstdlib.integer_of_int
+                                           i)
+                                    with
+                                    | e ->
+                                        raise
+                                          (Ortac_runtime.Partial_function
+                                             (e,
+                                               {
+                                                 Ortac_runtime.start =
+                                                   {
+                                                     pos_fname = "array.mli";
+                                                     pos_lnum = 12;
+                                                     pos_bol = 405;
+                                                     pos_cnum = 421
+                                                   };
+                                                 Ortac_runtime.stop =
+                                                   {
+                                                     pos_fname = "array.mli";
+                                                     pos_lnum = 12;
+                                                     pos_bol = 405;
+                                                     pos_cnum = 442
+                                                   }
+                                               })))))) "get"
                            [("a = List.nth t.contents i",
                               {
                                 Ortac_runtime.start =
@@ -530,7 +584,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Array" "get"
+                        (Ortac_runtime.report "Array" None "get"
                            [("0 <= i < t.size",
                               {
                                 Ortac_runtime.start =
@@ -585,7 +639,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Array" "set"
+                     (Ortac_runtime.report "Array" None "set"
                         [("0 <= i < t.size",
                            {
                              Ortac_runtime.start =
@@ -645,7 +699,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Array" "set"
+                        (Ortac_runtime.report "Array" None "set"
                            [("0 <= i < t.size",
                               {
                                 Ortac_runtime.start =
@@ -694,7 +748,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Array" "fill"
+                        (Ortac_runtime.report "Array" None "fill"
                            [("0 <= i",
                               {
                                 Ortac_runtime.start =
@@ -742,7 +796,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Array" "fill"
+                           (Ortac_runtime.report "Array" None "fill"
                               [("0 <= j",
                                  {
                                    Ortac_runtime.start =
@@ -793,7 +847,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Array" "fill"
+                           (Ortac_runtime.report "Array" None "fill"
                               [("i + j <= t.size",
                                  {
                                    Ortac_runtime.start =
@@ -847,7 +901,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Array" "fill"
+                           (Ortac_runtime.report "Array" None "fill"
                               [("0 <= i",
                                  {
                                    Ortac_runtime.start =
@@ -895,7 +949,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                           then None
                           else
                             Some
-                              (Ortac_runtime.report "Array" "fill"
+                              (Ortac_runtime.report "Array" None "fill"
                                  [("0 <= j",
                                     {
                                       Ortac_runtime.start =
@@ -947,7 +1001,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                           then None
                           else
                             Some
-                              (Ortac_runtime.report "Array" "fill"
+                              (Ortac_runtime.report "Array" None "fill"
                                  [("i + j <= t.size",
                                     {
                                       Ortac_runtime.start =
@@ -992,7 +1046,32 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Array" "to_list"
+              (Ortac_runtime.report "Array"
+                 (Some
+                    (Res
+                       ((list char),
+                         (try (Lazy.force new_state__011_).contents
+                          with
+                          | e ->
+                              raise
+                                (Ortac_runtime.Partial_function
+                                   (e,
+                                     {
+                                       Ortac_runtime.start =
+                                         {
+                                           pos_fname = "array.mli";
+                                           pos_lnum = 36;
+                                           pos_bol = 1559;
+                                           pos_cnum = 1575
+                                         };
+                                       Ortac_runtime.stop =
+                                         {
+                                           pos_fname = "array.mli";
+                                           pos_lnum = 36;
+                                           pos_bol = 1559;
+                                           pos_cnum = 1585
+                                         }
+                                     })))))) "to_list"
                  [("l = t.contents",
                     {
                       Ortac_runtime.start =
@@ -1040,7 +1119,8 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Array" "mem"
+              (Ortac_runtime.report "Array"
+                 (Some (Res (Ortac_runtime.dummy, ()))) "mem"
                  [("b = List.mem a t.contents",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/array_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/array_stm_tests.expected.ml
@@ -364,7 +364,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Array"
+              (Ortac_runtime.report "Array" "make 16 'a'"
                  (Some
                     (Res
                        (int,
@@ -444,7 +444,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Array" None "get"
+                     (Ortac_runtime.report "Array" "make 16 'a'" None "get"
                         [("0 <= i < t.size",
                            {
                              Ortac_runtime.start =
@@ -496,7 +496,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Array"
+                        (Ortac_runtime.report "Array" "make 16 'a'"
                            (Some
                               (Res
                                  (char,
@@ -584,7 +584,8 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Array" None "get"
+                        (Ortac_runtime.report "Array" "make 16 'a'" None
+                           "get"
                            [("0 <= i < t.size",
                               {
                                 Ortac_runtime.start =
@@ -639,7 +640,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Array" None "set"
+                     (Ortac_runtime.report "Array" "make 16 'a'" None "set"
                         [("0 <= i < t.size",
                            {
                              Ortac_runtime.start =
@@ -699,7 +700,8 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Array" None "set"
+                        (Ortac_runtime.report "Array" "make 16 'a'" None
+                           "set"
                            [("0 <= i < t.size",
                               {
                                 Ortac_runtime.start =
@@ -748,7 +750,8 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Array" None "fill"
+                        (Ortac_runtime.report "Array" "make 16 'a'" None
+                           "fill"
                            [("0 <= i",
                               {
                                 Ortac_runtime.start =
@@ -796,7 +799,8 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Array" None "fill"
+                           (Ortac_runtime.report "Array" "make 16 'a'" None
+                              "fill"
                               [("0 <= j",
                                  {
                                    Ortac_runtime.start =
@@ -847,7 +851,8 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Array" None "fill"
+                           (Ortac_runtime.report "Array" "make 16 'a'" None
+                              "fill"
                               [("i + j <= t.size",
                                  {
                                    Ortac_runtime.start =
@@ -901,7 +906,8 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Array" None "fill"
+                           (Ortac_runtime.report "Array" "make 16 'a'" None
+                              "fill"
                               [("0 <= i",
                                  {
                                    Ortac_runtime.start =
@@ -949,7 +955,8 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                           then None
                           else
                             Some
-                              (Ortac_runtime.report "Array" None "fill"
+                              (Ortac_runtime.report "Array" "make 16 'a'"
+                                 None "fill"
                                  [("0 <= j",
                                     {
                                       Ortac_runtime.start =
@@ -1001,7 +1008,8 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                           then None
                           else
                             Some
-                              (Ortac_runtime.report "Array" None "fill"
+                              (Ortac_runtime.report "Array" "make 16 'a'"
+                                 None "fill"
                                  [("i + j <= t.size",
                                     {
                                       Ortac_runtime.start =
@@ -1046,7 +1054,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Array"
+              (Ortac_runtime.report "Array" "make 16 'a'"
                  (Some
                     (Res
                        ((list char),
@@ -1119,7 +1127,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Array"
+              (Ortac_runtime.report "Array" "make 16 'a'"
                  (Some (Res (Ortac_runtime.dummy, ()))) "mem"
                  [("b = List.mem a t.contents",
                     {

--- a/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
@@ -37,7 +37,7 @@ module Spec =
     let show_cmd cmd__001_ =
       match cmd__001_ with
       | Set (i_1, a_2) ->
-          Format.asprintf "%s %a %a" "set" (Util.Pp.pp_int true) i_1
+          Format.asprintf "%s sut %a %a" "set" (Util.Pp.pp_int true) i_1
             (Util.Pp.pp_char true) a_2
     type nonrec state = {
       contents: char list }
@@ -199,7 +199,7 @@ let ortac_postcond cmd__006_ state__007_ res__008_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "set"
+                     (Ortac_runtime.report "Conjunctive_clauses" "set"
                         [("0 <= i < List.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -259,7 +259,7 @@ let ortac_postcond cmd__006_ state__007_ res__008_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "set"
+                        (Ortac_runtime.report "Conjunctive_clauses" "set"
                            [("0 <= i < List.length t.contents",
                               {
                                 Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
@@ -199,7 +199,7 @@ let ortac_postcond cmd__006_ state__007_ res__008_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Conjunctive_clauses" "set"
+                     (Ortac_runtime.report "Conjunctive_clauses" None "set"
                         [("0 <= i < List.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -259,7 +259,8 @@ let ortac_postcond cmd__006_ state__007_ res__008_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Conjunctive_clauses" "set"
+                        (Ortac_runtime.report "Conjunctive_clauses" None
+                           "set"
                            [("0 <= i < List.length t.contents",
                               {
                                 Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
@@ -199,7 +199,8 @@ let ortac_postcond cmd__006_ state__007_ res__008_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Conjunctive_clauses" None "set"
+                     (Ortac_runtime.report "Conjunctive_clauses"
+                        "make 42 'a'" None "set"
                         [("0 <= i < List.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -259,8 +260,8 @@ let ortac_postcond cmd__006_ state__007_ res__008_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Conjunctive_clauses" None
-                           "set"
+                        (Ortac_runtime.report "Conjunctive_clauses"
+                           "make 42 'a'" None "set"
                            [("0 <= i < List.length t.contents",
                               {
                                 Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/hashtbl_errors.expected
+++ b/plugins/qcheck-stm/test/hashtbl_errors.expected
@@ -115,7 +115,36 @@ File "hashtbl.mli", line 106, characters 0-54:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning: Skipping seeded_hash_param: functions without specifications cannot
          be tested.
+File "hashtbl.mli", line 28, characters 0-226:
+28 | val find : ('a, 'b) t -> 'a -> 'b
+29 | (*@ b = find h a
+30 |     raises Not_found -> forall x. not (List.mem (a, x) h.contents)
+31 |     raises Not_found -> not (List.mem a (List.map fst h.contents))
+32 |     ensures List.mem (a, b) h.contents *)
+Warning: Incomplete computation of the returned value in the specification of find. Failure message won't be able to display the expected returned value.
 File "hashtbl.mli", line 30, characters 24-66:
 30 |     raises Not_found -> forall x. not (List.mem (a, x) h.contents)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Warning: Skipping clause: unsupported quantification.
+File "hashtbl.mli", line 34, characters 0-197:
+34 | val find_opt : ('a, 'b) t -> 'a -> 'b option
+35 | (*@ o = find_opt h a
+36 |     ensures match o with
+37 |       | None -> not (List.mem a (List.map fst h.contents))
+38 |       | Some b -> List.mem (a, b) h.contents *)
+Warning: Incomplete computation of the returned value in the specification of find_opt. Failure message won't be able to display the expected returned value.
+File "hashtbl.mli", line 40, characters 0-162:
+40 | val find_all : ('a, 'b) t -> 'a -> 'b list
+41 | (*@ bs = find_all h a
+42 |     ensures bs = Sequence.filter_map (fun (x, y) -> if x = a then Some y else None) h.contents *)
+Warning: Incomplete computation of the returned value in the specification of find_all. Failure message won't be able to display the expected returned value.
+File "hashtbl.mli", line 44, characters 0-106:
+44 | val mem : ('a, 'b) t -> 'a -> bool
+45 | (*@ b = mem h a
+46 |     ensures b = List.mem a (List.map fst h.contents) *)
+Warning: Incomplete computation of the returned value in the specification of mem. Failure message won't be able to display the expected returned value.
+File "hashtbl.mli", line 74, characters 0-89:
+74 | val length : ('a, 'b) t -> int
+75 | (*@ i = length h
+76 |     ensures i = List.length h.contents *)
+Warning: Incomplete computation of the returned value in the specification of length. Failure message won't be able to display the expected returned value.

--- a/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
@@ -320,7 +320,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Hashtbl"
+                   (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
                       (Some (Res (Ortac_runtime.dummy, ()))) "find"
                       [("List.mem (a, b) h.contents",
                          {
@@ -371,7 +371,8 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Hashtbl" None "find"
+                   (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
+                      None "find"
                       [("not (List.mem a (List.map fst h.contents))",
                          {
                            Ortac_runtime.start =
@@ -434,7 +435,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Hashtbl"
+              (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
                  (Some (Res (Ortac_runtime.dummy, ()))) "find_opt"
                  [("match o with\n      | None -> not (List.mem a (List.map fst h.contents))\n      | Some b -> List.mem (a, b) h.contents",
                     {
@@ -485,7 +486,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Hashtbl"
+              (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
                  (Some (Res (Ortac_runtime.dummy, ()))) "find_all"
                  [("bs = Sequence.filter_map (fun (x, y) -> if x = a then Some y else None) h.contents",
                     {
@@ -536,7 +537,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Hashtbl"
+              (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
                  (Some (Res (Ortac_runtime.dummy, ()))) "mem"
                  [("b = List.mem a (List.map fst h.contents)",
                     {
@@ -587,7 +588,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Hashtbl"
+              (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
                  (Some (Res (Ortac_runtime.dummy, ()))) "length"
                  [("i = List.length h.contents",
                     {

--- a/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
@@ -47,23 +47,25 @@ module Spec =
       | Length 
     let show_cmd cmd__001_ =
       match cmd__001_ with
-      | Clear -> Format.asprintf "%s" "clear"
-      | Reset -> Format.asprintf "%s" "reset"
+      | Clear -> Format.asprintf "%s sut" "clear"
+      | Reset -> Format.asprintf "%s sut" "reset"
       | Add (a_2, b_2) ->
-          Format.asprintf "%s %a %a" "add" (Util.Pp.pp_char true) a_2
+          Format.asprintf "%s sut %a %a" "add" (Util.Pp.pp_char true) a_2
             (Util.Pp.pp_int true) b_2
-      | Find a_3 -> Format.asprintf "%s %a" "find" (Util.Pp.pp_char true) a_3
+      | Find a_3 ->
+          Format.asprintf "%s sut %a" "find" (Util.Pp.pp_char true) a_3
       | Find_opt a_4 ->
-          Format.asprintf "%s %a" "find_opt" (Util.Pp.pp_char true) a_4
+          Format.asprintf "%s sut %a" "find_opt" (Util.Pp.pp_char true) a_4
       | Find_all a_5 ->
-          Format.asprintf "%s %a" "find_all" (Util.Pp.pp_char true) a_5
-      | Mem a_6 -> Format.asprintf "%s %a" "mem" (Util.Pp.pp_char true) a_6
+          Format.asprintf "%s sut %a" "find_all" (Util.Pp.pp_char true) a_5
+      | Mem a_6 ->
+          Format.asprintf "%s sut %a" "mem" (Util.Pp.pp_char true) a_6
       | Remove a_7 ->
-          Format.asprintf "%s %a" "remove" (Util.Pp.pp_char true) a_7
+          Format.asprintf "%s sut %a" "remove" (Util.Pp.pp_char true) a_7
       | Replace (a_8, b_3) ->
-          Format.asprintf "%s %a %a" "replace" (Util.Pp.pp_char true) a_8
+          Format.asprintf "%s sut %a %a" "replace" (Util.Pp.pp_char true) a_8
             (Util.Pp.pp_int true) b_3
-      | Length -> Format.asprintf "%s" "length"
+      | Length -> Format.asprintf "%s sut" "length"
     type nonrec state = {
       contents: (char * int) list }
     let init_state =
@@ -318,7 +320,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "find"
+                   (Ortac_runtime.report "Hashtbl" "find"
                       [("List.mem (a, b) h.contents",
                          {
                            Ortac_runtime.start =
@@ -368,7 +370,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "find"
+                   (Ortac_runtime.report "Hashtbl" "find"
                       [("not (List.mem a (List.map fst h.contents))",
                          {
                            Ortac_runtime.start =
@@ -431,7 +433,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           then None
           else
             Some
-              (Ortac_runtime.report "find_opt"
+              (Ortac_runtime.report "Hashtbl" "find_opt"
                  [("match o with\n      | None -> not (List.mem a (List.map fst h.contents))\n      | Some b -> List.mem (a, b) h.contents",
                     {
                       Ortac_runtime.start =
@@ -481,7 +483,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           then None
           else
             Some
-              (Ortac_runtime.report "find_all"
+              (Ortac_runtime.report "Hashtbl" "find_all"
                  [("bs = Sequence.filter_map (fun (x, y) -> if x = a then Some y else None) h.contents",
                     {
                       Ortac_runtime.start =
@@ -531,7 +533,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           then None
           else
             Some
-              (Ortac_runtime.report "mem"
+              (Ortac_runtime.report "Hashtbl" "mem"
                  [("b = List.mem a (List.map fst h.contents)",
                     {
                       Ortac_runtime.start =
@@ -581,7 +583,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           then None
           else
             Some
-              (Ortac_runtime.report "length"
+              (Ortac_runtime.report "Hashtbl" "length"
                  [("i = List.length h.contents",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
@@ -320,7 +320,8 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Hashtbl" "find"
+                   (Ortac_runtime.report "Hashtbl"
+                      (Some (Res (Ortac_runtime.dummy, ()))) "find"
                       [("List.mem (a, b) h.contents",
                          {
                            Ortac_runtime.start =
@@ -370,7 +371,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Hashtbl" "find"
+                   (Ortac_runtime.report "Hashtbl" None "find"
                       [("not (List.mem a (List.map fst h.contents))",
                          {
                            Ortac_runtime.start =
@@ -433,7 +434,8 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Hashtbl" "find_opt"
+              (Ortac_runtime.report "Hashtbl"
+                 (Some (Res (Ortac_runtime.dummy, ()))) "find_opt"
                  [("match o with\n      | None -> not (List.mem a (List.map fst h.contents))\n      | Some b -> List.mem (a, b) h.contents",
                     {
                       Ortac_runtime.start =
@@ -483,7 +485,8 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Hashtbl" "find_all"
+              (Ortac_runtime.report "Hashtbl"
+                 (Some (Res (Ortac_runtime.dummy, ()))) "find_all"
                  [("bs = Sequence.filter_map (fun (x, y) -> if x = a then Some y else None) h.contents",
                     {
                       Ortac_runtime.start =
@@ -533,7 +536,8 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Hashtbl" "mem"
+              (Ortac_runtime.report "Hashtbl"
+                 (Some (Res (Ortac_runtime.dummy, ()))) "mem"
                  [("b = List.mem a (List.map fst h.contents)",
                     {
                       Ortac_runtime.start =
@@ -583,7 +587,8 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Hashtbl" "length"
+              (Ortac_runtime.report "Hashtbl"
+                 (Some (Res (Ortac_runtime.dummy, ()))) "length"
                  [("i = List.length h.contents",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
@@ -149,7 +149,8 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Invariants" "push"
+              (Ortac_runtime.report "Invariants" (Some (Res (unit, ())))
+                 "push"
                  [("List.length x.contents > 0",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
@@ -149,8 +149,8 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Invariants" (Some (Res (unit, ())))
-                 "push"
+              (Ortac_runtime.report "Invariants" "create 42"
+                 (Some (Res (unit, ()))) "push"
                  [("List.length x.contents > 0",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
@@ -11,7 +11,8 @@ module Spec =
       | Push of int 
     let show_cmd cmd__001_ =
       match cmd__001_ with
-      | Push a_1 -> Format.asprintf "%s %a" "push" (Util.Pp.pp_int true) a_1
+      | Push a_1 ->
+          Format.asprintf "%s %a sut" "push" (Util.Pp.pp_int true) a_1
     type nonrec state = {
       contents: int list }
     let init_state =
@@ -148,7 +149,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           then None
           else
             Some
-              (Ortac_runtime.report "push"
+              (Ortac_runtime.report "Invariants" "push"
                  [("List.length x.contents > 0",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/record_errors.expected
+++ b/plugins/qcheck-stm/test/record_errors.expected
@@ -6,6 +6,15 @@ File "record.mli", line 15, characters 12-22:
 15 | val plus2 : int -> int
                  ^^^^^^^^^^
 Warning: Skipping plus2: functions with no SUT argument cannot be tested.
+File "record.mli", line 20, characters 0-144:
+20 | val get : t -> int
+21 | (*@ i = get r
+22 |     pure
+23 |     ensures i = r.value
+24 |     ensures i = r.c
+25 |     ensures plus1 i = i + 1
+26 |     ensures plus2 i = i + 2 *)
+Warning: Incomplete computation of the returned value in the specification of get. Failure message won't be able to display the expected returned value.
 File "record.mli", line 24, characters 16-19:
 24 |     ensures i = r.c
                      ^^^

--- a/plugins/qcheck-stm/test/record_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/record_stm_tests.expected.ml
@@ -114,7 +114,8 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
              then None
              else
                Some
-                 (Ortac_runtime.report "Record" "get"
+                 (Ortac_runtime.report "Record"
+                    (Some (Res (Ortac_runtime.dummy, ()))) "get"
                     [("i = r.value",
                        {
                          Ortac_runtime.start =
@@ -164,7 +165,8 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
                 then None
                 else
                   Some
-                    (Ortac_runtime.report "Record" "get"
+                    (Ortac_runtime.report "Record"
+                       (Some (Res (Ortac_runtime.dummy, ()))) "get"
                        [("plus1 i = i + 1",
                           {
                             Ortac_runtime.start =
@@ -212,7 +214,8 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
                 then None
                 else
                   Some
-                    (Ortac_runtime.report "Record" "get"
+                    (Ortac_runtime.report "Record"
+                       (Some (Res (Ortac_runtime.dummy, ()))) "get"
                        [("plus2 i = i + 2",
                           {
                             Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/record_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/record_stm_tests.expected.ml
@@ -35,7 +35,7 @@ module Spec =
     type cmd =
       | Get 
     let show_cmd cmd__001_ =
-      match cmd__001_ with | Get -> Format.asprintf "%s" "get"
+      match cmd__001_ with | Get -> Format.asprintf "%s sut" "get"
     type nonrec state = {
       value: Ortac_runtime.integer }
     let init_state =
@@ -114,7 +114,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
              then None
              else
                Some
-                 (Ortac_runtime.report "get"
+                 (Ortac_runtime.report "Record" "get"
                     [("i = r.value",
                        {
                          Ortac_runtime.start =
@@ -164,7 +164,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
                 then None
                 else
                   Some
-                    (Ortac_runtime.report "get"
+                    (Ortac_runtime.report "Record" "get"
                        [("plus1 i = i + 1",
                           {
                             Ortac_runtime.start =
@@ -212,7 +212,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
                 then None
                 else
                   Some
-                    (Ortac_runtime.report "get"
+                    (Ortac_runtime.report "Record" "get"
                        [("plus2 i = i + 2",
                           {
                             Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/record_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/record_stm_tests.expected.ml
@@ -114,7 +114,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
              then None
              else
                Some
-                 (Ortac_runtime.report "Record"
+                 (Ortac_runtime.report "Record" "make 42"
                     (Some (Res (Ortac_runtime.dummy, ()))) "get"
                     [("i = r.value",
                        {
@@ -165,7 +165,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
                 then None
                 else
                   Some
-                    (Ortac_runtime.report "Record"
+                    (Ortac_runtime.report "Record" "make 42"
                        (Some (Res (Ortac_runtime.dummy, ()))) "get"
                        [("plus1 i = i + 1",
                           {
@@ -214,7 +214,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
                 then None
                 else
                   Some
-                    (Ortac_runtime.report "Record"
+                    (Ortac_runtime.report "Record" "make 42"
                        (Some (Res (Ortac_runtime.dummy, ()))) "get"
                        [("plus2 i = i + 2",
                           {

--- a/plugins/qcheck-stm/test/ref_errors.expected
+++ b/plugins/qcheck-stm/test/ref_errors.expected
@@ -1,3 +1,10 @@
+File "ref.mli", line 8, characters 0-96:
+ 8 | val get : t -> int
+ 9 | (*@ i = get r
+10 |     pure
+11 |     ensures i = r.value
+12 |     ensures i + 1 = succ !r *)
+Warning: Incomplete computation of the returned value in the specification of get. Failure message won't be able to display the expected returned value.
 File "ref.mli", line 12, characters 26-27:
 12 |     ensures i + 1 = succ !r *)
                                ^

--- a/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
@@ -88,7 +88,8 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Ref" "get"
+              (Ortac_runtime.report "Ref"
+                 (Some (Res (Ortac_runtime.dummy, ()))) "get"
                  [("i = r.value",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
@@ -10,7 +10,7 @@ module Spec =
     type cmd =
       | Get 
     let show_cmd cmd__001_ =
-      match cmd__001_ with | Get -> Format.asprintf "%s" "get"
+      match cmd__001_ with | Get -> Format.asprintf "%s sut" "get"
     type nonrec state = {
       value: Ortac_runtime.integer }
     let init_state =
@@ -88,7 +88,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           then None
           else
             Some
-              (Ortac_runtime.report "get"
+              (Ortac_runtime.report "Ref" "get"
                  [("i = r.value",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
@@ -88,7 +88,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Ref"
+              (Ortac_runtime.report "Ref" "make 42"
                  (Some (Res (Ortac_runtime.dummy, ()))) "get"
                  [("i = r.value",
                     {

--- a/plugins/qcheck-stm/test/sequence_model_errors.expected
+++ b/plugins/qcheck-stm/test/sequence_model_errors.expected
@@ -1,0 +1,16 @@
+File "sequence_model.mli", line 17, characters 0-253:
+17 | val remove : 'a t -> 'a option
+18 | (*@ o = remove t
+19 |     modifies t.contents
+20 |     ensures t.contents = match Sequence.length (old t.contents) with
+21 |                           | 0 -> Sequence.empty
+22 |                           | _ -> Sequence.tl (old t.contents) *)
+Warning: Incomplete computation of the returned value in the specification of remove. Failure message won't be able to display the expected returned value.
+File "sequence_model.mli", line 24, characters 0-255:
+24 | val remove_ : 'a t -> 'a option
+25 | (*@ o = remove_ t
+26 |     modifies t.contents
+27 |     ensures t.contents = match length_opt (old t.contents) with
+28 |                           | Some 0 -> Sequence.empty
+29 |                           | _ -> Sequence.tl (old t.contents) *)
+Warning: Incomplete computation of the returned value in the specification of remove_. Failure message won't be able to display the expected returned value.

--- a/plugins/qcheck-stm/test/sequence_model_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/sequence_model_stm_tests.expected.ml
@@ -36,9 +36,9 @@ module Spec =
       | Remove_ 
     let show_cmd cmd__001_ =
       match cmd__001_ with
-      | Add v -> Format.asprintf "%s %a" "add" (Util.Pp.pp_char true) v
-      | Remove -> Format.asprintf "%s" "remove"
-      | Remove_ -> Format.asprintf "%s" "remove_"
+      | Add v -> Format.asprintf "%s %a sut" "add" (Util.Pp.pp_char true) v
+      | Remove -> Format.asprintf "%s sut" "remove"
+      | Remove_ -> Format.asprintf "%s sut" "remove_"
     type nonrec state = {
       contents: char Ortac_runtime.Gospelstdlib.sequence }
     let init_state =


### PR DESCRIPTION

This PR is the continuation of, and is based on, #202.
Please consider only the six last commits.

This PR makes the failure message print a runnable scenario with information about returned and expected values.

It uses the same mechanism as introduced in #202 for communicating with `Qcheck.fail_reportf`.

For printing the commands with their `sut` argument in the right place, only the generated `show_cmd` has been modified.

Printing the user-provided value for `init_sut` is quite straightforward, we just have to pass the information to the runtime.

Printing the expected value is a bit more complicated.
First, we look at the Gospel specifications to see if there is enough information to compute the expected returned value (some functions may be specified in a way that their contract doesn't include a computation of the returned value).
If there is, we wrap this value in a `STM.res` type and send it to the runtime through `ortac_postond` along all the other information.
It there is not, we send a `dummy` value, to inform the printer that the expected returned value is unknown.
A warning will be displayed to the user in the second case, but this will not affect whether the function is tested or not.

This PR only deals with normal behaviour, meaning that the excpetional branches in `ortac_postond` don't send an expected returned value to the runtime for now.
I believe that handling exceptional behaviour can be done in another PR (this is me trying to keep PRs short).

The `ortac_runtime` now handle this extra information to print a runnable scenario to the user in case of test failure.

For now, I've made the choice to print the function calls in an `ignore` and to print the returned value and the optional expected returned value in comments.
We've discussed elsewhere about placing the function calls in an `assert`, but we don't always have an expected returned value


If we introduce a bug in `plugins/qcheck-stm/test/array.ml`, we have now:

```
λ dune build @launchtests
File "plugins/qcheck-stm/test/dune.inc", line 49, characters 0-75:
49 | (rule
50 |  (alias launchtests)
51 |  (action
52 |   (run %{dep:array_stm_tests.exe} -v)))
random seed: 515405686
generated error fail pass / total     time test name
[✗]    1    0    1    0 / 1000     0.0s Array STM tests (generating)

--- Failure --------------------------------------------------------------------

Test Array STM tests failed (14 shrink steps):

   set sut (-2603392982468686691) '\190'
   to_list sut


+++ Messages ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

Messages for test Array STM tests:

Gospel specification violation in function to_list

  File "array.mli", line 36, characters 12-26:
    l = t.contents
  
when executing the following sequence of operations:

  let sut = make 16 'a' in
  ignore (set sut (-2603392982468686691) '\190'); (* returned Error (Invalid_argument("index ou t of bounds")) *)
  ignore (to_list sut); (* returned ['a'; 'a'; 'a'; 'a'; 'a'; 'a'; 'a'; '\190'; 'a'; 'a'; 'a'; 'a'; 'a'; 'a'; 'a'; 'a']
                           expected ['a'; 'a'; 'a'; 'a'; 'a'; 'a'; 'a'; 'a'; 'a'; 'a'; 'a'; 'a' ; 'a'; 'a'; 'a'; 'a'] *)
  

================================================================================
failure (1 tests failed, 0 tests errored, ran 1 tests)
                                       
[1]
```