### PR TITLE
Add support for exceptional behaviour to printing runnable scenario

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 - Improve test-failure message
   [\#202](https://github.com/ocaml-gospel/ortac/pull/202) and
-  [\#204](https://github.com/ocaml-gospel/ortac/pull/204)
+  [\#204](https://github.com/ocaml-gospel/ortac/pull/204) and
+  [\#206](https://github.com/ocaml-gospel/ortac/pull/206)
 - Add a comment warning that the file is generated
   [\#198](https://github.com/ocaml-gospel/ortac/pull/198)
 - Add support for type invariants

--- a/examples/lwt_dllist_tests.ml
+++ b/examples/lwt_dllist_tests.ml
@@ -25,8 +25,8 @@ module Spec =
           Format.asprintf "%s %a sut" "add_l" (Util.Pp.pp_int true) a_1
       | Add_r a_2 ->
           Format.asprintf "%s %a sut" "add_r" (Util.Pp.pp_int true) a_2
-      | Take_l -> Format.asprintf "%s sut" "take_l"
-      | Take_r -> Format.asprintf "%s sut" "take_r"
+      | Take_l -> Format.asprintf "protect (fun () -> %s sut)" "take_l"
+      | Take_r -> Format.asprintf "protect (fun () -> %s sut)" "take_r"
       | Take_opt_l -> Format.asprintf "%s sut" "take_opt_l"
       | Take_opt_r -> Format.asprintf "%s sut" "take_opt_r"
     type nonrec state = {

--- a/examples/lwt_dllist_tests.ml
+++ b/examples/lwt_dllist_tests.ml
@@ -337,7 +337,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
           else
             Some
               (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                 (Some (Res (Ortac_runtime.dummy, ()))) "is_empty"
+                 (Either.right (Res (Ortac_runtime.dummy, ()))) "is_empty"
                  [("b <-> s.contents = Sequence.empty",
                     {
                       Ortac_runtime.start =
@@ -386,7 +386,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
           else
             Some
               (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                 (Some (Res (Ortac_runtime.dummy, ()))) "length"
+                 (Either.right (Res (Ortac_runtime.dummy, ()))) "length"
                  [("l = Sequence.length s.contents",
                     {
                       Ortac_runtime.start =
@@ -444,7 +444,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
                else
                  Some
                    (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                      (Some (Res (Ortac_runtime.dummy, ()))) "take_l"
+                      (Either.right (Res (Ortac_runtime.dummy, ()))) "take_l"
                       [("if old s.contents = Sequence.empty\n              then false\n              else a = Sequence.hd (old s.contents)",
                          {
                            Ortac_runtime.start =
@@ -496,8 +496,8 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Lwt_dllist_spec" "create ()" None
-                      "take_l"
+                   (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
+                      (Either.left "Empty") "take_l"
                       [("old s.contents = Sequence.empty = s.contents",
                          {
                            Ortac_runtime.start =
@@ -558,7 +558,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
                else
                  Some
                    (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                      (Some (Res (Ortac_runtime.dummy, ()))) "take_r"
+                      (Either.right (Res (Ortac_runtime.dummy, ()))) "take_r"
                       [("if old s.contents = Sequence.empty\n              then false\n              else a = (old s.contents)[Sequence.length (old s.contents) - 1]",
                          {
                            Ortac_runtime.start =
@@ -610,8 +610,8 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Lwt_dllist_spec" "create ()" None
-                      "take_r"
+                   (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
+                      (Either.left "Empty") "take_r"
                       [("old s.contents = Sequence.empty = s.contents",
                          {
                            Ortac_runtime.start =
@@ -664,7 +664,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
           else
             Some
               (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                 (Some (Res (Ortac_runtime.dummy, ()))) "take_opt_l"
+                 (Either.right (Res (Ortac_runtime.dummy, ()))) "take_opt_l"
                  [("old s.contents = match o with\n                                | None -> Sequence.empty\n                                | Some a -> Sequence.cons a s.contents",
                     {
                       Ortac_runtime.start =
@@ -716,7 +716,7 @@ let ortac_postcond cmd__005_ state__006_ res__007_ =
           else
             Some
               (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                 (Some (Res (Ortac_runtime.dummy, ()))) "take_opt_r"
+                 (Either.right (Res (Ortac_runtime.dummy, ()))) "take_opt_r"
                  [("old s.contents = match o with\n                                | None -> Sequence.empty\n                                | Some a -> Sequence.snoc s.contents a",
                     {
                       Ortac_runtime.start =

--- a/examples/varray_circular_tests.ml
+++ b/examples/varray_circular_tests.ml
@@ -82,29 +82,33 @@ module Spec =
       | Push_back x ->
           Format.asprintf "%s sut %a" "push_back"
             (Util.Pp.pp_elt Util.Pp.pp_char true) x
-      | Pop_back -> Format.asprintf "%s sut" "pop_back"
+      | Pop_back -> Format.asprintf "protect (fun () -> %s sut)" "pop_back"
       | Push_front x_1 ->
           Format.asprintf "%s sut %a" "push_front"
             (Util.Pp.pp_elt Util.Pp.pp_char true) x_1
-      | Pop_front -> Format.asprintf "%s sut" "pop_front"
+      | Pop_front -> Format.asprintf "protect (fun () -> %s sut)" "pop_front"
       | Insert_at (i_1, x_2) ->
-          Format.asprintf "%s sut %a %a" "insert_at" (Util.Pp.pp_int true)
-            i_1 (Util.Pp.pp_elt Util.Pp.pp_char true) x_2
+          Format.asprintf "protect (fun () -> %s sut %a %a)" "insert_at"
+            (Util.Pp.pp_int true) i_1 (Util.Pp.pp_elt Util.Pp.pp_char true)
+            x_2
       | Pop_at i_2 ->
-          Format.asprintf "%s sut %a" "pop_at" (Util.Pp.pp_int true) i_2
+          Format.asprintf "protect (fun () -> %s sut %a)" "pop_at"
+            (Util.Pp.pp_int true) i_2
       | Delete_at i_3 ->
-          Format.asprintf "%s sut %a" "delete_at" (Util.Pp.pp_int true) i_3
+          Format.asprintf "protect (fun () -> %s sut %a)" "delete_at"
+            (Util.Pp.pp_int true) i_3
       | Get i_4 ->
-          Format.asprintf "%s sut %a" "get" (Util.Pp.pp_int true) i_4
+          Format.asprintf "protect (fun () -> %s sut %a)" "get"
+            (Util.Pp.pp_int true) i_4
       | Set (i_5, v) ->
-          Format.asprintf "%s sut %a %a" "set" (Util.Pp.pp_int true) i_5
-            (Util.Pp.pp_elt Util.Pp.pp_char true) v
+          Format.asprintf "protect (fun () -> %s sut %a %a)" "set"
+            (Util.Pp.pp_int true) i_5 (Util.Pp.pp_elt Util.Pp.pp_char true) v
       | Length -> Format.asprintf "%s sut" "length"
       | Is_empty -> Format.asprintf "%s sut" "is_empty"
       | Fill (pos, len, x_3) ->
-          Format.asprintf "%s sut %a %a %a" "fill" (Util.Pp.pp_int true) pos
-            (Util.Pp.pp_int true) len (Util.Pp.pp_elt Util.Pp.pp_char true)
-            x_3
+          Format.asprintf "protect (fun () -> %s sut %a %a %a)" "fill"
+            (Util.Pp.pp_int true) pos (Util.Pp.pp_int true) len
+            (Util.Pp.pp_elt Util.Pp.pp_char true) x_3
     type nonrec state = {
       contents: char Ortac_runtime.Gospelstdlib.sequence }
     let init_state =

--- a/examples/varray_circular_tests.ml
+++ b/examples/varray_circular_tests.ml
@@ -763,7 +763,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                else
                  Some
                    (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
-                      (Some (Res (Ortac_runtime.dummy, ()))) "pop_back"
+                      (Either.right (Res (Ortac_runtime.dummy, ())))
+                      "pop_back"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = (old t.contents)[Sequence.length (old t.contents) - 1]",
                          {
                            Ortac_runtime.start =
@@ -816,7 +817,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                else
                  Some
                    (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
-                      None "pop_back"
+                      (Either.left "Not_found") "pop_back"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -874,7 +875,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                else
                  Some
                    (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
-                      (Some (Res (Ortac_runtime.dummy, ()))) "pop_front"
+                      (Either.right (Res (Ortac_runtime.dummy, ())))
+                      "pop_front"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = Sequence.hd (old t.contents)",
                          {
                            Ortac_runtime.start =
@@ -927,7 +929,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                else
                  Some
                    (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
-                      None "pop_front"
+                      (Either.left "Not_found") "pop_front"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -984,7 +986,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_circular_spec"
-                        "make 42 'a'" None "insert_at"
+                        "make 42 'a'" (Either.left "Invalid_argument")
+                        "insert_at"
                         [("0 <= i <= Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -1047,7 +1050,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" None "insert_at"
+                           "make 42 'a'" (Either.left "Invalid_argument")
+                           "insert_at"
                            [("0 <= i <= Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1096,7 +1100,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_circular_spec"
-                        "make 42 'a'" None "pop_at"
+                        "make 42 'a'" (Either.left "Invalid_argument")
+                        "pop_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1152,7 +1157,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
                            "make 42 'a'"
-                           (Some (Res (Ortac_runtime.dummy, ()))) "pop_at"
+                           (Either.right (Res (Ortac_runtime.dummy, ())))
+                           "pop_at"
                            [("(proj x) = old t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -1208,7 +1214,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" None "pop_at"
+                           "make 42 'a'" (Either.left "Invalid_argument")
+                           "pop_at"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1257,7 +1264,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_circular_spec"
-                        "make 42 'a'" None "delete_at"
+                        "make 42 'a'" (Either.left "Invalid_argument")
+                        "delete_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1315,7 +1323,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" (Some (Res (unit, ()))) "delete_at"
+                           "make 42 'a'" (Either.right (Res (unit, ())))
+                           "delete_at"
                            [("Sequence.length t.contents = Sequence.length (old t.contents) - 1",
                               {
                                 Ortac_runtime.start =
@@ -1371,7 +1380,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" None "delete_at"
+                           "make 42 'a'" (Either.left "Invalid_argument")
+                           "delete_at"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1420,7 +1430,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_circular_spec"
-                        "make 42 'a'" None "get"
+                        "make 42 'a'" (Either.left "Invalid_argument") "get"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1476,7 +1486,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
                            "make 42 'a'"
-                           (Some (Res (Ortac_runtime.dummy, ()))) "get"
+                           (Either.right (Res (Ortac_runtime.dummy, ())))
+                           "get"
                            [("(proj x) = t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -1532,7 +1543,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" None "get"
+                           "make 42 'a'" (Either.left "Invalid_argument")
+                           "get"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1581,7 +1593,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_circular_spec"
-                        "make 42 'a'" None "set"
+                        "make 42 'a'" (Either.left "Invalid_argument") "set"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1638,7 +1650,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" None "set"
+                           "make 42 'a'" (Either.left "Invalid_argument")
+                           "set"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1687,7 +1700,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
           else
             Some
               (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
-                 (Some (Res (Ortac_runtime.dummy, ()))) "length"
+                 (Either.right (Res (Ortac_runtime.dummy, ()))) "length"
                  [("l = Sequence.length t.contents",
                     {
                       Ortac_runtime.start =
@@ -1736,7 +1749,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
           else
             Some
               (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
-                 (Some (Res (Ortac_runtime.dummy, ()))) "is_empty"
+                 (Either.right (Res (Ortac_runtime.dummy, ()))) "is_empty"
                  [("b <-> t.contents = Sequence.empty",
                     {
                       Ortac_runtime.start =
@@ -1800,7 +1813,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_circular_spec"
-                        "make 42 'a'" None "fill"
+                        "make 42 'a'" (Either.left "Invalid_argument") "fill"
                         [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -1873,7 +1886,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" None "fill"
+                           "make 42 'a'" (Either.left "Invalid_argument")
+                           "fill"
                            [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =

--- a/examples/varray_tests.ml
+++ b/examples/varray_tests.ml
@@ -763,7 +763,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                else
                  Some
                    (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                      (Some (Res (Ortac_runtime.dummy, ()))) "pop_back"
+                      (Either.right (Res (Ortac_runtime.dummy, ())))
+                      "pop_back"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = (old t.contents)[Sequence.length (old t.contents) - 1]",
                          {
                            Ortac_runtime.start =
@@ -815,8 +816,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_spec" "make 42 'a'" None
-                      "pop_back"
+                   (Ortac_runtime.report "Varray_spec" "make 42 'a'"
+                      (Either.left "Not_found") "pop_back"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -874,7 +875,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                else
                  Some
                    (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                      (Some (Res (Ortac_runtime.dummy, ()))) "pop_front"
+                      (Either.right (Res (Ortac_runtime.dummy, ())))
+                      "pop_front"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = Sequence.hd (old t.contents)",
                          {
                            Ortac_runtime.start =
@@ -926,8 +928,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_spec" "make 42 'a'" None
-                      "pop_front"
+                   (Ortac_runtime.report "Varray_spec" "make 42 'a'"
+                      (Either.left "Not_found") "pop_front"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -983,8 +985,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_spec" "make 42 'a'" None
-                        "insert_at"
+                     (Ortac_runtime.report "Varray_spec" "make 42 'a'"
+                        (Either.left "Invalid_argument") "insert_at"
                         [("0 <= i <= Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -1045,7 +1047,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           None "insert_at"
+                           (Either.left "Invalid_argument") "insert_at"
                            [("0 <= i <= Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1093,8 +1095,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_spec" "make 42 'a'" None
-                        "pop_at"
+                     (Ortac_runtime.report "Varray_spec" "make 42 'a'"
+                        (Either.left "Invalid_argument") "pop_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1147,7 +1149,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           (Some (Res (Ortac_runtime.dummy, ()))) "pop_at"
+                           (Either.right (Res (Ortac_runtime.dummy, ())))
+                           "pop_at"
                            [("(proj x) = old t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -1201,7 +1204,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           None "pop_at"
+                           (Either.left "Invalid_argument") "pop_at"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1249,8 +1252,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_spec" "make 42 'a'" None
-                        "delete_at"
+                     (Ortac_runtime.report "Varray_spec" "make 42 'a'"
+                        (Either.left "Invalid_argument") "delete_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1306,7 +1309,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           (Some (Res (unit, ()))) "delete_at"
+                           (Either.right (Res (unit, ()))) "delete_at"
                            [("Sequence.length t.contents = Sequence.length (old t.contents) - 1",
                               {
                                 Ortac_runtime.start =
@@ -1360,7 +1363,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           None "delete_at"
+                           (Either.left "Invalid_argument") "delete_at"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1408,8 +1411,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_spec" "make 42 'a'" None
-                        "get"
+                     (Ortac_runtime.report "Varray_spec" "make 42 'a'"
+                        (Either.left "Invalid_argument") "get"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1462,7 +1465,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           (Some (Res (Ortac_runtime.dummy, ()))) "get"
+                           (Either.right (Res (Ortac_runtime.dummy, ())))
+                           "get"
                            [("(proj x) = t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -1516,7 +1520,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           None "get"
+                           (Either.left "Invalid_argument") "get"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1564,8 +1568,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_spec" "make 42 'a'" None
-                        "set"
+                     (Ortac_runtime.report "Varray_spec" "make 42 'a'"
+                        (Either.left "Invalid_argument") "set"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1620,7 +1624,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           None "set"
+                           (Either.left "Invalid_argument") "set"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1669,7 +1673,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
           else
             Some
               (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                 (Some (Res (Ortac_runtime.dummy, ()))) "length"
+                 (Either.right (Res (Ortac_runtime.dummy, ()))) "length"
                  [("l = Sequence.length t.contents",
                     {
                       Ortac_runtime.start =
@@ -1718,7 +1722,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
           else
             Some
               (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                 (Some (Res (Ortac_runtime.dummy, ()))) "is_empty"
+                 (Either.right (Res (Ortac_runtime.dummy, ()))) "is_empty"
                  [("b <-> t.contents = Sequence.empty",
                     {
                       Ortac_runtime.start =
@@ -1781,8 +1785,8 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_spec" "make 42 'a'" None
-                        "fill"
+                     (Ortac_runtime.report "Varray_spec" "make 42 'a'"
+                        (Either.left "Invalid_argument") "fill"
                         [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -1853,7 +1857,7 @@ let ortac_postcond cmd__016_ state__017_ res__018_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           None "fill"
+                           (Either.left "Invalid_argument") "fill"
                            [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =

--- a/examples/varray_tests.ml
+++ b/examples/varray_tests.ml
@@ -82,29 +82,33 @@ module Spec =
       | Push_back x ->
           Format.asprintf "%s sut %a" "push_back"
             (Util.Pp.pp_elt Util.Pp.pp_char true) x
-      | Pop_back -> Format.asprintf "%s sut" "pop_back"
+      | Pop_back -> Format.asprintf "protect (fun () -> %s sut)" "pop_back"
       | Push_front x_1 ->
           Format.asprintf "%s sut %a" "push_front"
             (Util.Pp.pp_elt Util.Pp.pp_char true) x_1
-      | Pop_front -> Format.asprintf "%s sut" "pop_front"
+      | Pop_front -> Format.asprintf "protect (fun () -> %s sut)" "pop_front"
       | Insert_at (i_1, x_2) ->
-          Format.asprintf "%s sut %a %a" "insert_at" (Util.Pp.pp_int true)
-            i_1 (Util.Pp.pp_elt Util.Pp.pp_char true) x_2
+          Format.asprintf "protect (fun () -> %s sut %a %a)" "insert_at"
+            (Util.Pp.pp_int true) i_1 (Util.Pp.pp_elt Util.Pp.pp_char true)
+            x_2
       | Pop_at i_2 ->
-          Format.asprintf "%s sut %a" "pop_at" (Util.Pp.pp_int true) i_2
+          Format.asprintf "protect (fun () -> %s sut %a)" "pop_at"
+            (Util.Pp.pp_int true) i_2
       | Delete_at i_3 ->
-          Format.asprintf "%s sut %a" "delete_at" (Util.Pp.pp_int true) i_3
+          Format.asprintf "protect (fun () -> %s sut %a)" "delete_at"
+            (Util.Pp.pp_int true) i_3
       | Get i_4 ->
-          Format.asprintf "%s sut %a" "get" (Util.Pp.pp_int true) i_4
+          Format.asprintf "protect (fun () -> %s sut %a)" "get"
+            (Util.Pp.pp_int true) i_4
       | Set (i_5, v) ->
-          Format.asprintf "%s sut %a %a" "set" (Util.Pp.pp_int true) i_5
-            (Util.Pp.pp_elt Util.Pp.pp_char true) v
+          Format.asprintf "protect (fun () -> %s sut %a %a)" "set"
+            (Util.Pp.pp_int true) i_5 (Util.Pp.pp_elt Util.Pp.pp_char true) v
       | Length -> Format.asprintf "%s sut" "length"
       | Is_empty -> Format.asprintf "%s sut" "is_empty"
       | Fill (pos, len, x_3) ->
-          Format.asprintf "%s sut %a %a %a" "fill" (Util.Pp.pp_int true) pos
-            (Util.Pp.pp_int true) len (Util.Pp.pp_elt Util.Pp.pp_char true)
-            x_3
+          Format.asprintf "protect (fun () -> %s sut %a %a %a)" "fill"
+            (Util.Pp.pp_int true) pos (Util.Pp.pp_int true) len
+            (Util.Pp.pp_elt Util.Pp.pp_char true) x_3
     type nonrec state = {
       contents: char Ortac_runtime.Gospelstdlib.sequence }
     let init_state =

--- a/plugins/qcheck-stm/src/runtime/ortac_runtime_qcheck_stm.ml
+++ b/plugins/qcheck-stm/src/runtime/ortac_runtime_qcheck_stm.ml
@@ -47,7 +47,12 @@ module Make (Spec : Spec) = struct
           aux ppf xs
       | _ -> assert false
     in
-    pf ppf "@[open %s@\nlet sut = %s@\n%a@]" mod_name init_sut aux trace
+    pf ppf
+      "@[open %s@\n\
+       let protect f = try Ok (f ()) with e -> Error e@\n\
+       let sut = %s@\n\
+       %a@]"
+      mod_name init_sut aux trace
 
   let pp_terms ppf err =
     let open Fmt in

--- a/plugins/qcheck-stm/src/runtime/ortac_runtime_qcheck_stm.ml
+++ b/plugins/qcheck-stm/src/runtime/ortac_runtime_qcheck_stm.ml
@@ -4,7 +4,7 @@ include Ortac_runtime
 type report = {
   mod_name : string;
   init_sut : string;
-  ret : res option;
+  ret : (string, res) Either.t;
   cmd : string;
   terms : (string * location) list;
 }
@@ -33,8 +33,14 @@ module Make (Spec : Spec) = struct
   let pp_trace ppf (trace, mod_name, init_sut, ret) =
     let open Fmt in
     let pp_expected ppf = function
-      | Some ret when not @@ is_dummy ret ->
+      | Either.Right ret when not @@ is_dummy ret ->
           pf ppf "assert (r = %s)@\n" (show_res ret)
+      | Either.Left exn ->
+          pf ppf
+            "assert (@[match r with@\n\
+            \  @[| Error (%s _) -> true@\n\
+             | _ -> false@]@])@\n"
+            exn
       | _ -> ()
     in
     let rec aux ppf = function

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -748,9 +748,13 @@ let pp_cmd_case config value =
              type)"
     in
     let* fmt, pp_args = aux value.ty value.args in
-    let fmt = String.concat " " ("%s" :: fmt) |> estring in
+    let fmt =
+      let call = String.concat " " ("%s" :: fmt) in
+      if may_raise_exception value then "protect (fun () -> " ^ call ^ ")"
+      else call
+    in
     let args =
-      List.map (fun x -> (Nolabel, x)) (fmt :: estring name :: pp_args)
+      List.map (fun x -> (Nolabel, x)) (estring fmt :: estring name :: pp_args)
     in
     pexp_apply (qualify [ "Format" ] "asprintf") args |> ok
   in

--- a/plugins/qcheck-stm/test/array_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/array_stm_tests.expected.ml
@@ -368,7 +368,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
           else
             Some
               (Ortac_runtime.report "Array" "make 16 'a'"
-                 (Some
+                 (Either.right
                     (Res
                        (int,
                          (try (Lazy.force new_state__011_).size
@@ -447,7 +447,8 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Array" "make 16 'a'" None "get"
+                     (Ortac_runtime.report "Array" "make 16 'a'"
+                        (Either.left "Invalid_argument") "get"
                         [("0 <= i < t.size",
                            {
                              Ortac_runtime.start =
@@ -500,7 +501,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                     else
                       Some
                         (Ortac_runtime.report "Array" "make 16 'a'"
-                           (Some
+                           (Either.right
                               (Res
                                  (char,
                                    (try
@@ -587,8 +588,8 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Array" "make 16 'a'" None
-                           "get"
+                        (Ortac_runtime.report "Array" "make 16 'a'"
+                           (Either.left "Invalid_argument") "get"
                            [("0 <= i < t.size",
                               {
                                 Ortac_runtime.start =
@@ -643,7 +644,8 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Array" "make 16 'a'" None "set"
+                     (Ortac_runtime.report "Array" "make 16 'a'"
+                        (Either.left "Invalid_argument") "set"
                         [("0 <= i < t.size",
                            {
                              Ortac_runtime.start =
@@ -703,8 +705,8 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Array" "make 16 'a'" None
-                           "set"
+                        (Ortac_runtime.report "Array" "make 16 'a'"
+                           (Either.left "Invalid_argument") "set"
                            [("0 <= i < t.size",
                               {
                                 Ortac_runtime.start =
@@ -753,8 +755,8 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Array" "make 16 'a'" None
-                           "fill"
+                        (Ortac_runtime.report "Array" "make 16 'a'"
+                           (Either.left "Invalid_argument") "fill"
                            [("0 <= i",
                               {
                                 Ortac_runtime.start =
@@ -802,8 +804,8 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Array" "make 16 'a'" None
-                              "fill"
+                           (Ortac_runtime.report "Array" "make 16 'a'"
+                              (Either.left "Invalid_argument") "fill"
                               [("0 <= j",
                                  {
                                    Ortac_runtime.start =
@@ -854,8 +856,8 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Array" "make 16 'a'" None
-                              "fill"
+                           (Ortac_runtime.report "Array" "make 16 'a'"
+                              (Either.left "Invalid_argument") "fill"
                               [("i + j <= t.size",
                                  {
                                    Ortac_runtime.start =
@@ -909,8 +911,8 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Array" "make 16 'a'" None
-                              "fill"
+                           (Ortac_runtime.report "Array" "make 16 'a'"
+                              (Either.left "Invalid_argument") "fill"
                               [("0 <= i",
                                  {
                                    Ortac_runtime.start =
@@ -959,7 +961,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                           else
                             Some
                               (Ortac_runtime.report "Array" "make 16 'a'"
-                                 None "fill"
+                                 (Either.left "Invalid_argument") "fill"
                                  [("0 <= j",
                                     {
                                       Ortac_runtime.start =
@@ -1012,7 +1014,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                           else
                             Some
                               (Ortac_runtime.report "Array" "make 16 'a'"
-                                 None "fill"
+                                 (Either.left "Invalid_argument") "fill"
                                  [("i + j <= t.size",
                                     {
                                       Ortac_runtime.start =
@@ -1058,7 +1060,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
           else
             Some
               (Ortac_runtime.report "Array" "make 16 'a'"
-                 (Some
+                 (Either.right
                     (Res
                        ((list char),
                          (try (Lazy.force new_state__011_).contents
@@ -1131,7 +1133,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
           else
             Some
               (Ortac_runtime.report "Array" "make 16 'a'"
-                 (Some (Res (Ortac_runtime.dummy, ()))) "mem"
+                 (Either.right (Res (Ortac_runtime.dummy, ()))) "mem"
                  [("b = List.mem a t.contents",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/array_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/array_stm_tests.expected.ml
@@ -17,13 +17,16 @@ module Spec =
     let show_cmd cmd__001_ =
       match cmd__001_ with
       | Length -> Format.asprintf "%s sut" "length"
-      | Get i -> Format.asprintf "%s sut %a" "get" (Util.Pp.pp_int true) i
+      | Get i ->
+          Format.asprintf "protect (fun () -> %s sut %a)" "get"
+            (Util.Pp.pp_int true) i
       | Set (i_1, a_1) ->
-          Format.asprintf "%s sut %a %a" "set" (Util.Pp.pp_int true) i_1
-            (Util.Pp.pp_char true) a_1
+          Format.asprintf "protect (fun () -> %s sut %a %a)" "set"
+            (Util.Pp.pp_int true) i_1 (Util.Pp.pp_char true) a_1
       | Fill (i_2, j, a_2) ->
-          Format.asprintf "%s sut %a %a %a" "fill" (Util.Pp.pp_int true) i_2
-            (Util.Pp.pp_int true) j (Util.Pp.pp_char true) a_2
+          Format.asprintf "protect (fun () -> %s sut %a %a %a)" "fill"
+            (Util.Pp.pp_int true) i_2 (Util.Pp.pp_int true) j
+            (Util.Pp.pp_char true) a_2
       | To_list -> Format.asprintf "%s sut" "to_list"
       | Mem a_3 ->
           Format.asprintf "%s %a sut" "mem" (Util.Pp.pp_char true) a_3

--- a/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
@@ -37,8 +37,8 @@ module Spec =
     let show_cmd cmd__001_ =
       match cmd__001_ with
       | Set (i_1, a_2) ->
-          Format.asprintf "%s sut %a %a" "set" (Util.Pp.pp_int true) i_1
-            (Util.Pp.pp_char true) a_2
+          Format.asprintf "protect (fun () -> %s sut %a %a)" "set"
+            (Util.Pp.pp_int true) i_1 (Util.Pp.pp_char true) a_2
     type nonrec state = {
       contents: char list }
     let init_state =

--- a/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
@@ -200,7 +200,7 @@ let ortac_postcond cmd__006_ state__007_ res__008_ =
                  else
                    Some
                      (Ortac_runtime.report "Conjunctive_clauses"
-                        "make 42 'a'" None "set"
+                        "make 42 'a'" (Either.left "Invalid_argument") "set"
                         [("0 <= i < List.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -261,7 +261,8 @@ let ortac_postcond cmd__006_ state__007_ res__008_ =
                     else
                       Some
                         (Ortac_runtime.report "Conjunctive_clauses"
-                           "make 42 'a'" None "set"
+                           "make 42 'a'" (Either.left "Invalid_argument")
+                           "set"
                            [("0 <= i < List.length t.contents",
                               {
                                 Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
@@ -53,7 +53,8 @@ module Spec =
           Format.asprintf "%s sut %a %a" "add" (Util.Pp.pp_char true) a_2
             (Util.Pp.pp_int true) b_2
       | Find a_3 ->
-          Format.asprintf "%s sut %a" "find" (Util.Pp.pp_char true) a_3
+          Format.asprintf "protect (fun () -> %s sut %a)" "find"
+            (Util.Pp.pp_char true) a_3
       | Find_opt a_4 ->
           Format.asprintf "%s sut %a" "find_opt" (Util.Pp.pp_char true) a_4
       | Find_all a_5 ->

--- a/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
@@ -322,7 +322,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
                else
                  Some
                    (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
-                      (Some (Res (Ortac_runtime.dummy, ()))) "find"
+                      (Either.right (Res (Ortac_runtime.dummy, ()))) "find"
                       [("List.mem (a, b) h.contents",
                          {
                            Ortac_runtime.start =
@@ -373,7 +373,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
                else
                  Some
                    (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
-                      None "find"
+                      (Either.left "Not_found") "find"
                       [("not (List.mem a (List.map fst h.contents))",
                          {
                            Ortac_runtime.start =
@@ -437,7 +437,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           else
             Some
               (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
-                 (Some (Res (Ortac_runtime.dummy, ()))) "find_opt"
+                 (Either.right (Res (Ortac_runtime.dummy, ()))) "find_opt"
                  [("match o with\n      | None -> not (List.mem a (List.map fst h.contents))\n      | Some b -> List.mem (a, b) h.contents",
                     {
                       Ortac_runtime.start =
@@ -488,7 +488,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           else
             Some
               (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
-                 (Some (Res (Ortac_runtime.dummy, ()))) "find_all"
+                 (Either.right (Res (Ortac_runtime.dummy, ()))) "find_all"
                  [("bs = Sequence.filter_map (fun (x, y) -> if x = a then Some y else None) h.contents",
                     {
                       Ortac_runtime.start =
@@ -539,7 +539,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           else
             Some
               (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
-                 (Some (Res (Ortac_runtime.dummy, ()))) "mem"
+                 (Either.right (Res (Ortac_runtime.dummy, ()))) "mem"
                  [("b = List.mem a (List.map fst h.contents)",
                     {
                       Ortac_runtime.start =
@@ -590,7 +590,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           else
             Some
               (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
-                 (Some (Res (Ortac_runtime.dummy, ()))) "length"
+                 (Either.right (Res (Ortac_runtime.dummy, ()))) "length"
                  [("i = List.length h.contents",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
@@ -150,7 +150,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           else
             Some
               (Ortac_runtime.report "Invariants" "create 42"
-                 (Some (Res (unit, ()))) "push"
+                 (Either.right (Res (unit, ()))) "push"
                  [("List.length x.contents > 0",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/record_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/record_stm_tests.expected.ml
@@ -115,7 +115,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
              else
                Some
                  (Ortac_runtime.report "Record" "make 42"
-                    (Some (Res (Ortac_runtime.dummy, ()))) "get"
+                    (Either.right (Res (Ortac_runtime.dummy, ()))) "get"
                     [("i = r.value",
                        {
                          Ortac_runtime.start =
@@ -166,7 +166,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
                 else
                   Some
                     (Ortac_runtime.report "Record" "make 42"
-                       (Some (Res (Ortac_runtime.dummy, ()))) "get"
+                       (Either.right (Res (Ortac_runtime.dummy, ()))) "get"
                        [("plus1 i = i + 1",
                           {
                             Ortac_runtime.start =
@@ -215,7 +215,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
                 else
                   Some
                     (Ortac_runtime.report "Record" "make 42"
-                       (Some (Res (Ortac_runtime.dummy, ()))) "get"
+                       (Either.right (Res (Ortac_runtime.dummy, ()))) "get"
                        [("plus2 i = i + 2",
                           {
                             Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
@@ -89,7 +89,7 @@ let ortac_postcond cmd__004_ state__005_ res__006_ =
           else
             Some
               (Ortac_runtime.report "Ref" "make 42"
-                 (Some (Res (Ortac_runtime.dummy, ()))) "get"
+                 (Either.right (Res (Ortac_runtime.dummy, ()))) "get"
                  [("i = r.value",
                     {
                       Ortac_runtime.start =


### PR DESCRIPTION

This PR proposes to add support for exceptional behaviour when printing a runnable scenariowhen a test is failing.

This PR is based on #204, please consider only the two last commits.

This PR should complete the story to fix #188

Again, if we introduce a bug in `plugins/qcheck-stm/test/array.ml` (here `let get a _ = get a 7`), we have now:

```
λ dune build @launchtests
File "plugins/qcheck-stm/test/dune.inc", line 49, characters 0-75:
49 | (rule
50 |  (alias launchtests)
51 |  (action
52 |   (run %{dep:array_stm_tests.exe} -v)))
random seed: 163835566
generated error fail pass / total     time test name
[✗]    1    0    1    0 / 1000     0.0s Array STM tests (generating)

--- Failure --------------------------------------------------------------------

Test Array STM tests failed (5 shrink steps):

   protect (fun () -> get sut (-952798241484687328))


+++ Messages ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

Messages for test Array STM tests:

Gospel specification violation in function get

  File "array.mli", line 11, characters 11-26:
    0 <= i < t.size
  
when executing the following sequence of operations:

  open Array
  let protect f = try Ok (f ()) with e -> Error e
  let sut = make 16 'a'
  let r = protect (fun () -> get sut (-952798241484687328))
  assert (match r with
            | Error (Invalid_argument _) -> true
            | _ -> false)
  (* returned Ok ('a') *)
  

================================================================================
failure (1 tests failed, 0 tests errored, ran 1 tests)
                                     
[1]
```

So the call to any function that may raise an exception (according to the Gospel psecifications) are protected to return a `('a, exn) result` instead of a simple `'a` (as it is done today in QCheck-STM).

The value returned by the protected call is then compared to the expected result: here we were expecting an `Invalid_argument` exception because the clause is a `checks`, but in the case of a `raises` clause, the name of the expected exception will be printed.

Note that only the name of the exception is printed, this PR does not propose to handle the arguments of the said exception. I may want to wait to see how [gospel#379](https://github.com/ocaml-gospel/gospel/issues/379) evolves.