### PR TITLE
Bump all OCaml version to the same number

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -30,7 +30,7 @@
  (maintainers "Clément Pascutto <clement@pascutto.fr>")
  (documentation "https://ocaml-gospel.github.io/ortac/ortac-core/")
  (depends
-  (ocaml (>= 4.11.0))
+  (ocaml (>= 4.12.0))
   dune-build-info
   dune-site
   (cmdliner (>= 1.1.0))
@@ -76,7 +76,7 @@
   "Nicolas Osborne <nicolas.osborne@tarides.com>")
  (maintainers "Clément Pascutto <clement@pascutto.fr>")
  (depends
-  (ocaml (>= 4.11.0))
+  (ocaml (>= 4.12.0))
   (cmdliner (>= 1.1.0))
   fmt
   (ppxlib (>= 0.26.0))
@@ -102,7 +102,7 @@
  (authors "Nicolas Osborne <nicolas.osborne@tarides.com>")
  (maintainers "Nicolas Osborne <nicolas.osborne@tarides.com>")
  (depends
-  (ocaml (>= 4.11.0))
+  (ocaml (>= 4.12.0))
   (cmdliner (>= 1.1.0))
   fmt
   (ppxlib (>= 0.26.0))
@@ -127,7 +127,7 @@
  (authors "Nicolas Osborne <nicolas.osborne@tarides.com>")
  (maintainers "Nicolas Osborne <nicolas.osborne@tarides.com>")
  (depends
-  (ocaml (>= 4.11.0))
+  (ocaml (>= 4.12.0))
   (monolith (>= 20201026))
   pprint
   (fmt (>= 0.9.0))
@@ -153,7 +153,7 @@
  (maintainers "Nicolas Osborne <nicolas.osborne@tarides.com>")
  (documentation "https://ocaml-gospel.github.io/ortac/ortac-qcheck-stm/")
  (depends
-  (ocaml (>= 4.11.0))
+  (ocaml (>= 4.12.0))
   (cmdliner (>= 1.1.0))
   fmt
   (ppxlib (>= 0.26.0))
@@ -176,7 +176,7 @@
   "Nicolas Osborne <nicolas.osborne@tarides.com>")
  (maintainers "Nicolas Osborne <nicolas.osborne@tarides.com>")
  (depends
-  (ocaml (>= 4.11.0))
+  (ocaml (>= 4.12.0))
   fmt
   (cmdliner (>= 1.1.0))
   ortac-core
@@ -196,7 +196,7 @@
  (authors "Nicolas Osborne <nicolas.osborne@tarides.com>")
  (maintainers "Nicolas Osborne <nicolas.osborne@tarides.com>")
  (depends
-  (ocaml (>= 4.11.0))
+  (ocaml (>= 4.12.0))
   qcheck-stm
   ortac-runtime))
 
@@ -209,7 +209,7 @@
   "Samuel Hym <samuel.hym@rustyne.lautre.net>")
  (maintainers "Nicolas Osborne <nicolas.osborne@tarides.com>")
  (depends
-  (ocaml (>= 4.11.0))
+  (ocaml (>= 4.12.0))
   ortac-core
   ortac-qcheck-stm
   ortac-dune

--- a/ortac-core.opam
+++ b/ortac-core.opam
@@ -25,7 +25,7 @@ doc: "https://ocaml-gospel.github.io/ortac/ortac-core/"
 bug-reports: "https://github.com/ocaml-gospel/ortac/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.12.0"}
   "dune-build-info"
   "dune-site"
   "cmdliner" {>= "1.1.0"}

--- a/ortac-dune.opam
+++ b/ortac-dune.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/ocaml-gospel/ortac"
 bug-reports: "https://github.com/ocaml-gospel/ortac/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.12.0"}
   "fmt"
   "cmdliner" {>= "1.1.0"}
   "ortac-core"

--- a/ortac-examples.opam
+++ b/ortac-examples.opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/ocaml-gospel/ortac"
 bug-reports: "https://github.com/ocaml-gospel/ortac/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.12.0"}
   "ortac-core"
   "ortac-qcheck-stm"
   "ortac-dune"

--- a/ortac-monolith.opam
+++ b/ortac-monolith.opam
@@ -19,7 +19,7 @@ homepage: "https://github.com/ocaml-gospel/ortac"
 bug-reports: "https://github.com/ocaml-gospel/ortac/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.12.0"}
   "cmdliner" {>= "1.1.0"}
   "fmt"
   "ppxlib" {>= "0.26.0"}

--- a/ortac-qcheck-stm.opam
+++ b/ortac-qcheck-stm.opam
@@ -23,7 +23,7 @@ doc: "https://ocaml-gospel.github.io/ortac/ortac-qcheck-stm/"
 bug-reports: "https://github.com/ocaml-gospel/ortac/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.12.0"}
   "cmdliner" {>= "1.1.0"}
   "fmt"
   "ppxlib" {>= "0.26.0"}

--- a/ortac-runtime-monolith.opam
+++ b/ortac-runtime-monolith.opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/ocaml-gospel/ortac"
 bug-reports: "https://github.com/ocaml-gospel/ortac/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.12.0"}
   "monolith" {>= "20201026"}
   "pprint"
   "fmt" {>= "0.9.0"}

--- a/ortac-runtime-qcheck-stm.opam
+++ b/ortac-runtime-qcheck-stm.opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/ocaml-gospel/ortac"
 bug-reports: "https://github.com/ocaml-gospel/ortac/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.12.0"}
   "qcheck-stm"
   "ortac-runtime"
   "odoc" {with-doc}

--- a/ortac-wrapper.opam
+++ b/ortac-wrapper.opam
@@ -20,7 +20,7 @@ homepage: "https://github.com/ocaml-gospel/ortac"
 bug-reports: "https://github.com/ocaml-gospel/ortac/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.12.0"}
   "cmdliner" {>= "1.1.0"}
   "fmt"
   "ppxlib" {>= "0.26.0"}


### PR DESCRIPTION
4.12.0 is neccessary for `Either`
