### PR TITLE
Move to use a default `Cmdliner.term` rather than the `usage` function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Make `--help` and `--version` work even without any plugins installed
+  [\#217](https://github.com/ocaml-gospel/ortac/pull/217)
 - Improve test-failure message
   [\#202](https://github.com/ocaml-gospel/ortac/pull/202) and
   [\#204](https://github.com/ocaml-gospel/ortac/pull/204) and

--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -5,25 +5,31 @@ let () =
 
 open Cmdliner
 
-let usage () =
-  Format.(fprintf err_formatter)
-    "@[ortac: required plugin is missing, please install at least one@ \
-     (qcheck-stm,@ monolith@ or@ wrapper).@]@.";
-  exit Cmd.Exit.cli_error
+let default_cmd cmds =
+  let errmsg, usage =
+    match cmds with
+    | [] ->
+        (* We cannot be in the case where ORTAC_ONLY_PLUGIN was set, since
+           trying to load only one missing plugin would have raised an exception
+           earlier, so we know no plugin is available *)
+        (* Displaying usage in that case is useless *)
+        ("error: no plugin is available, please install at least one", false)
+    | _ -> ("error: missing command", true)
+  in
+  Term.(term_result ~usage (const (Result.error (`Msg errmsg))))
 
 let () =
-  match
+  let doc = "Run ORTAC."
+  and version =
+    Printf.sprintf "ortac version: %s"
+      (match Build_info.V1.version () with
+      | None -> "n/a"
+      | Some v -> Build_info.V1.Version.to_string v)
+  in
+  let info = Cmd.info "ortac" ~doc ~version
+  and cmds =
     Registration.fold (fun acc cmd -> cmd :: acc) [] Registration.plugins
-  with
-  | [] -> usage ()
-  | cmds ->
-      let doc = "Run ORTAC." in
-      let version =
-        Printf.sprintf "ortac version: %s"
-          (match Build_info.V1.version () with
-          | None -> "n/a"
-          | Some v -> Build_info.V1.Version.to_string v)
-      in
-      let info = Cmd.info "ortac" ~doc ~version in
-      let group = Cmd.group info cmds in
-      Stdlib.exit (Cmd.eval group)
+  in
+  let default = default_cmd cmds in
+  let group = Cmd.group info ~default cmds in
+  Stdlib.exit (Cmd.eval group)


### PR DESCRIPTION

Fixes #216

The inspiration comes from [this example](https://erratique.ch/software/cmdliner/doc/examples.html#exdarcs)
Though use of `ret` is [discouraged](https://erratique.ch/software/cmdliner/doc/Cmdliner/Term/index.html#val-ret).
But I didn't find any alteratives.