### PR TITLE
Add empty cmd error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # 0.3.0
 
+- Add error for empty command type 
+  [\#234](https://github.com/ocaml-gospel/ortac/pull/234)
 - Move to a module-based configuration
   [\#214](https://github.com/ocaml-gospel/ortac/pull/214)
 - Add support for custom ghost types as model

--- a/plugins/qcheck-stm/doc/example_empty_cmd.mli
+++ b/plugins/qcheck-stm/doc/example_empty_cmd.mli
@@ -1,3 +1,5 @@
+(* $MDX part-begin=fun-decl *)
+
 type 'a t
 (*@ model size : int
     mutable model contents : 'a list *)
@@ -7,14 +9,5 @@ val make : int -> 'a -> 'a t
     checks i >= 0
     ensures t.size = i
     ensures t.contents = List.init i (fun j -> a) *)
-
-val dummy : 'a t -> int
-(*@ l = dummy t
-    ensures l = t.size *)
-
-(* $MDX part-begin=fun-decl *)
-
-val incompatible_type : char -> string t -> bool
-(*@ b = incompatible_type c t *)
 
 (* $MDX part-end *)

--- a/plugins/qcheck-stm/doc/example_ghost.mli
+++ b/plugins/qcheck-stm/doc/example_ghost.mli
@@ -8,6 +8,10 @@ val make : int -> 'a -> 'a t
     ensures t.size = i
     ensures t.contents = List.init i (fun j -> a) *)
 
+val dummy : 'a t -> int
+(*@ l = dummy t
+    ensures l = t.size *)
+
 (* $MDX part-begin=fun-decl *)
 
 val ghost_arg : char -> 'a t -> bool

--- a/plugins/qcheck-stm/doc/index.mld
+++ b/plugins/qcheck-stm/doc/index.mld
@@ -332,9 +332,8 @@ the command will generate the following warning:
 
 {@sh[
 $ ortac qcheck-stm example_ghost.mli example_config.ml -o foo.ml
-Error: The generated cmd type is empty.
-File "example_ghost.mli", line 14, characters 20-21:
-14 | (*@ b = ghost_arg [ i : integer] c t *)
+File "example_ghost.mli", line 18, characters 20-21:
+18 | (*@ b = ghost_arg [ i : integer] c t *)
                          ^
 Warning: Skipping ghost_arg: functions with a ghost argument are not
          supported.
@@ -359,9 +358,8 @@ the plugin will generate a warning for this function and skip it.
 
 {@sh[
 $ ortac qcheck-stm example_incompatible_type.mli example_config.ml -o foo.ml
-Error: The generated cmd type is empty.
-File "example_incompatible_type.mli", line 13, characters 32-40:
-13 | val incompatible_type : char -> string t -> bool
+File "example_incompatible_type.mli", line 17, characters 32-40:
+17 | val incompatible_type : char -> string t -> bool
                                      ^^^^^^^^
 Warning: Skipping incompatible_type: the type of its SUT-type argument is
          incompatible with the configured SUT type: char t.
@@ -369,6 +367,34 @@ Warning: Skipping incompatible_type: the type of its SUT-type argument is
 
 In the case you have functions specialized with different instantiations, you
 can always generate one test per possible instantiation, of course.
+
+{2 Empty command type} 
+
+During the translation of the Gospel annotations [ortac] will leave out 
+specifications that do not adhere to its requirements. In the extreme case this 
+may result in an empty set of commands that it can use to create test traces 
+from. 
+
+Given the following example: 
+
+{@ocaml file=example_empty_cmd.mli,part=fun-decl[
+type 'a t
+(*@ model size : int
+    mutable model contents : 'a list *)
+
+val make : int -> 'a -> 'a t
+(*@ t = make i a
+    checks i >= 0
+    ensures t.size = i
+    ensures t.contents = List.init i (fun j -> a) *)
+]}
+
+the command will generate the following error: 
+
+{@sh[
+$ ortac qcheck-stm example_empty_cmd.mli example_config.ml -o foo.ml 
+Error: The generated cmd type is empty.
+]}
 
 {2 [ortac] limitations}
 
@@ -479,3 +505,4 @@ File "example_limitations.mli", line 22, characters 8-17:
              ^^^^^^^^^
 Warning: Type (int * int) not supported.
 ]}
+

--- a/plugins/qcheck-stm/doc/index.mld
+++ b/plugins/qcheck-stm/doc/index.mld
@@ -332,6 +332,7 @@ the command will generate the following warning:
 
 {@sh[
 $ ortac qcheck-stm example_ghost.mli example_config.ml -o foo.ml
+Error: The generated cmd type is empty.
 File "example_ghost.mli", line 14, characters 20-21:
 14 | (*@ b = ghost_arg [ i : integer] c t *)
                          ^
@@ -358,6 +359,7 @@ the plugin will generate a warning for this function and skip it.
 
 {@sh[
 $ ortac qcheck-stm example_incompatible_type.mli example_config.ml -o foo.ml
+Error: The generated cmd type is empty.
 File "example_incompatible_type.mli", line 13, characters 32-40:
 13 | val incompatible_type : char -> string t -> bool
                                      ^^^^^^^^

--- a/plugins/qcheck-stm/doc/index.mld
+++ b/plugins/qcheck-stm/doc/index.mld
@@ -505,4 +505,3 @@ File "example_limitations.mli", line 22, characters 8-17:
              ^^^^^^^^^
 Warning: Type (int * int) not supported.
 ]}
-

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -11,6 +11,7 @@ type init_state_error =
 
 type W.kind +=
   | Constant_value of string
+  | Empty_cmd_type
   | Ensures_not_found_for_next_state of (string * string)
   | Functional_argument of string
   | Ghost_values of (string * [ `Arg | `Ret ])
@@ -48,7 +49,7 @@ let level kind =
   | No_sut_argument _ | Returned_tuple _ | Returning_sut _
   | Type_not_supported _ ->
       W.Warning
-  | Impossible_init_state_generation _ | Incompatible_sut _
+  | Empty_cmd_type | Impossible_init_state_generation _ | Incompatible_sut _
   | Incomplete_configuration_module _ | No_configuration_file _
   | No_init_function _ | No_models _ | No_sut_type _ | Not_a_structure _
   | Sut_type_not_specified _ | Sut_type_not_supported _
@@ -100,6 +101,7 @@ let pp_kind ppf kind =
   (* Warnings *)
   | Constant_value id ->
       pf ppf "Skipping %s:@ %a" id text "constants cannot be tested"
+  | Empty_cmd_type -> pf ppf "The generated cmd type is empty"
   | Ensures_not_found_for_next_state (f, m) ->
       pf ppf "Skipping %s:@ model@ %s %a@;%a%s%a" f m text
         "is declared as modified by the function but no suitable ensures \

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -11,6 +11,7 @@ type init_state_error =
 
 type W.kind +=
   | Constant_value of string
+  | Empty_cmd_type
   | Ensures_not_found_for_next_state of (string * string)
   | Functional_argument of string
   | Ghost_values of (string * [ `Arg | `Ret ])

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -712,7 +712,10 @@ let cmd_type ir =
     type_declaration ~name:(noloc "cmd") ~params:[] ~cstrs:[]
       ~kind:(Ptype_variant constructors) ~private_:Public ~manifest:None
   in
-  pstr_type Recursive [ td ]
+  let open Reserr in
+  if List.length constructors = 0 then
+    error (Empty_cmd_type, Ppxlib.Location.none)
+  else pstr_type Recursive [ td ] |> ok
 
 let pp_cmd_case config value =
   let lhs = mk_cmd_pattern value in
@@ -969,7 +972,7 @@ let stm config ir =
   let* config, ghost_functions = ghost_functions config ir.ghost_functions in
   let warn = [%stri [@@@ocaml.warning "-26-27"]] in
   let sut = sut_type config in
-  let cmd = cmd_type ir in
+  let* cmd = cmd_type ir in
   let* cmd_show = cmd_show config ir in
   let state = state_type ir in
   let* idx, next_state = next_state config ir in

--- a/plugins/qcheck-stm/test/dune
+++ b/plugins/qcheck-stm/test/dune
@@ -46,3 +46,24 @@
  (alias runtest)
  (action
   (diff dune.inc dune.inc.gen)))
+
+(rule
+ (target empty_cmd_errors)
+ (package ortac-qcheck-stm)
+ (deps
+  (package ortac-core)
+  (package ortac-qcheck-stm))
+ (action
+  (setenv
+   ORTAC_ONLY_PLUGIN
+   qcheck-stm
+   (ignore-stdout
+    (with-stderr-to
+     %{target}
+     (run ortac qcheck-stm %{dep:empty_cmd.mli} %{dep:empty_cmd_config.ml}))))))
+
+(rule
+ (alias runtest)
+ (package ortac-qcheck-stm)
+ (action
+  (diff empty_cmd_errors.expected empty_cmd_errors)))

--- a/plugins/qcheck-stm/test/empty_cmd.mli
+++ b/plugins/qcheck-stm/test/empty_cmd.mli
@@ -1,0 +1,6 @@
+type t
+(*@ model content : integer *)
+
+val make : unit -> t
+(*@ t = make u
+    ensures t.content = 0 *)

--- a/plugins/qcheck-stm/test/empty_cmd_config.ml
+++ b/plugins/qcheck-stm/test/empty_cmd_config.ml
@@ -1,0 +1,5 @@
+open Empty_cmd
+
+type sut = t
+
+let init_sut = make ()

--- a/plugins/qcheck-stm/test/empty_cmd_errors.expected
+++ b/plugins/qcheck-stm/test/empty_cmd_errors.expected
@@ -1,0 +1,1 @@
+Error: The generated cmd type is empty.

--- a/plugins/qcheck-stm/test/test_errors.t
+++ b/plugins/qcheck-stm/test/test_errors.t
@@ -153,13 +153,7 @@ Or specify it using clauses that cannot be executed:
   >     ensures t.value = if forall i. i = i then a :: [] else [] *)
   > EOF
   $ ortac qcheck-stm foo.mli foo_config.ml
-  Error: Unsupported INIT function: the specification of the function called in
-         the INIT expression does not provide a translatable specification for
-         the following field of the model: value.
-  File "foo.mli", line 6, characters 25-40:
-  6 |     ensures t.value = if forall i. i = i then a :: [] else [] *)
-                               ^^^^^^^^^^^^^^^
-  Warning: Skipping clause: unsupported quantification.
+  Error: The generated cmd type is empty.
 
 Or we can give a function that does not return the type of the system under test:
 
@@ -247,14 +241,7 @@ We shouldn't be able to define a model by itsef in the `make` function:
   > type sut = int t
   > EOF
   $ ortac qcheck-stm foo.mli foo_config.ml
-  Error: Unsupported INIT function: the specification of the function called in
-         the INIT expression does not provide a translatable specification for
-         the following field of the model: value.
-  File "foo.mli", line 6, characters 22-23:
-  6 |     ensures t.value = t.value *)
-                            ^
-  Warning: Skipping clause: impossible to define the initial value of the model
-           with a recursive expression.
+  Error: The generated cmd type is empty.
 
 If we add some custom generators, we should do so in a `Gen` module that is implemented (functor application or reference to another module are not supported):
   $ cat > foo.mli << EOF

--- a/plugins/qcheck-stm/test/test_errors.t
+++ b/plugins/qcheck-stm/test/test_errors.t
@@ -151,9 +151,18 @@ Or specify it using clauses that cannot be executed:
   > (*@ t = make a
   >     requires true
   >     ensures t.value = if forall i. i = i then a :: [] else [] *)
+  > val dummy : 'a t -> 'a list
+  > (*@ l = dummy t
+  >     ensures l = t.value *)
   > EOF
   $ ortac qcheck-stm foo.mli foo_config.ml
-  Error: The generated cmd type is empty.
+  Error: Unsupported INIT function: the specification of the function called in
+         the INIT expression does not provide a translatable specification for
+         the following field of the model: value.
+  File "foo.mli", line 6, characters 25-40:
+  6 |     ensures t.value = if forall i. i = i then a :: [] else [] *)
+                               ^^^^^^^^^^^^^^^
+  Warning: Skipping clause: unsupported quantification.
 
 Or we can give a function that does not return the type of the system under test:
 
@@ -234,6 +243,9 @@ We shouldn't be able to define a model by itsef in the `make` function:
   > (*@ t = make a
   >     requires true
   >     ensures t.value = t.value *)
+  > val dummy : 'a t -> 'a list 
+  > (*@ l = dummy t 
+  >     ensures l = t.value *)
   > EOF
   $ cat > foo_config.ml << EOF
   > open Foo
@@ -241,7 +253,14 @@ We shouldn't be able to define a model by itsef in the `make` function:
   > type sut = int t
   > EOF
   $ ortac qcheck-stm foo.mli foo_config.ml
-  Error: The generated cmd type is empty.
+  Error: Unsupported INIT function: the specification of the function called in
+         the INIT expression does not provide a translatable specification for
+         the following field of the model: value.
+  File "foo.mli", line 6, characters 22-23:
+  6 |     ensures t.value = t.value *)
+                            ^
+  Warning: Skipping clause: impossible to define the initial value of the model
+           with a recursive expression.
 
 If we add some custom generators, we should do so in a `Gen` module that is implemented (functor application or reference to another module are not supported):
   $ cat > foo.mli << EOF


### PR DESCRIPTION
This PR adds a new error which is triggered when there are no commands produced during the translation from Gospel to OCaml. 

This fixes #213 