### PR TITLE
Clean up some dependencies

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -157,9 +157,7 @@
   (ppxlib (>= 0.26.0))
   (mdx (and :with-test (>= 2.3.0)))
   (gospel (= 0.3.0))
-  (qcheck-core :with-test)
   (qcheck-stm (>= 0.3))
-  (qcheck-multicoretests-util :with-test)
   (ortac-core (= :version))
   (ortac-runtime-qcheck-stm (= :version)))
  (conflicts

--- a/dune-project
+++ b/dune-project
@@ -206,8 +206,6 @@
   (ortac-core (= :version))
   (ortac-qcheck-stm (= :version))
   (ortac-dune (= :version))
-  (ortac-runtime (= :version))
-  (qcheck-stm :with-test)
   lwt-dllist
   (varray (>= 0.2))))
 

--- a/dune-project
+++ b/dune-project
@@ -161,7 +161,6 @@
   (qcheck-stm (>= 0.3))
   (qcheck-multicoretests-util :with-test)
   (ortac-core (= :version))
-  (ortac-runtime (and :with-test (= :version)))
   (ortac-runtime-qcheck-stm (= :version)))
  (conflicts
   (result (< 1.5))))

--- a/dune-project
+++ b/dune-project
@@ -158,7 +158,7 @@
   (mdx (and :with-test (>= 2.3.0)))
   (gospel (= 0.3.0))
   (qcheck-core :with-test)
-  (qcheck-stm (and :with-test (>= 0.3)))
+  (qcheck-stm (>= 0.3))
   (qcheck-multicoretests-util :with-test)
   (ortac-core (= :version))
   (ortac-runtime (and :with-test (= :version)))

--- a/dune-project
+++ b/dune-project
@@ -158,7 +158,7 @@
   (mdx (and :with-test (>= 2.3.0)))
   (gospel (= 0.3.0))
   (qcheck-core :with-test)
-  (qcheck-stm :with-test)
+  (qcheck-stm (and :with-test (>= 0.3)))
   (qcheck-multicoretests-util :with-test)
   (ortac-core (= :version))
   (ortac-runtime (and :with-test (= :version)))
@@ -194,7 +194,7 @@
  (authors "Nicolas Osborne <nicolas.osborne@tarides.com>")
  (depends
   (ocaml (>= 4.12.0))
-  qcheck-stm
+  (qcheck-stm (>= 0.3))
   (ortac-runtime (= :version))))
 
 (package

--- a/ortac-examples.opam
+++ b/ortac-examples.opam
@@ -16,8 +16,6 @@ depends: [
   "ortac-core" {= version}
   "ortac-qcheck-stm" {= version}
   "ortac-dune" {= version}
-  "ortac-runtime" {= version}
-  "qcheck-stm" {with-test}
   "lwt-dllist"
   "varray" {>= "0.2"}
   "odoc" {with-doc}

--- a/ortac-qcheck-stm.opam
+++ b/ortac-qcheck-stm.opam
@@ -31,7 +31,7 @@ depends: [
   "mdx" {with-test & >= "2.3.0"}
   "gospel" {= "0.3.0"}
   "qcheck-core" {with-test}
-  "qcheck-stm" {with-test}
+  "qcheck-stm" {with-test & >= "0.3"}
   "qcheck-multicoretests-util" {with-test}
   "ortac-core" {= version}
   "ortac-runtime" {with-test & = version}

--- a/ortac-qcheck-stm.opam
+++ b/ortac-qcheck-stm.opam
@@ -31,7 +31,7 @@ depends: [
   "mdx" {with-test & >= "2.3.0"}
   "gospel" {= "0.3.0"}
   "qcheck-core" {with-test}
-  "qcheck-stm" {with-test & >= "0.3"}
+  "qcheck-stm" {>= "0.3"}
   "qcheck-multicoretests-util" {with-test}
   "ortac-core" {= version}
   "ortac-runtime" {with-test & = version}

--- a/ortac-qcheck-stm.opam
+++ b/ortac-qcheck-stm.opam
@@ -30,9 +30,7 @@ depends: [
   "ppxlib" {>= "0.26.0"}
   "mdx" {with-test & >= "2.3.0"}
   "gospel" {= "0.3.0"}
-  "qcheck-core" {with-test}
   "qcheck-stm" {>= "0.3"}
-  "qcheck-multicoretests-util" {with-test}
   "ortac-core" {= version}
   "ortac-runtime-qcheck-stm" {= version}
   "odoc" {with-doc}

--- a/ortac-qcheck-stm.opam
+++ b/ortac-qcheck-stm.opam
@@ -34,7 +34,6 @@ depends: [
   "qcheck-stm" {>= "0.3"}
   "qcheck-multicoretests-util" {with-test}
   "ortac-core" {= version}
-  "ortac-runtime" {with-test & = version}
   "ortac-runtime-qcheck-stm" {= version}
   "odoc" {with-doc}
 ]

--- a/ortac-runtime-qcheck-stm.opam
+++ b/ortac-runtime-qcheck-stm.opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml-gospel/ortac/issues"
 depends: [
   "dune" {>= "3.8"}
   "ocaml" {>= "4.12.0"}
-  "qcheck-stm"
+  "qcheck-stm" {>= "0.3"}
   "ortac-runtime" {= version}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
There is a double objective here:

1. make `opam install ortac-qcheck-stm` put the user in a position where tests can be generated and run
2. fix lower bounds
