### PR TITLE
Fix display of the runnable scenario for protected values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix display of the runnable scenario for protected values
+  [\#251](https://github.com/ocaml-gospel/ortac/pull/251)
 - Fix sut as type argument or inside tuple bug
   [\#245](https://github.com/ocaml-gospel/ortac/pull/245)
 - Add support for multiple sut arguments

--- a/examples/lwt_dllist_spec_tests.ml
+++ b/examples/lwt_dllist_spec_tests.ml
@@ -516,7 +516,8 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
           else
             Some
               (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                 (Either.right (Res (Ortac_runtime.dummy, ()))) "is_empty"
+                 (Ortac_runtime.Value (Res (Ortac_runtime.dummy, ())))
+                 "is_empty"
                  [("b <-> s.contents = Sequence.empty",
                     {
                       Ortac_runtime.start =
@@ -567,7 +568,7 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
           else
             Some
               (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                 (Either.right
+                 (Ortac_runtime.Value
                     (Res
                        (integer,
                          (let s_old__030_ = Model.get state__024_ 0
@@ -657,7 +658,8 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                else
                  Some
                    (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                      (Either.right (Res (Ortac_runtime.dummy, ()))) "take_l"
+                      (Ortac_runtime.Protected_value
+                         (Res (Ortac_runtime.dummy, ()))) "take_l"
                       [("if old s.contents = Sequence.empty\n              then false\n              else a = Sequence.hd (old s.contents)",
                          {
                            Ortac_runtime.start =
@@ -713,7 +715,7 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                else
                  Some
                    (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                      (Either.left "Empty") "take_l"
+                      (Ortac_runtime.Exception "Empty") "take_l"
                       [("old s.contents = Sequence.empty = s.contents",
                          {
                            Ortac_runtime.start =
@@ -777,7 +779,8 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                else
                  Some
                    (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                      (Either.right (Res (Ortac_runtime.dummy, ()))) "take_r"
+                      (Ortac_runtime.Protected_value
+                         (Res (Ortac_runtime.dummy, ()))) "take_r"
                       [("if old s.contents = Sequence.empty\n              then false\n              else a = (old s.contents)[Sequence.length (old s.contents) - 1]",
                          {
                            Ortac_runtime.start =
@@ -833,7 +836,7 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                else
                  Some
                    (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                      (Either.left "Empty") "take_r"
+                      (Ortac_runtime.Exception "Empty") "take_r"
                       [("old s.contents = Sequence.empty = s.contents",
                          {
                            Ortac_runtime.start =
@@ -888,7 +891,8 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
           else
             Some
               (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                 (Either.right (Res (Ortac_runtime.dummy, ()))) "take_opt_l"
+                 (Ortac_runtime.Value (Res (Ortac_runtime.dummy, ())))
+                 "take_opt_l"
                  [("old s.contents = match o with\n                                | None -> Sequence.empty\n                                | Some a -> Sequence.cons a s.contents",
                     {
                       Ortac_runtime.start =
@@ -942,7 +946,8 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
           else
             Some
               (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                 (Either.right (Res (Ortac_runtime.dummy, ()))) "take_opt_r"
+                 (Ortac_runtime.Value (Res (Ortac_runtime.dummy, ())))
+                 "take_opt_r"
                  [("old s.contents = match o with\n                                | None -> Sequence.empty\n                                | Some a -> Sequence.snoc s.contents a",
                     {
                       Ortac_runtime.start =

--- a/examples/varray_circular_spec_tests.ml
+++ b/examples/varray_circular_spec_tests.ml
@@ -1588,8 +1588,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                else
                  Some
                    (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
-                      (Either.right (Res (Ortac_runtime.dummy, ())))
-                      "pop_back"
+                      (Ortac_runtime.Protected_value
+                         (Res (Ortac_runtime.dummy, ()))) "pop_back"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = (old t.contents)[Sequence.length (old t.contents) - 1]",
                          {
                            Ortac_runtime.start =
@@ -1645,7 +1645,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                else
                  Some
                    (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
-                      (Either.left "Not_found") "pop_back"
+                      (Ortac_runtime.Exception "Not_found") "pop_back"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -1706,8 +1706,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                else
                  Some
                    (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
-                      (Either.right (Res (Ortac_runtime.dummy, ())))
-                      "pop_front"
+                      (Ortac_runtime.Protected_value
+                         (Res (Ortac_runtime.dummy, ()))) "pop_front"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = Sequence.hd (old t.contents)",
                          {
                            Ortac_runtime.start =
@@ -1763,7 +1763,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                else
                  Some
                    (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
-                      (Either.left "Not_found") "pop_front"
+                      (Ortac_runtime.Exception "Not_found") "pop_front"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -1821,7 +1821,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_circular_spec"
-                        "make 42 'a'" (Either.left "Invalid_argument")
+                        "make 42 'a'"
+                        (Ortac_runtime.Exception "Invalid_argument")
                         "insert_at"
                         [("0 <= i <= Sequence.length t.contents",
                            {
@@ -1886,7 +1887,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" (Either.left "Invalid_argument")
+                           "make 42 'a'"
+                           (Ortac_runtime.Exception "Invalid_argument")
                            "insert_at"
                            [("0 <= i <= Sequence.length t.contents",
                               {
@@ -1937,8 +1939,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_circular_spec"
-                        "make 42 'a'" (Either.left "Invalid_argument")
-                        "pop_at"
+                        "make 42 'a'"
+                        (Ortac_runtime.Exception "Invalid_argument") "pop_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1997,8 +1999,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
                            "make 42 'a'"
-                           (Either.right (Res (Ortac_runtime.dummy, ())))
-                           "pop_at"
+                           (Ortac_runtime.Protected_value
+                              (Res (Ortac_runtime.dummy, ()))) "pop_at"
                            [("(proj x) = old t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -2055,7 +2057,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" (Either.left "Invalid_argument")
+                           "make 42 'a'"
+                           (Ortac_runtime.Exception "Invalid_argument")
                            "pop_at"
                            [("inside i t.contents",
                               {
@@ -2106,7 +2109,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_circular_spec"
-                        "make 42 'a'" (Either.left "Invalid_argument")
+                        "make 42 'a'"
+                        (Ortac_runtime.Exception "Invalid_argument")
                         "delete_at"
                         [("inside i t.contents",
                            {
@@ -2168,7 +2172,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" (Either.right (Res (unit, ())))
+                           "make 42 'a'"
+                           (Ortac_runtime.Protected_value (Res (unit, ())))
                            "delete_at"
                            [("Sequence.length t.contents = Sequence.length (old t.contents) - 1",
                               {
@@ -2226,7 +2231,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" (Either.left "Invalid_argument")
+                           "make 42 'a'"
+                           (Ortac_runtime.Exception "Invalid_argument")
                            "delete_at"
                            [("inside i t.contents",
                               {
@@ -2277,7 +2283,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_circular_spec"
-                        "make 42 'a'" (Either.left "Invalid_argument") "get"
+                        "make 42 'a'"
+                        (Ortac_runtime.Exception "Invalid_argument") "get"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -2336,8 +2343,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
                            "make 42 'a'"
-                           (Either.right (Res (Ortac_runtime.dummy, ())))
-                           "get"
+                           (Ortac_runtime.Protected_value
+                              (Res (Ortac_runtime.dummy, ()))) "get"
                            [("(proj x) = t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -2394,8 +2401,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" (Either.left "Invalid_argument")
-                           "get"
+                           "make 42 'a'"
+                           (Ortac_runtime.Exception "Invalid_argument") "get"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -2445,7 +2452,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_circular_spec"
-                        "make 42 'a'" (Either.left "Invalid_argument") "set"
+                        "make 42 'a'"
+                        (Ortac_runtime.Exception "Invalid_argument") "set"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -2503,8 +2511,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" (Either.left "Invalid_argument")
-                           "set"
+                           "make 42 'a'"
+                           (Ortac_runtime.Exception "Invalid_argument") "set"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -2555,7 +2563,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
           else
             Some
               (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
-                 (Either.right
+                 (Ortac_runtime.Value
                     (Res
                        (integer,
                          (let t_old__107_ = Model.get state__075_ 0
@@ -2635,7 +2643,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_circular_spec"
-                        "make 42 'a'" (Either.left "Invalid_argument") "make"
+                        "make 42 'a'"
+                        (Ortac_runtime.Exception "Invalid_argument") "make"
                         [("n >= 0",
                            {
                              Ortac_runtime.start =
@@ -2691,7 +2700,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" (Either.left "Invalid_argument")
+                           "make 42 'a'"
+                           (Ortac_runtime.Exception "Invalid_argument")
                            "make"
                            [("n >= 0",
                               {
@@ -2744,7 +2754,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
           else
             Some
               (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
-                 (Either.right (Res (Ortac_runtime.dummy, ()))) "is_empty"
+                 (Ortac_runtime.Value (Res (Ortac_runtime.dummy, ())))
+                 "is_empty"
                  [("b <-> t.contents = Sequence.empty",
                     {
                       Ortac_runtime.start =
@@ -2803,8 +2814,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" (Either.left "Invalid_argument")
-                           "sub"
+                           "make 42 'a'"
+                           (Ortac_runtime.Exception "Invalid_argument") "sub"
                            [("0 <= i <= Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -2864,8 +2875,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" (Either.left "Invalid_argument")
-                           "sub"
+                           "make 42 'a'"
+                           (Ortac_runtime.Exception "Invalid_argument") "sub"
                            [("i <= i + n <= Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -2930,7 +2941,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                        else
                          Some
                            (Ortac_runtime.report "Varray_circular_spec"
-                              "make 42 'a'" (Either.left "Invalid_argument")
+                              "make 42 'a'"
+                              (Ortac_runtime.Exception "Invalid_argument")
                               "sub"
                               [("0 <= i <= Sequence.length t.contents",
                                  {
@@ -2997,7 +3009,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                        else
                          Some
                            (Ortac_runtime.report "Varray_circular_spec"
-                              "make 42 'a'" (Either.left "Invalid_argument")
+                              "make 42 'a'"
+                              (Ortac_runtime.Exception "Invalid_argument")
                               "sub"
                               [("i <= i + n <= Sequence.length t.contents",
                                  {
@@ -3064,7 +3077,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_circular_spec"
-                        "make 42 'a'" (Either.left "Invalid_argument") "fill"
+                        "make 42 'a'"
+                        (Ortac_runtime.Exception "Invalid_argument") "fill"
                         [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -3138,7 +3152,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" (Either.left "Invalid_argument")
+                           "make 42 'a'"
+                           (Ortac_runtime.Exception "Invalid_argument")
                            "fill"
                            [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                               {
@@ -3215,7 +3230,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" (Either.left "Invalid_argument")
+                           "make 42 'a'"
+                           (Ortac_runtime.Exception "Invalid_argument")
                            "blit"
                            [("0 <= src_pos <= src_pos + len <= Sequence.length src.contents",
                               {
@@ -3289,7 +3305,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_circular_spec"
-                           "make 42 'a'" (Either.left "Invalid_argument")
+                           "make 42 'a'"
+                           (Ortac_runtime.Exception "Invalid_argument")
                            "blit"
                            [("0 <= dst_pos <= dst_pos + len <= Sequence.length dst.contents",
                               {
@@ -3372,7 +3389,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                        else
                          Some
                            (Ortac_runtime.report "Varray_circular_spec"
-                              "make 42 'a'" (Either.left "Invalid_argument")
+                              "make 42 'a'"
+                              (Ortac_runtime.Exception "Invalid_argument")
                               "blit"
                               [("0 <= src_pos <= src_pos + len <= Sequence.length src.contents",
                                  {
@@ -3448,7 +3466,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                        else
                          Some
                            (Ortac_runtime.report "Varray_circular_spec"
-                              "make 42 'a'" (Either.left "Invalid_argument")
+                              "make 42 'a'"
+                              (Ortac_runtime.Exception "Invalid_argument")
                               "blit"
                               [("0 <= dst_pos <= dst_pos + len <= Sequence.length dst.contents",
                                  {

--- a/examples/varray_spec_tests.ml
+++ b/examples/varray_spec_tests.ml
@@ -1525,8 +1525,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                else
                  Some
                    (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                      (Either.right (Res (Ortac_runtime.dummy, ())))
-                      "pop_back"
+                      (Ortac_runtime.Protected_value
+                         (Res (Ortac_runtime.dummy, ()))) "pop_back"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = (old t.contents)[Sequence.length (old t.contents) - 1]",
                          {
                            Ortac_runtime.start =
@@ -1582,7 +1582,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                else
                  Some
                    (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                      (Either.left "Not_found") "pop_back"
+                      (Ortac_runtime.Exception "Not_found") "pop_back"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -1643,8 +1643,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                else
                  Some
                    (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                      (Either.right (Res (Ortac_runtime.dummy, ())))
-                      "pop_front"
+                      (Ortac_runtime.Protected_value
+                         (Res (Ortac_runtime.dummy, ()))) "pop_front"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = Sequence.hd (old t.contents)",
                          {
                            Ortac_runtime.start =
@@ -1700,7 +1700,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                else
                  Some
                    (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                      (Either.left "Not_found") "pop_front"
+                      (Ortac_runtime.Exception "Not_found") "pop_front"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -1758,7 +1758,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                        (Either.left "Invalid_argument") "insert_at"
+                        (Ortac_runtime.Exception "Invalid_argument")
+                        "insert_at"
                         [("0 <= i <= Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -1820,7 +1821,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           (Either.left "Invalid_argument") "insert_at"
+                           (Ortac_runtime.Exception "Invalid_argument")
+                           "insert_at"
                            [("0 <= i <= Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1870,7 +1872,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                        (Either.left "Invalid_argument") "pop_at"
+                        (Ortac_runtime.Exception "Invalid_argument") "pop_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1926,8 +1928,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           (Either.right (Res (Ortac_runtime.dummy, ())))
-                           "pop_at"
+                           (Ortac_runtime.Protected_value
+                              (Res (Ortac_runtime.dummy, ()))) "pop_at"
                            [("(proj x) = old t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -1982,7 +1984,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           (Either.left "Invalid_argument") "pop_at"
+                           (Ortac_runtime.Exception "Invalid_argument")
+                           "pop_at"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -2032,7 +2035,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                        (Either.left "Invalid_argument") "delete_at"
+                        (Ortac_runtime.Exception "Invalid_argument")
+                        "delete_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -2091,7 +2095,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           (Either.right (Res (unit, ()))) "delete_at"
+                           (Ortac_runtime.Protected_value (Res (unit, ())))
+                           "delete_at"
                            [("Sequence.length t.contents = Sequence.length (old t.contents) - 1",
                               {
                                 Ortac_runtime.start =
@@ -2146,7 +2151,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           (Either.left "Invalid_argument") "delete_at"
+                           (Ortac_runtime.Exception "Invalid_argument")
+                           "delete_at"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -2196,7 +2202,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                        (Either.left "Invalid_argument") "get"
+                        (Ortac_runtime.Exception "Invalid_argument") "get"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -2252,8 +2258,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           (Either.right (Res (Ortac_runtime.dummy, ())))
-                           "get"
+                           (Ortac_runtime.Protected_value
+                              (Res (Ortac_runtime.dummy, ()))) "get"
                            [("(proj x) = t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -2308,7 +2314,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           (Either.left "Invalid_argument") "get"
+                           (Ortac_runtime.Exception "Invalid_argument") "get"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -2358,7 +2364,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                        (Either.left "Invalid_argument") "set"
+                        (Ortac_runtime.Exception "Invalid_argument") "set"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -2414,7 +2420,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           (Either.left "Invalid_argument") "set"
+                           (Ortac_runtime.Exception "Invalid_argument") "set"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -2465,7 +2471,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
           else
             Some
               (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                 (Either.right
+                 (Ortac_runtime.Value
                     (Res
                        (integer,
                          (let t_old__107_ = Model.get state__075_ 0
@@ -2649,7 +2655,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
           else
             Some
               (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                 (Either.right (Res (Ortac_runtime.dummy, ()))) "is_empty"
+                 (Ortac_runtime.Value (Res (Ortac_runtime.dummy, ())))
+                 "is_empty"
                  [("b <-> t.contents = Sequence.empty",
                     {
                       Ortac_runtime.start =
@@ -2961,7 +2968,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  else
                    Some
                      (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                        (Either.left "Invalid_argument") "fill"
+                        (Ortac_runtime.Exception "Invalid_argument") "fill"
                         [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -3033,7 +3040,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           (Either.left "Invalid_argument") "fill"
+                           (Ortac_runtime.Exception "Invalid_argument")
+                           "fill"
                            [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -3109,7 +3117,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           (Either.left "Invalid_argument") "blit"
+                           (Ortac_runtime.Exception "Invalid_argument")
+                           "blit"
                            [("0 <= src_pos <= src_pos + len <= Sequence.length src.contents",
                               {
                                 Ortac_runtime.start =
@@ -3182,7 +3191,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     else
                       Some
                         (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                           (Either.left "Invalid_argument") "blit"
+                           (Ortac_runtime.Exception "Invalid_argument")
+                           "blit"
                            [("0 <= dst_pos <= dst_pos + len <= Sequence.length dst.contents",
                               {
                                 Ortac_runtime.start =
@@ -3262,7 +3272,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                        else
                          Some
                            (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                              (Either.left "Invalid_argument") "blit"
+                              (Ortac_runtime.Exception "Invalid_argument")
+                              "blit"
                               [("0 <= src_pos <= src_pos + len <= Sequence.length src.contents",
                                  {
                                    Ortac_runtime.start =
@@ -3335,7 +3346,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                        else
                          Some
                            (Ortac_runtime.report "Varray_spec" "make 42 'a'"
-                              (Either.left "Invalid_argument") "blit"
+                              (Ortac_runtime.Exception "Invalid_argument")
+                              "blit"
                               [("0 <= dst_pos <= dst_pos + len <= Sequence.length dst.contents",
                                  {
                                    Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/array_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/array_stm_tests.expected.ml
@@ -942,7 +942,7 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
           else
             Some
               (Ortac_runtime.report "Array" "make 16 'a'"
-                 (Either.right
+                 (Ortac_runtime.Value
                     (Res
                        (integer,
                          (let t_old__046_ = Model.get state__043_ 0
@@ -1025,7 +1025,7 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                  else
                    Some
                      (Ortac_runtime.report "Array" "make 16 'a'"
-                        (Either.left "Invalid_argument") "get"
+                        (Ortac_runtime.Exception "Invalid_argument") "get"
                         [("0 <= i < t.size",
                            {
                              Ortac_runtime.start =
@@ -1081,7 +1081,7 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                     else
                       Some
                         (Ortac_runtime.report "Array" "make 16 'a'"
-                           (Either.right
+                           (Ortac_runtime.Protected_value
                               (Res
                                  (char,
                                    (let t_old__051_ = Model.get state__043_ 0
@@ -1174,7 +1174,7 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                     else
                       Some
                         (Ortac_runtime.report "Array" "make 16 'a'"
-                           (Either.left "Invalid_argument") "get"
+                           (Ortac_runtime.Exception "Invalid_argument") "get"
                            [("0 <= i < t.size",
                               {
                                 Ortac_runtime.start =
@@ -1230,7 +1230,7 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                  else
                    Some
                      (Ortac_runtime.report "Array" "make 16 'a'"
-                        (Either.left "Invalid_argument") "set"
+                        (Ortac_runtime.Exception "Invalid_argument") "set"
                         [("0 <= i < t.size",
                            {
                              Ortac_runtime.start =
@@ -1291,7 +1291,7 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                     else
                       Some
                         (Ortac_runtime.report "Array" "make 16 'a'"
-                           (Either.left "Invalid_argument") "set"
+                           (Ortac_runtime.Exception "Invalid_argument") "set"
                            [("0 <= i < t.size",
                               {
                                 Ortac_runtime.start =
@@ -1340,7 +1340,7 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                  else
                    Some
                      (Ortac_runtime.report "Array" "make 16 'a'"
-                        (Either.left "Invalid_argument") "make"
+                        (Ortac_runtime.Exception "Invalid_argument") "make"
                         [("i >= 0",
                            {
                              Ortac_runtime.start =
@@ -1394,7 +1394,8 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                     else
                       Some
                         (Ortac_runtime.report "Array" "make 16 'a'"
-                           (Either.left "Invalid_argument") "make"
+                           (Ortac_runtime.Exception "Invalid_argument")
+                           "make"
                            [("i >= 0",
                               {
                                 Ortac_runtime.start =
@@ -1453,7 +1454,7 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                     else
                       Some
                         (Ortac_runtime.report "Array" "make 16 'a'"
-                           (Either.left "Invalid_argument") "sub"
+                           (Ortac_runtime.Exception "Invalid_argument") "sub"
                            [("0 <= i <= Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1513,7 +1514,7 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                     else
                       Some
                         (Ortac_runtime.report "Array" "make 16 'a'"
-                           (Either.left "Invalid_argument") "sub"
+                           (Ortac_runtime.Exception "Invalid_argument") "sub"
                            [("i <= i + n <= Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1576,7 +1577,8 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                        else
                          Some
                            (Ortac_runtime.report "Array" "make 16 'a'"
-                              (Either.left "Invalid_argument") "sub"
+                              (Ortac_runtime.Exception "Invalid_argument")
+                              "sub"
                               [("0 <= i <= Sequence.length t.contents",
                                  {
                                    Ortac_runtime.start =
@@ -1640,7 +1642,8 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                        else
                          Some
                            (Ortac_runtime.report "Array" "make 16 'a'"
-                              (Either.left "Invalid_argument") "sub"
+                              (Ortac_runtime.Exception "Invalid_argument")
+                              "sub"
                               [("i <= i + n <= Sequence.length t.contents",
                                  {
                                    Ortac_runtime.start =
@@ -1692,7 +1695,8 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                     else
                       Some
                         (Ortac_runtime.report "Array" "make 16 'a'"
-                           (Either.left "Invalid_argument") "fill"
+                           (Ortac_runtime.Exception "Invalid_argument")
+                           "fill"
                            [("0 <= pos",
                               {
                                 Ortac_runtime.start =
@@ -1742,7 +1746,8 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                        else
                          Some
                            (Ortac_runtime.report "Array" "make 16 'a'"
-                              (Either.left "Invalid_argument") "fill"
+                              (Ortac_runtime.Exception "Invalid_argument")
+                              "fill"
                               [("0 <= len",
                                  {
                                    Ortac_runtime.start =
@@ -1794,7 +1799,8 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                        else
                          Some
                            (Ortac_runtime.report "Array" "make 16 'a'"
-                              (Either.left "Invalid_argument") "fill"
+                              (Ortac_runtime.Exception "Invalid_argument")
+                              "fill"
                               [("pos + len <= t.size",
                                  {
                                    Ortac_runtime.start =
@@ -1850,7 +1856,8 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                        else
                          Some
                            (Ortac_runtime.report "Array" "make 16 'a'"
-                              (Either.left "Invalid_argument") "fill"
+                              (Ortac_runtime.Exception "Invalid_argument")
+                              "fill"
                               [("0 <= pos",
                                  {
                                    Ortac_runtime.start =
@@ -1901,7 +1908,8 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                           else
                             Some
                               (Ortac_runtime.report "Array" "make 16 'a'"
-                                 (Either.left "Invalid_argument") "fill"
+                                 (Ortac_runtime.Exception "Invalid_argument")
+                                 "fill"
                                  [("0 <= len",
                                     {
                                       Ortac_runtime.start =
@@ -1953,7 +1961,8 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                           else
                             Some
                               (Ortac_runtime.report "Array" "make 16 'a'"
-                                 (Either.left "Invalid_argument") "fill"
+                                 (Ortac_runtime.Exception "Invalid_argument")
+                                 "fill"
                                  [("pos + len <= t.size",
                                     {
                                       Ortac_runtime.start =
@@ -2004,7 +2013,7 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
           else
             Some
               (Ortac_runtime.report "Array" "make 16 'a'"
-                 (Either.right
+                 (Ortac_runtime.Value
                     (Res
                        ((list char),
                          (let t_old__070_ = Model.get state__043_ 0
@@ -2084,7 +2093,7 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
           else
             Some
               (Ortac_runtime.report "Array" "make 16 'a'"
-                 (Either.right (Res (Ortac_runtime.dummy, ()))) "mem"
+                 (Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))) "mem"
                  [("b = Sequence.mem t.contents a",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
@@ -314,7 +314,8 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                  else
                    Some
                      (Ortac_runtime.report "Conjunctive_clauses"
-                        "make 42 'a'" (Either.left "Invalid_argument") "make"
+                        "make 42 'a'"
+                        (Ortac_runtime.Exception "Invalid_argument") "make"
                         [("i >= 0",
                            {
                              Ortac_runtime.start =
@@ -368,7 +369,8 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                     else
                       Some
                         (Ortac_runtime.report "Conjunctive_clauses"
-                           "make 42 'a'" (Either.left "Invalid_argument")
+                           "make 42 'a'"
+                           (Ortac_runtime.Exception "Invalid_argument")
                            "make"
                            [("i >= 0",
                               {
@@ -426,7 +428,8 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                  else
                    Some
                      (Ortac_runtime.report "Conjunctive_clauses"
-                        "make 42 'a'" (Either.left "Invalid_argument") "set"
+                        "make 42 'a'"
+                        (Ortac_runtime.Exception "Invalid_argument") "set"
                         [("0 <= i < List.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -488,8 +491,8 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                     else
                       Some
                         (Ortac_runtime.report "Conjunctive_clauses"
-                           "make 42 'a'" (Either.left "Invalid_argument")
-                           "set"
+                           "make 42 'a'"
+                           (Ortac_runtime.Exception "Invalid_argument") "set"
                            [("0 <= i < List.length t.contents",
                               {
                                 Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/custom_config_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/custom_config_stm_tests.expected.ml
@@ -293,7 +293,7 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                  else
                    Some
                      (Ortac_runtime.report "Custom_config" "empty ()"
-                        (Either.left "Invalid_argument") "top"
+                        (Ortac_runtime.Exception "Invalid_argument") "top"
                         [("t.contents <> Sequence.empty",
                            {
                              Ortac_runtime.start =
@@ -348,8 +348,8 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                     else
                       Some
                         (Ortac_runtime.report "Custom_config" "empty ()"
-                           (Either.right (Res (Ortac_runtime.dummy, ())))
-                           "top"
+                           (Ortac_runtime.Protected_value
+                              (Res (Ortac_runtime.dummy, ()))) "top"
                            [("proj a = Sequence.hd t.contents",
                               {
                                 Ortac_runtime.start =
@@ -403,7 +403,7 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                     else
                       Some
                         (Ortac_runtime.report "Custom_config" "empty ()"
-                           (Either.left "Invalid_argument") "top"
+                           (Ortac_runtime.Exception "Invalid_argument") "top"
                            [("t.contents <> Sequence.empty",
                               {
                                 Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
@@ -581,7 +581,8 @@ let ortac_postcond cmd__030_ state__031_ res__032_ =
                else
                  Some
                    (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
-                      (Either.right (Res (Ortac_runtime.dummy, ()))) "find"
+                      (Ortac_runtime.Protected_value
+                         (Res (Ortac_runtime.dummy, ()))) "find"
                       [("List.mem (a, b) h.contents",
                          {
                            Ortac_runtime.start =
@@ -635,7 +636,7 @@ let ortac_postcond cmd__030_ state__031_ res__032_ =
                else
                  Some
                    (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
-                      (Either.left "Not_found") "find"
+                      (Ortac_runtime.Exception "Not_found") "find"
                       [("not (List.mem a (List.map fst h.contents))",
                          {
                            Ortac_runtime.start =
@@ -701,7 +702,8 @@ let ortac_postcond cmd__030_ state__031_ res__032_ =
           else
             Some
               (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
-                 (Either.right (Res (Ortac_runtime.dummy, ()))) "find_opt"
+                 (Ortac_runtime.Value (Res (Ortac_runtime.dummy, ())))
+                 "find_opt"
                  [("match o with\n      | None -> not (List.mem a (List.map fst h.contents))\n      | Some b -> List.mem (a, b) h.contents",
                     {
                       Ortac_runtime.start =
@@ -754,7 +756,8 @@ let ortac_postcond cmd__030_ state__031_ res__032_ =
           else
             Some
               (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
-                 (Either.right (Res (Ortac_runtime.dummy, ()))) "find_all"
+                 (Ortac_runtime.Value (Res (Ortac_runtime.dummy, ())))
+                 "find_all"
                  [("bs = Sequence.filter_map (fun (x, y) -> if x = a then Some y else None) h.contents",
                     {
                       Ortac_runtime.start =
@@ -807,7 +810,7 @@ let ortac_postcond cmd__030_ state__031_ res__032_ =
           else
             Some
               (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
-                 (Either.right (Res (Ortac_runtime.dummy, ()))) "mem"
+                 (Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))) "mem"
                  [("b = List.mem a (List.map fst h.contents)",
                     {
                       Ortac_runtime.start =
@@ -860,7 +863,7 @@ let ortac_postcond cmd__030_ state__031_ res__032_ =
           else
             Some
               (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
-                 (Either.right
+                 (Ortac_runtime.Value
                     (Res
                        (integer,
                          (let h_old__056_ = Model.get state__031_ 0

--- a/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
@@ -541,7 +541,8 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
           else
             Some
               (Ortac_runtime.report "Invariants" "create 42"
-                 (Either.right (Res (Ortac_runtime.dummy, ()))) "create"
+                 (Ortac_runtime.Value (Res (Ortac_runtime.dummy, ())))
+                 "create"
                  [("Sequence.length x.contents > 0",
                     {
                       Ortac_runtime.start =
@@ -592,7 +593,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
           else
             Some
               (Ortac_runtime.report "Invariants" "create 42"
-                 (Either.right (Res (unit, ()))) "push"
+                 (Ortac_runtime.Value (Res (unit, ()))) "push"
                  [("Sequence.length x.contents > 0",
                     {
                       Ortac_runtime.start =
@@ -644,7 +645,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
              else
                Some
                  (Ortac_runtime.report "Invariants" "create 42"
-                    (Either.right (Res (unit, ()))) "transfer"
+                    (Ortac_runtime.Value (Res (unit, ()))) "transfer"
                     [("Sequence.length x.contents > 0",
                        {
                          Ortac_runtime.start =
@@ -694,7 +695,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
              else
                Some
                  (Ortac_runtime.report "Invariants" "create 42"
-                    (Either.right (Res (unit, ()))) "transfer"
+                    (Ortac_runtime.Value (Res (unit, ()))) "transfer"
                     [("Sequence.length x.contents > 0",
                        {
                          Ortac_runtime.start =
@@ -746,7 +747,8 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
              else
                Some
                  (Ortac_runtime.report "Invariants" "create 42"
-                    (Either.right (Res (Ortac_runtime.dummy, ()))) "copy"
+                    (Ortac_runtime.Value (Res (Ortac_runtime.dummy, ())))
+                    "copy"
                     [("Sequence.length x.contents > 0",
                        {
                          Ortac_runtime.start =
@@ -796,7 +798,8 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
              else
                Some
                  (Ortac_runtime.report "Invariants" "create 42"
-                    (Either.right (Res (Ortac_runtime.dummy, ()))) "copy"
+                    (Ortac_runtime.Value (Res (Ortac_runtime.dummy, ())))
+                    "copy"
                     [("Sequence.length x.contents > 0",
                        {
                          Ortac_runtime.start =
@@ -854,7 +857,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                     else
                       Some
                         (Ortac_runtime.report "Invariants" "create 42"
-                           (Either.left "Invalid_argument") "sub"
+                           (Ortac_runtime.Exception "Invalid_argument") "sub"
                            [("0 <= i <= Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -919,7 +922,8 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                        else
                          Some
                            (Ortac_runtime.report "Invariants" "create 42"
-                              (Either.left "Invalid_argument") "sub"
+                              (Ortac_runtime.Exception "Invalid_argument")
+                              "sub"
                               [("i <= i + n <= Sequence.length t.contents",
                                  {
                                    Ortac_runtime.start =
@@ -968,7 +972,8 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                        else
                          Some
                            (Ortac_runtime.report "Invariants" "create 42"
-                              (Either.left "Invalid_argument") "sub"
+                              (Ortac_runtime.Exception "Invalid_argument")
+                              "sub"
                               [("n >= 1",
                                  {
                                    Ortac_runtime.start =
@@ -1024,8 +1029,8 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                        else
                          Some
                            (Ortac_runtime.report "Invariants" "create 42"
-                              (Either.right (Res (Ortac_runtime.dummy, ())))
-                              "sub"
+                              (Ortac_runtime.Protected_value
+                                 (Res (Ortac_runtime.dummy, ()))) "sub"
                               [("Sequence.length x.contents > 0",
                                  {
                                    Ortac_runtime.start =
@@ -1076,8 +1081,8 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                        else
                          Some
                            (Ortac_runtime.report "Invariants" "create 42"
-                              (Either.right (Res (Ortac_runtime.dummy, ())))
-                              "sub"
+                              (Ortac_runtime.Protected_value
+                                 (Res (Ortac_runtime.dummy, ()))) "sub"
                               [("Sequence.length x.contents > 0",
                                  {
                                    Ortac_runtime.start =
@@ -1139,7 +1144,8 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                        else
                          Some
                            (Ortac_runtime.report "Invariants" "create 42"
-                              (Either.left "Invalid_argument") "sub"
+                              (Ortac_runtime.Exception "Invalid_argument")
+                              "sub"
                               [("0 <= i <= Sequence.length t.contents",
                                  {
                                    Ortac_runtime.start =
@@ -1205,7 +1211,8 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                           else
                             Some
                               (Ortac_runtime.report "Invariants" "create 42"
-                                 (Either.left "Invalid_argument") "sub"
+                                 (Ortac_runtime.Exception "Invalid_argument")
+                                 "sub"
                                  [("i <= i + n <= Sequence.length t.contents",
                                     {
                                       Ortac_runtime.start =
@@ -1254,7 +1261,8 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                           else
                             Some
                               (Ortac_runtime.report "Invariants" "create 42"
-                                 (Either.left "Invalid_argument") "sub"
+                                 (Ortac_runtime.Exception "Invalid_argument")
+                                 "sub"
                                  [("n >= 1",
                                     {
                                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/queue_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/queue_stm_tests.expected.ml
@@ -457,7 +457,7 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                   else
                     Some
                       (Ortac_runtime.report "Queue" "create ()"
-                         (Either.right
+                         (Ortac_runtime.Protected_value
                             (Res
                                (int,
                                  (let t_old__028_ = Model.get state__024_ 0
@@ -539,7 +539,7 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                   else
                     Some
                       (Ortac_runtime.report "Queue" "create ()"
-                         (Either.right
+                         (Ortac_runtime.Protected_value
                             (Res
                                (int,
                                  (let t_old__028_ = Model.get state__024_ 0
@@ -626,7 +626,7 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                else
                  Some
                    (Ortac_runtime.report "Queue" "create ()"
-                      (Either.left "Empty") "pop"
+                      (Ortac_runtime.Exception "Empty") "pop"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -681,7 +681,7 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                else
                  Some
                    (Ortac_runtime.report "Queue" "create ()"
-                      (Either.right
+                      (Ortac_runtime.Protected_value
                          (Res
                             (int,
                               (let t_old__039_ = Model.get state__024_ 0
@@ -767,7 +767,7 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                else
                  Some
                    (Ortac_runtime.report "Queue" "create ()"
-                      (Either.left "Empty") "peek"
+                      (Ortac_runtime.Exception "Empty") "peek"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -831,7 +831,8 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
           else
             Some
               (Ortac_runtime.report "Queue" "create ()"
-                 (Either.right (Res (Ortac_runtime.dummy, ()))) "peek_opt"
+                 (Ortac_runtime.Value (Res (Ortac_runtime.dummy, ())))
+                 "peek_opt"
                  [("match v with\n        | None -> t.contents = Sequence.empty\n        | Some a -> a = Sequence.hd t.contents",
                     {
                       Ortac_runtime.start =
@@ -889,7 +890,7 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
           else
             Some
               (Ortac_runtime.report "Queue" "create ()"
-                 (Either.right
+                 (Ortac_runtime.Value
                     (Res
                        (bool,
                          (let t_old__052_ = Model.get state__024_ 0

--- a/plugins/qcheck-stm/test/record_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/record_stm_tests.expected.ml
@@ -225,7 +225,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
           else
             Some
               (Ortac_runtime.report "Record" "make 42"
-                 (Either.right
+                 (Ortac_runtime.Value
                     (Res
                        (integer,
                          (try
@@ -302,7 +302,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
           else
             Some
               (Ortac_runtime.report "Record" "make 42"
-                 (Either.right
+                 (Ortac_runtime.Value
                     (Res
                        (integer,
                          (try
@@ -381,7 +381,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
              else
                Some
                  (Ortac_runtime.report "Record" "make 42"
-                    (Either.right
+                    (Ortac_runtime.Value
                        (Res
                           (integer,
                             (let r_old__013_ = Model.get state__009_ 0
@@ -463,7 +463,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                 else
                   Some
                     (Ortac_runtime.report "Record" "make 42"
-                       (Either.right
+                       (Ortac_runtime.Value
                           (Res
                              (integer,
                                (let r_old__013_ = Model.get state__009_ 0
@@ -543,7 +543,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                 else
                   Some
                     (Ortac_runtime.report "Record" "make 42"
-                       (Either.right
+                       (Ortac_runtime.Value
                           (Res
                              (integer,
                                (let r_old__013_ = Model.get state__009_ 0

--- a/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
@@ -173,7 +173,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
           else
             Some
               (Ortac_runtime.report "Ref" "make 42"
-                 (Either.right
+                 (Ortac_runtime.Value
                     (Res
                        (integer,
                          (let r_old__012_ = Model.get state__009_ 0

--- a/plugins/qcheck-stm/test/sut_in_type_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/sut_in_type_stm_tests.expected.ml
@@ -207,7 +207,7 @@ let ortac_postcond cmd__006_ state__007_ res__008_ =
                  else
                    Some
                      (Ortac_runtime.report "Sut_in_type" "make 16 0"
-                        (Either.left "Invalid_argument") "make"
+                        (Ortac_runtime.Exception "Invalid_argument") "make"
                         [("i >= 0",
                            {
                              Ortac_runtime.start =
@@ -261,7 +261,8 @@ let ortac_postcond cmd__006_ state__007_ res__008_ =
                     else
                       Some
                         (Ortac_runtime.report "Sut_in_type" "make 16 0"
-                           (Either.left "Invalid_argument") "make"
+                           (Ortac_runtime.Exception "Invalid_argument")
+                           "make"
                            [("i >= 0",
                               {
                                 Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/test_without_sut_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/test_without_sut_stm_tests.expected.ml
@@ -219,7 +219,7 @@ let ortac_postcond cmd__006_ state__007_ res__008_ =
                  else
                    Some
                      (Ortac_runtime.report "Test_without_sut" "make 16 0"
-                        (Either.left "Invalid_argument") "make"
+                        (Ortac_runtime.Exception "Invalid_argument") "make"
                         [("i >= 0",
                            {
                              Ortac_runtime.start =
@@ -273,7 +273,8 @@ let ortac_postcond cmd__006_ state__007_ res__008_ =
                     else
                       Some
                         (Ortac_runtime.report "Test_without_sut" "make 16 0"
-                           (Either.left "Invalid_argument") "make"
+                           (Ortac_runtime.Exception "Invalid_argument")
+                           "make"
                            [("i >= 0",
                               {
                                 Ortac_runtime.start =
@@ -323,7 +324,7 @@ let ortac_postcond cmd__006_ state__007_ res__008_ =
           else
             Some
               (Ortac_runtime.report "Test_without_sut" "make 16 0"
-                 (Either.right
+                 (Ortac_runtime.Value
                     (Res
                        (integer,
                          (try

--- a/plugins/qcheck-stm/test/tuples_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/tuples_stm_tests.expected.ml
@@ -428,7 +428,8 @@ let ortac_postcond cmd__018_ state__019_ res__020_ =
              else
                Some
                  (Ortac_runtime.report "Tuples" "create ()"
-                    (Either.right (Res (Ortac_runtime.dummy, ()))) "size_tup"
+                    (Ortac_runtime.Value (Res (Ortac_runtime.dummy, ())))
+                    "size_tup"
                     [("x = List.length t.contents",
                        {
                          Ortac_runtime.start =
@@ -479,7 +480,8 @@ let ortac_postcond cmd__018_ state__019_ res__020_ =
              else
                Some
                  (Ortac_runtime.report "Tuples" "create ()"
-                    (Either.right (Res (Ortac_runtime.dummy, ()))) "size_tup"
+                    (Ortac_runtime.Value (Res (Ortac_runtime.dummy, ())))
+                    "size_tup"
                     [("y = List.length t.contents",
                        {
                          Ortac_runtime.start =
@@ -532,7 +534,7 @@ let ortac_postcond cmd__018_ state__019_ res__020_ =
              else
                Some
                  (Ortac_runtime.report "Tuples" "create ()"
-                    (Either.right (Res (Ortac_runtime.dummy, ())))
+                    (Ortac_runtime.Value (Res (Ortac_runtime.dummy, ())))
                     "size_tup'"
                     [("x = List.length t.contents",
                        {
@@ -585,7 +587,7 @@ let ortac_postcond cmd__018_ state__019_ res__020_ =
                 else
                   Some
                     (Ortac_runtime.report "Tuples" "create ()"
-                       (Either.right (Res (Ortac_runtime.dummy, ())))
+                       (Ortac_runtime.Value (Res (Ortac_runtime.dummy, ())))
                        "size_tup'"
                        [("y = List.length t.contents",
                           {
@@ -637,7 +639,7 @@ let ortac_postcond cmd__018_ state__019_ res__020_ =
                 else
                   Some
                     (Ortac_runtime.report "Tuples" "create ()"
-                       (Either.right (Res (Ortac_runtime.dummy, ())))
+                       (Ortac_runtime.Value (Res (Ortac_runtime.dummy, ())))
                        "size_tup'"
                        [("z = List.length t.contents",
                           {


### PR DESCRIPTION

Fixes #248

As suggested in the issue, the PR add a variant with three constructors to `Ortac_runtime_qcheck_stm` making it possible to pass the information whether the result is a value, a protected value or an exception from the generated tests to the runtime.

We don't really have tests for failing tests, which explains why we didn't spot the bug earlier. I'll open an issue for that, to keep this PR small and focused on the fix.