### PR TITLE
Add command shrinker function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add command shrinker function
+  [\#272](https://github.com/ocaml-gospel/ortac/pull/272)
 - Remove unnecessary stack access from precondition
   [\#264](https://github.com/ocaml-gospel/ortac/pull/264)
 

--- a/examples/lwt_dllist_spec_tests.ml
+++ b/examples/lwt_dllist_spec_tests.ml
@@ -81,10 +81,24 @@ module Spec =
       | Take_r -> Format.asprintf "protect (fun () -> %s <sut>)" "take_r"
       | Take_opt_l -> Format.asprintf "%s <sut>" "take_opt_l"
       | Take_opt_r -> Format.asprintf "%s <sut>" "take_opt_r"
+    let shrink_cmd cmd__002_ =
+      let open QCheck in
+        let open Shrink in
+          let open Iter in
+            match cmd__002_ with
+            | Create () -> map (fun () -> Create ()) (unit ())
+            | Is_empty -> empty
+            | Length -> empty
+            | Add_l a_1 -> map (fun a_1 -> Add_l a_1) (int a_1)
+            | Add_r a_2 -> map (fun a_2 -> Add_r a_2) (int a_2)
+            | Take_l -> empty
+            | Take_r -> empty
+            | Take_opt_l -> empty
+            | Take_opt_r -> empty
     let cleanup _ = ()
     let arb_cmd _ =
       let open QCheck in
-        make ~print:show_cmd
+        make ~print:show_cmd ~shrink:shrink_cmd
           (let open Gen in
              oneof
                [(pure (fun () -> Create ())) <*> unit;
@@ -96,10 +110,10 @@ module Spec =
                pure Take_r;
                pure Take_opt_l;
                pure Take_opt_r])
-    let next_state cmd__002_ state__003_ =
-      match cmd__002_ with
+    let next_state cmd__003_ state__004_ =
+      match cmd__003_ with
       | Create () ->
-          let s__005_ =
+          let s__006_ =
             let open ModelElt in
               {
                 contents =
@@ -126,24 +140,24 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 0) s__005_
+          Model.push (Model.drop_n state__004_ 0) s__006_
       | Is_empty ->
-          let s_1__006_ = Model.get state__003_ 0 in
-          let s_1__007_ = s_1__006_ in
-          Model.push (Model.drop_n state__003_ 1) s_1__007_
+          let s_1__007_ = Model.get state__004_ 0 in
+          let s_1__008_ = s_1__007_ in
+          Model.push (Model.drop_n state__004_ 1) s_1__008_
       | Length ->
-          let s_2__008_ = Model.get state__003_ 0 in
-          let s_2__009_ = s_2__008_ in
-          Model.push (Model.drop_n state__003_ 1) s_2__009_
+          let s_2__009_ = Model.get state__004_ 0 in
+          let s_2__010_ = s_2__009_ in
+          Model.push (Model.drop_n state__004_ 1) s_2__010_
       | Add_l a_1 ->
-          let s_3__010_ = Model.get state__003_ 0 in
-          let s_3__011_ =
+          let s_3__011_ = Model.get state__004_ 0 in
+          let s_3__012_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      Ortac_runtime.Gospelstdlib.Sequence.cons a_1
-                       s_3__010_.contents
+                       s_3__011_.contents
                    with
                    | e ->
                        raise
@@ -166,16 +180,16 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) s_3__011_
+          Model.push (Model.drop_n state__004_ 1) s_3__012_
       | Add_r a_2 ->
-          let s_4__012_ = Model.get state__003_ 0 in
-          let s_4__013_ =
+          let s_4__013_ = Model.get state__004_ 0 in
+          let s_4__014_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      Ortac_runtime.Gospelstdlib.Sequence.snoc
-                       s_4__012_.contents a_2
+                       s_4__013_.contents a_2
                    with
                    | e ->
                        raise
@@ -198,21 +212,21 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) s_4__013_
+          Model.push (Model.drop_n state__004_ 1) s_4__014_
       | Take_l ->
-          let s_5__014_ = Model.get state__003_ 0 in
-          let s_5__015_ =
+          let s_5__015_ = Model.get state__004_ 0 in
+          let s_5__016_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      if
-                       s_5__014_.contents =
+                       s_5__015_.contents =
                          Ortac_runtime.Gospelstdlib.Sequence.empty
                      then Ortac_runtime.Gospelstdlib.Sequence.empty
                      else
                        Ortac_runtime.Gospelstdlib.Sequence.tl
-                         s_5__014_.contents
+                         s_5__015_.contents
                    with
                    | e ->
                        raise
@@ -235,24 +249,24 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) s_5__015_
+          Model.push (Model.drop_n state__004_ 1) s_5__016_
       | Take_r ->
-          let s_6__016_ = Model.get state__003_ 0 in
-          let s_6__017_ =
+          let s_6__017_ = Model.get state__004_ 0 in
+          let s_6__018_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      if
-                       s_6__016_.contents =
+                       s_6__017_.contents =
                          Ortac_runtime.Gospelstdlib.Sequence.empty
                      then Ortac_runtime.Gospelstdlib.Sequence.empty
                      else
                        Ortac_runtime.Gospelstdlib.__mix_Bddub
-                         s_6__016_.contents
+                         s_6__017_.contents
                          (Ortac_runtime.Gospelstdlib.(-)
                             (Ortac_runtime.Gospelstdlib.Sequence.length
-                               s_6__016_.contents)
+                               s_6__017_.contents)
                             (Ortac_runtime.Gospelstdlib.integer_of_int 2))
                    with
                    | e ->
@@ -276,22 +290,22 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) s_6__017_
+          Model.push (Model.drop_n state__004_ 1) s_6__018_
       | Take_opt_l ->
-          let s_7__018_ = Model.get state__003_ 0 in
-          let s_7__019_ =
+          let s_7__019_ = Model.get state__004_ 0 in
+          let s_7__020_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      if
                        (Ortac_runtime.Gospelstdlib.Sequence.length
-                          s_7__018_.contents)
+                          s_7__019_.contents)
                          = (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                      then Ortac_runtime.Gospelstdlib.Sequence.empty
                      else
                        Ortac_runtime.Gospelstdlib.Sequence.tl
-                         s_7__018_.contents
+                         s_7__019_.contents
                    with
                    | e ->
                        raise
@@ -314,24 +328,24 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) s_7__019_
+          Model.push (Model.drop_n state__004_ 1) s_7__020_
       | Take_opt_r ->
-          let s_8__020_ = Model.get state__003_ 0 in
-          let s_8__022_ =
+          let s_8__021_ = Model.get state__004_ 0 in
+          let s_8__023_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      match Ortac_runtime.Gospelstdlib.Sequence.length
-                             s_8__020_.contents
+                             s_8__021_.contents
                      with
-                     | __x__021_ when
-                         (=) __x__021_
+                     | __x__022_ when
+                         (=) __x__022_
                            (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                          -> Ortac_runtime.Gospelstdlib.Sequence.empty
                      | l ->
                          Ortac_runtime.Gospelstdlib.__mix_Bddub
-                           s_8__020_.contents
+                           s_8__021_.contents
                            (Ortac_runtime.Gospelstdlib.(-) l
                               (Ortac_runtime.Gospelstdlib.integer_of_int 2))
                    with
@@ -356,9 +370,9 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) s_8__022_
-    let precond cmd__057_ state__058_ =
-      match cmd__057_ with
+          Model.push (Model.drop_n state__004_ 1) s_8__023_
+    let precond cmd__058_ state__059_ =
+      match cmd__058_ with
       | Create () -> true
       | Is_empty -> true
       | Length -> true
@@ -369,127 +383,127 @@ module Spec =
       | Take_opt_l -> true
       | Take_opt_r -> true
     let postcond _ _ _ = true
-    let run cmd__059_ sut__060_ =
-      match cmd__059_ with
+    let run cmd__060_ sut__061_ =
+      match cmd__060_ with
       | Create () ->
           Res
             (sut,
-              (let res__061_ = create () in
-               (SUT.push sut__060_ res__061_; res__061_)))
+              (let res__062_ = create () in
+               (SUT.push sut__061_ res__062_; res__062_)))
       | Is_empty ->
           Res
             (bool,
-              (let s_1__062_ = SUT.pop sut__060_ in
-               let res__063_ = is_empty s_1__062_ in
-               (SUT.push sut__060_ s_1__062_; res__063_)))
+              (let s_1__063_ = SUT.pop sut__061_ in
+               let res__064_ = is_empty s_1__063_ in
+               (SUT.push sut__061_ s_1__063_; res__064_)))
       | Length ->
           Res
             (int,
-              (let s_2__064_ = SUT.pop sut__060_ in
-               let res__065_ = length s_2__064_ in
-               (SUT.push sut__060_ s_2__064_; res__065_)))
+              (let s_2__065_ = SUT.pop sut__061_ in
+               let res__066_ = length s_2__065_ in
+               (SUT.push sut__061_ s_2__065_; res__066_)))
       | Add_l a_1 ->
           Res
             ((node int),
-              (let s_3__066_ = SUT.pop sut__060_ in
-               let res__067_ = add_l a_1 s_3__066_ in
-               (SUT.push sut__060_ s_3__066_; res__067_)))
+              (let s_3__067_ = SUT.pop sut__061_ in
+               let res__068_ = add_l a_1 s_3__067_ in
+               (SUT.push sut__061_ s_3__067_; res__068_)))
       | Add_r a_2 ->
           Res
             ((node int),
-              (let s_4__068_ = SUT.pop sut__060_ in
-               let res__069_ = add_r a_2 s_4__068_ in
-               (SUT.push sut__060_ s_4__068_; res__069_)))
+              (let s_4__069_ = SUT.pop sut__061_ in
+               let res__070_ = add_r a_2 s_4__069_ in
+               (SUT.push sut__061_ s_4__069_; res__070_)))
       | Take_l ->
           Res
             ((result int exn),
-              (let s_5__070_ = SUT.pop sut__060_ in
-               let res__071_ = protect (fun () -> take_l s_5__070_) () in
-               (SUT.push sut__060_ s_5__070_; res__071_)))
+              (let s_5__071_ = SUT.pop sut__061_ in
+               let res__072_ = protect (fun () -> take_l s_5__071_) () in
+               (SUT.push sut__061_ s_5__071_; res__072_)))
       | Take_r ->
           Res
             ((result int exn),
-              (let s_6__072_ = SUT.pop sut__060_ in
-               let res__073_ = protect (fun () -> take_r s_6__072_) () in
-               (SUT.push sut__060_ s_6__072_; res__073_)))
+              (let s_6__073_ = SUT.pop sut__061_ in
+               let res__074_ = protect (fun () -> take_r s_6__073_) () in
+               (SUT.push sut__061_ s_6__073_; res__074_)))
       | Take_opt_l ->
           Res
             ((option int),
-              (let s_7__074_ = SUT.pop sut__060_ in
-               let res__075_ = take_opt_l s_7__074_ in
-               (SUT.push sut__060_ s_7__074_; res__075_)))
+              (let s_7__075_ = SUT.pop sut__061_ in
+               let res__076_ = take_opt_l s_7__075_ in
+               (SUT.push sut__061_ s_7__075_; res__076_)))
       | Take_opt_r ->
           Res
             ((option int),
-              (let s_8__076_ = SUT.pop sut__060_ in
-               let res__077_ = take_opt_r s_8__076_ in
-               (SUT.push sut__060_ s_8__076_; res__077_)))
+              (let s_8__077_ = SUT.pop sut__061_ in
+               let res__078_ = take_opt_r s_8__077_ in
+               (SUT.push sut__061_ s_8__077_; res__078_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__079_ state__080_ last__082_ res__081_ =
+let ortac_show_cmd cmd__080_ state__081_ last__083_ res__082_ =
   let open Spec in
     let open STM in
-      match (cmd__079_, res__081_) with
+      match (cmd__080_, res__082_) with
       | (Create (), Res ((SUT, _), s)) ->
-          let lhs = if last__082_ then "r" else SUT.get_name state__080_ 0
+          let lhs = if last__083_ then "r" else SUT.get_name state__081_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "create"
             (Util.Pp.pp_unit true) ()
       | (Is_empty, Res ((Bool, _), _)) ->
-          let lhs = if last__082_ then "r" else "_"
+          let lhs = if last__083_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "is_empty"
-            (SUT.get_name state__080_ (0 + shift))
+            (SUT.get_name state__081_ (0 + shift))
       | (Length, Res ((Int, _), _)) ->
-          let lhs = if last__082_ then "r" else "_"
+          let lhs = if last__083_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "length"
-            (SUT.get_name state__080_ (0 + shift))
+            (SUT.get_name state__081_ (0 + shift))
       | (Add_l a_1, Res ((Node (Int), _), _)) ->
-          let lhs = if last__082_ then "r" else "_"
+          let lhs = if last__083_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "add_l"
-            (Util.Pp.pp_int true) a_1 (SUT.get_name state__080_ (0 + shift))
+            (Util.Pp.pp_int true) a_1 (SUT.get_name state__081_ (0 + shift))
       | (Add_r a_2, Res ((Node (Int), _), _)) ->
-          let lhs = if last__082_ then "r" else "_"
+          let lhs = if last__083_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "add_r"
-            (Util.Pp.pp_int true) a_2 (SUT.get_name state__080_ (0 + shift))
+            (Util.Pp.pp_int true) a_2 (SUT.get_name state__081_ (0 + shift))
       | (Take_l, Res ((Result (Int, Exn), _), _)) ->
-          let lhs = if last__082_ then "r" else "_"
+          let lhs = if last__083_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "take_l"
-            (SUT.get_name state__080_ (0 + shift))
+            (SUT.get_name state__081_ (0 + shift))
       | (Take_r, Res ((Result (Int, Exn), _), _)) ->
-          let lhs = if last__082_ then "r" else "_"
+          let lhs = if last__083_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "take_r"
-            (SUT.get_name state__080_ (0 + shift))
+            (SUT.get_name state__081_ (0 + shift))
       | (Take_opt_l, Res ((Option (Int), _), _)) ->
-          let lhs = if last__082_ then "r" else "_"
+          let lhs = if last__083_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "take_opt_l"
-            (SUT.get_name state__080_ (0 + shift))
+            (SUT.get_name state__081_ (0 + shift))
       | (Take_opt_r, Res ((Option (Int), _), _)) ->
-          let lhs = if last__082_ then "r" else "_"
+          let lhs = if last__083_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "take_opt_r"
-            (SUT.get_name state__080_ (0 + shift))
+            (SUT.get_name state__081_ (0 + shift))
       | _ -> assert false
-let ortac_postcond cmd__023_ state__024_ res__025_ =
+let ortac_postcond cmd__024_ state__025_ res__026_ =
   let open Spec in
     let open STM in
-      let new_state__026_ = lazy (next_state cmd__023_ state__024_) in
-      match (cmd__023_, res__025_) with
+      let new_state__027_ = lazy (next_state cmd__024_ state__025_) in
+      match (cmd__024_, res__026_) with
       | (Create (), Res ((SUT, _), s)) -> None
       | (Is_empty, Res ((Bool, _), b)) ->
           if
-            let s_old__027_ = Model.get state__024_ 0
-            and s_new__028_ = lazy (Model.get (Lazy.force new_state__026_) 0) in
+            let s_old__028_ = Model.get state__025_ 0
+            and s_new__029_ = lazy (Model.get (Lazy.force new_state__027_) 0) in
             (try
                (b = true) =
-                 ((Lazy.force s_new__028_).contents =
+                 ((Lazy.force s_new__029_).contents =
                     Ortac_runtime.Gospelstdlib.Sequence.empty)
              with
              | e ->
@@ -537,12 +551,12 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                     })])
       | (Length, Res ((Int, _), l_1)) ->
           if
-            let s_old__032_ = Model.get state__024_ 0
-            and s_new__033_ = lazy (Model.get (Lazy.force new_state__026_) 0) in
+            let s_old__033_ = Model.get state__025_ 0
+            and s_new__034_ = lazy (Model.get (Lazy.force new_state__027_) 0) in
             (try
                (Ortac_runtime.Gospelstdlib.integer_of_int l_1) =
                  (Ortac_runtime.Gospelstdlib.Sequence.length
-                    (Lazy.force s_new__033_).contents)
+                    (Lazy.force s_new__034_).contents)
              with
              | e ->
                  raise
@@ -571,12 +585,12 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                  (Ortac_runtime.Value
                     (Res
                        (integer,
-                         (let s_old__030_ = Model.get state__024_ 0
-                          and s_new__031_ =
-                            lazy (Model.get (Lazy.force new_state__026_) 0) in
+                         (let s_old__031_ = Model.get state__025_ 0
+                          and s_new__032_ =
+                            lazy (Model.get (Lazy.force new_state__027_) 0) in
                           try
                             Ortac_runtime.Gospelstdlib.Sequence.length
-                              (Lazy.force s_new__031_).contents
+                              (Lazy.force s_new__032_).contents
                           with
                           | e ->
                               raise
@@ -621,18 +635,18 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
           (match a_3 with
            | Ok a_3 ->
                if
-                 let s_old__037_ = Model.get state__024_ 0
-                 and s_new__038_ =
-                   lazy (Model.get (Lazy.force new_state__026_) 0) in
+                 let s_old__038_ = Model.get state__025_ 0
+                 and s_new__039_ =
+                   lazy (Model.get (Lazy.force new_state__027_) 0) in
                  (try
                     if
-                      s_old__037_.contents =
+                      s_old__038_.contents =
                         Ortac_runtime.Gospelstdlib.Sequence.empty
                     then false
                     else
                       a_3 =
                         (Ortac_runtime.Gospelstdlib.Sequence.hd
-                           s_old__037_.contents)
+                           s_old__038_.contents)
                   with
                   | e ->
                       raise
@@ -679,17 +693,17 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                          })])
            | Error (Empty) ->
                if
-                 let s_old__039_ = Model.get state__024_ 0
-                 and s_new__040_ =
-                   lazy (Model.get (Lazy.force new_state__026_) 0) in
+                 let s_old__040_ = Model.get state__025_ 0
+                 and s_new__041_ =
+                   lazy (Model.get (Lazy.force new_state__027_) 0) in
                  (try
-                    let __t1__041_ =
-                      s_old__039_.contents =
+                    let __t1__042_ =
+                      s_old__040_.contents =
                         Ortac_runtime.Gospelstdlib.Sequence.empty in
-                    let __t2__042_ =
+                    let __t2__043_ =
                       Ortac_runtime.Gospelstdlib.Sequence.empty =
-                        (Lazy.force s_new__040_).contents in
-                    __t1__041_ && __t2__042_
+                        (Lazy.force s_new__041_).contents in
+                    __t1__042_ && __t2__043_
                   with
                   | e ->
                       raise
@@ -738,21 +752,21 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
           (match a_4 with
            | Ok a_4 ->
                if
-                 let s_old__044_ = Model.get state__024_ 0
-                 and s_new__045_ =
-                   lazy (Model.get (Lazy.force new_state__026_) 0) in
+                 let s_old__045_ = Model.get state__025_ 0
+                 and s_new__046_ =
+                   lazy (Model.get (Lazy.force new_state__027_) 0) in
                  (try
                     if
-                      s_old__044_.contents =
+                      s_old__045_.contents =
                         Ortac_runtime.Gospelstdlib.Sequence.empty
                     then false
                     else
                       a_4 =
                         (Ortac_runtime.Gospelstdlib.__mix_Bub
-                           s_old__044_.contents
+                           s_old__045_.contents
                            (Ortac_runtime.Gospelstdlib.(-)
                               (Ortac_runtime.Gospelstdlib.Sequence.length
-                                 s_old__044_.contents)
+                                 s_old__045_.contents)
                               (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
                   with
                   | e ->
@@ -800,17 +814,17 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                          })])
            | Error (Empty) ->
                if
-                 let s_old__046_ = Model.get state__024_ 0
-                 and s_new__047_ =
-                   lazy (Model.get (Lazy.force new_state__026_) 0) in
+                 let s_old__047_ = Model.get state__025_ 0
+                 and s_new__048_ =
+                   lazy (Model.get (Lazy.force new_state__027_) 0) in
                  (try
-                    let __t1__048_ =
-                      s_old__046_.contents =
+                    let __t1__049_ =
+                      s_old__047_.contents =
                         Ortac_runtime.Gospelstdlib.Sequence.empty in
-                    let __t2__049_ =
+                    let __t2__050_ =
                       Ortac_runtime.Gospelstdlib.Sequence.empty =
-                        (Lazy.force s_new__047_).contents in
-                    __t1__048_ && __t2__049_
+                        (Lazy.force s_new__048_).contents in
+                    __t1__049_ && __t2__050_
                   with
                   | e ->
                       raise
@@ -857,15 +871,15 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
            | _ -> None)
       | (Take_opt_l, Res ((Option (Int), _), o)) ->
           if
-            let s_old__051_ = Model.get state__024_ 0
-            and s_new__052_ = lazy (Model.get (Lazy.force new_state__026_) 0) in
+            let s_old__052_ = Model.get state__025_ 0
+            and s_new__053_ = lazy (Model.get (Lazy.force new_state__027_) 0) in
             (try
-               s_old__051_.contents =
+               s_old__052_.contents =
                  (match o with
                   | None -> Ortac_runtime.Gospelstdlib.Sequence.empty
                   | Some a_5 ->
                       Ortac_runtime.Gospelstdlib.Sequence.cons a_5
-                        (Lazy.force s_new__052_).contents)
+                        (Lazy.force s_new__053_).contents)
              with
              | e ->
                  raise
@@ -912,15 +926,15 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                     })])
       | (Take_opt_r, Res ((Option (Int), _), o_1)) ->
           if
-            let s_old__054_ = Model.get state__024_ 0
-            and s_new__055_ = lazy (Model.get (Lazy.force new_state__026_) 0) in
+            let s_old__055_ = Model.get state__025_ 0
+            and s_new__056_ = lazy (Model.get (Lazy.force new_state__027_) 0) in
             (try
-               s_old__054_.contents =
+               s_old__055_.contents =
                  (match o_1 with
                   | None -> Ortac_runtime.Gospelstdlib.Sequence.empty
                   | Some a_6 ->
                       Ortac_runtime.Gospelstdlib.Sequence.snoc
-                        (Lazy.force s_new__055_).contents a_6)
+                        (Lazy.force s_new__056_).contents a_6)
              with
              | e ->
                  raise

--- a/examples/varray_circular_spec_config.ml
+++ b/examples/varray_circular_spec_config.ml
@@ -13,6 +13,10 @@ module Gen = struct
   let elt gen = gen
 end
 
+module Shrink = struct
+  let elt shrink = shrink
+end
+
 module Ty = struct
   type _ ty += Elt : 'a ty -> 'a elt ty
 

--- a/examples/varray_circular_spec_tests.ml
+++ b/examples/varray_circular_spec_tests.ml
@@ -197,10 +197,53 @@ module Spec =
           Format.asprintf "protect (fun () -> %s <sut> %a <sut> %a %a)"
             "blit" (Util.Pp.pp_int true) src_pos (Util.Pp.pp_int true)
             dst_pos (Util.Pp.pp_int true) len_1
+    let shrink_cmd cmd__004_ =
+      let open QCheck in
+        let open Shrink in
+          let open Iter in
+            match cmd__004_ with
+            | Push_back x -> map (fun x -> Push_back x) (elt char x)
+            | Pop_back -> empty
+            | Push_front x_1 ->
+                map (fun x_1 -> Push_front x_1) (elt char x_1)
+            | Pop_front -> empty
+            | Insert_at (i_1, x_2) ->
+                (map (fun i_1 -> Insert_at (i_1, x_2)) (int i_1)) <+>
+                  (map (fun x_2 -> Insert_at (i_1, x_2)) (elt char x_2))
+            | Pop_at i_2 -> map (fun i_2 -> Pop_at i_2) (int i_2)
+            | Delete_at i_3 -> map (fun i_3 -> Delete_at i_3) (int i_3)
+            | Get i_4 -> map (fun i_4 -> Get i_4) (int i_4)
+            | Set (i_5, v) ->
+                (map (fun i_5 -> Set (i_5, v)) (int i_5)) <+>
+                  (map (fun v -> Set (i_5, v)) (elt char v))
+            | Length -> empty
+            | Make (n, x_3) ->
+                (map (fun n -> Make (n, x_3)) (int n)) <+>
+                  (map (fun x_3 -> Make (n, x_3)) (elt char x_3))
+            | Empty () -> map (fun () -> Empty ()) (unit ())
+            | Is_empty -> empty
+            | Append -> empty
+            | Sub (i_6, n_1) ->
+                (map (fun i_6 -> Sub (i_6, n_1)) (int i_6)) <+>
+                  (map (fun n_1 -> Sub (i_6, n_1)) (int n_1))
+            | Copy -> empty
+            | Fill (pos, len, x_4) ->
+                ((map (fun pos -> Fill (pos, len, x_4)) (int pos)) <+>
+                   (map (fun len -> Fill (pos, len, x_4)) (int len)))
+                  <+> (map (fun x_4 -> Fill (pos, len, x_4)) (elt char x_4))
+            | Blit (src_pos, dst_pos, len_1) ->
+                ((map (fun src_pos -> Blit (src_pos, dst_pos, len_1))
+                    (int src_pos))
+                   <+>
+                   (map (fun dst_pos -> Blit (src_pos, dst_pos, len_1))
+                      (int dst_pos)))
+                  <+>
+                  (map (fun len_1 -> Blit (src_pos, dst_pos, len_1))
+                     (int len_1))
     let cleanup _ = ()
     let arb_cmd _ =
       let open QCheck in
-        make ~print:show_cmd
+        make ~print:show_cmd ~shrink:shrink_cmd
           (let open Gen in
              oneof
                [(pure (fun x -> Push_back x)) <*> (elt char);
@@ -236,17 +279,17 @@ module Spec =
                    <*> int)
                   <*> int)
                  <*> int])
-    let next_state cmd__004_ state__005_ =
-      match cmd__004_ with
+    let next_state cmd__005_ state__006_ =
+      match cmd__005_ with
       | Push_back x ->
-          let t_1__006_ = Model.get state__005_ 0 in
-          let t_1__007_ =
+          let t_1__007_ = Model.get state__006_ 0 in
+          let t_1__008_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      Ortac_runtime.Gospelstdlib.Sequence.snoc
-                       t_1__006_.contents (proj x)
+                       t_1__007_.contents (proj x)
                    with
                    | e ->
                        raise
@@ -269,24 +312,24 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__005_ 1) t_1__007_
+          Model.push (Model.drop_n state__006_ 1) t_1__008_
       | Pop_back ->
-          let t_2__008_ = Model.get state__005_ 0 in
-          let t_2__009_ =
+          let t_2__009_ = Model.get state__006_ 0 in
+          let t_2__010_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      if
-                       t_2__008_.contents =
+                       t_2__009_.contents =
                          Ortac_runtime.Gospelstdlib.Sequence.empty
                      then Ortac_runtime.Gospelstdlib.Sequence.empty
                      else
                        Ortac_runtime.Gospelstdlib.__mix_Bddub
-                         t_2__008_.contents
+                         t_2__009_.contents
                          (Ortac_runtime.Gospelstdlib.(-)
                             (Ortac_runtime.Gospelstdlib.Sequence.length
-                               t_2__008_.contents)
+                               t_2__009_.contents)
                             (Ortac_runtime.Gospelstdlib.integer_of_int 2))
                    with
                    | e ->
@@ -310,16 +353,16 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__005_ 1) t_2__009_
+          Model.push (Model.drop_n state__006_ 1) t_2__010_
       | Push_front x_1 ->
-          let t_3__010_ = Model.get state__005_ 0 in
-          let t_3__011_ =
+          let t_3__011_ = Model.get state__006_ 0 in
+          let t_3__012_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      Ortac_runtime.Gospelstdlib.Sequence.cons (proj x_1)
-                       t_3__010_.contents
+                       t_3__011_.contents
                    with
                    | e ->
                        raise
@@ -342,21 +385,21 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__005_ 1) t_3__011_
+          Model.push (Model.drop_n state__006_ 1) t_3__012_
       | Pop_front ->
-          let t_4__012_ = Model.get state__005_ 0 in
-          let t_4__013_ =
+          let t_4__013_ = Model.get state__006_ 0 in
+          let t_4__014_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      if
-                       t_4__012_.contents =
+                       t_4__013_.contents =
                          Ortac_runtime.Gospelstdlib.Sequence.empty
                      then Ortac_runtime.Gospelstdlib.Sequence.empty
                      else
                        Ortac_runtime.Gospelstdlib.Sequence.tl
-                         t_4__012_.contents
+                         t_4__013_.contents
                    with
                    | e ->
                        raise
@@ -379,21 +422,21 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__005_ 1) t_4__013_
+          Model.push (Model.drop_n state__006_ 1) t_4__014_
       | Insert_at (i_1, x_2) ->
-          let t_5__014_ = Model.get state__005_ 0 in
+          let t_5__015_ = Model.get state__006_ 0 in
           if
             (try
-               let __t1__018_ =
+               let __t1__019_ =
                  Ortac_runtime.Gospelstdlib.(<=)
                    (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                    (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
-               let __t2__019_ =
+               let __t2__020_ =
                  Ortac_runtime.Gospelstdlib.(<=)
                    (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
                    (Ortac_runtime.Gospelstdlib.Sequence.length
-                      t_5__014_.contents) in
-               __t1__018_ && __t2__019_
+                      t_5__015_.contents) in
+               __t1__019_ && __t2__020_
              with
              | e ->
                  raise
@@ -416,26 +459,26 @@ module Spec =
                             }
                         })))
           then
-            let t_5__017_ =
+            let t_5__018_ =
               let open ModelElt in
                 {
                   contents =
                     (try
                        if
-                         let __t1__015_ =
+                         let __t1__016_ =
                            Ortac_runtime.Gospelstdlib.(<=)
                              (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                              (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
-                         let __t2__016_ =
+                         let __t2__017_ =
                            Ortac_runtime.Gospelstdlib.(<=)
                              (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
                              (Ortac_runtime.Gospelstdlib.Sequence.length
-                                t_5__014_.contents) in
-                         __t1__015_ && __t2__016_
+                                t_5__015_.contents) in
+                         __t1__016_ && __t2__017_
                        then
                          Ortac_runtime.Gospelstdlib.(++)
                            (Ortac_runtime.Gospelstdlib.__mix_Bddub
-                              t_5__014_.contents
+                              t_5__015_.contents
                               (Ortac_runtime.Gospelstdlib.(-)
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
                                     i_1)
@@ -443,10 +486,10 @@ module Spec =
                            (Ortac_runtime.Gospelstdlib.Sequence.cons
                               (proj x_2)
                               (Ortac_runtime.Gospelstdlib.__mix_Buddb
-                                 t_5__014_.contents
+                                 t_5__015_.contents
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
                                     i_1)))
-                       else t_5__014_.contents
+                       else t_5__015_.contents
                      with
                      | e ->
                          raise
@@ -469,14 +512,14 @@ module Spec =
                                     }
                                 })))
                 } in
-            Model.push (Model.drop_n state__005_ 1) t_5__017_
-          else state__005_
+            Model.push (Model.drop_n state__006_ 1) t_5__018_
+          else state__006_
       | Pop_at i_2 ->
-          let t_6__020_ = Model.get state__005_ 0 in
+          let t_6__021_ = Model.get state__006_ 0 in
           if
             (try
                (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
-                  t_6__020_.contents)
+                  t_6__021_.contents)
                  = true
              with
              | e ->
@@ -500,19 +543,19 @@ module Spec =
                             }
                         })))
           then
-            let t_6__021_ =
+            let t_6__022_ =
               let open ModelElt in
                 {
                   contents =
                     (try
                        Ortac_runtime.Gospelstdlib.(++)
                          (Ortac_runtime.Gospelstdlib.__mix_Bddub
-                            t_6__020_.contents
+                            t_6__021_.contents
                             (Ortac_runtime.Gospelstdlib.(-)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
                                (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
                          (Ortac_runtime.Gospelstdlib.__mix_Buddb
-                            t_6__020_.contents
+                            t_6__021_.contents
                             (Ortac_runtime.Gospelstdlib.(+)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
                                (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
@@ -538,14 +581,14 @@ module Spec =
                                     }
                                 })))
                 } in
-            Model.push (Model.drop_n state__005_ 1) t_6__021_
-          else state__005_
+            Model.push (Model.drop_n state__006_ 1) t_6__022_
+          else state__006_
       | Delete_at i_3 ->
-          let t_7__022_ = Model.get state__005_ 0 in
+          let t_7__023_ = Model.get state__006_ 0 in
           if
             (try
                (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
-                  t_7__022_.contents)
+                  t_7__023_.contents)
                  = true
              with
              | e ->
@@ -569,19 +612,19 @@ module Spec =
                             }
                         })))
           then
-            let t_7__023_ =
+            let t_7__024_ =
               let open ModelElt in
                 {
                   contents =
                     (try
                        Ortac_runtime.Gospelstdlib.(++)
                          (Ortac_runtime.Gospelstdlib.__mix_Bddub
-                            t_7__022_.contents
+                            t_7__023_.contents
                             (Ortac_runtime.Gospelstdlib.(-)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                                (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
                          (Ortac_runtime.Gospelstdlib.__mix_Buddb
-                            t_7__022_.contents
+                            t_7__023_.contents
                             (Ortac_runtime.Gospelstdlib.(+)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                                (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
@@ -607,14 +650,14 @@ module Spec =
                                     }
                                 })))
                 } in
-            Model.push (Model.drop_n state__005_ 1) t_7__023_
-          else state__005_
+            Model.push (Model.drop_n state__006_ 1) t_7__024_
+          else state__006_
       | Get i_4 ->
-          let t_8__024_ = Model.get state__005_ 0 in
+          let t_8__025_ = Model.get state__006_ 0 in
           if
             (try
                (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_4)
-                  t_8__024_.contents)
+                  t_8__025_.contents)
                  = true
              with
              | e ->
@@ -638,15 +681,15 @@ module Spec =
                             }
                         })))
           then
-            let t_8__025_ = t_8__024_ in
-            Model.push (Model.drop_n state__005_ 1) t_8__025_
-          else state__005_
+            let t_8__026_ = t_8__025_ in
+            Model.push (Model.drop_n state__006_ 1) t_8__026_
+          else state__006_
       | Set (i_5, v) ->
-          let t_9__026_ = Model.get state__005_ 0 in
+          let t_9__027_ = Model.get state__006_ 0 in
           if
             (try
                (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_5)
-                  t_9__026_.contents)
+                  t_9__027_.contents)
                  = true
              with
              | e ->
@@ -670,13 +713,13 @@ module Spec =
                             }
                         })))
           then
-            let t_9__027_ =
+            let t_9__028_ =
               let open ModelElt in
                 {
                   contents =
                     (try
                        Ortac_runtime.Gospelstdlib.Sequence.set
-                         t_9__026_.contents
+                         t_9__027_.contents
                          (Ortac_runtime.Gospelstdlib.integer_of_int i_5)
                          (proj v)
                      with
@@ -701,12 +744,12 @@ module Spec =
                                     }
                                 })))
                 } in
-            Model.push (Model.drop_n state__005_ 1) t_9__027_
-          else state__005_
+            Model.push (Model.drop_n state__006_ 1) t_9__028_
+          else state__006_
       | Length ->
-          let t_10__028_ = Model.get state__005_ 0 in
-          let t_10__029_ = t_10__028_ in
-          Model.push (Model.drop_n state__005_ 1) t_10__029_
+          let t_10__029_ = Model.get state__006_ 0 in
+          let t_10__030_ = t_10__029_ in
+          Model.push (Model.drop_n state__006_ 1) t_10__030_
       | Make (n, x_3) ->
           if
             (try
@@ -735,7 +778,7 @@ module Spec =
                             }
                         })))
           then
-            let t_11__031_ =
+            let t_11__032_ =
               let open ModelElt in
                 {
                   contents =
@@ -765,10 +808,10 @@ module Spec =
                                     }
                                 })))
                 } in
-            Model.push (Model.drop_n state__005_ 0) t_11__031_
-          else state__005_
+            Model.push (Model.drop_n state__006_ 0) t_11__032_
+          else state__006_
       | Empty () ->
-          let t_12__033_ =
+          let t_12__034_ =
             let open ModelElt in
               {
                 contents =
@@ -795,21 +838,21 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__005_ 0) t_12__033_
+          Model.push (Model.drop_n state__006_ 0) t_12__034_
       | Is_empty ->
-          let t_13__034_ = Model.get state__005_ 0 in
-          let t_13__035_ = t_13__034_ in
-          Model.push (Model.drop_n state__005_ 1) t_13__035_
+          let t_13__035_ = Model.get state__006_ 0 in
+          let t_13__036_ = t_13__035_ in
+          Model.push (Model.drop_n state__006_ 1) t_13__036_
       | Append ->
-          let a_1__036_ = Model.get state__005_ 0
-          and b__037_ = Model.get state__005_ 1 in
-          let t_14__041_ =
+          let a_1__037_ = Model.get state__006_ 0
+          and b__038_ = Model.get state__006_ 1 in
+          let t_14__042_ =
             let open ModelElt in
               {
                 contents =
                   (try
-                     Ortac_runtime.Gospelstdlib.(++) a_1__036_.contents
-                       b__037_.contents
+                     Ortac_runtime.Gospelstdlib.(++) a_1__037_.contents
+                       b__038_.contents
                    with
                    | e ->
                        raise
@@ -832,25 +875,25 @@ module Spec =
                                   }
                               })))
               }
-          and a_1__040_ = a_1__036_
-          and b__039_ = b__037_ in
+          and a_1__041_ = a_1__037_
+          and b__040_ = b__038_ in
           Model.push
-            (Model.push (Model.push (Model.drop_n state__005_ 2) b__039_)
-               a_1__040_) t_14__041_
+            (Model.push (Model.push (Model.drop_n state__006_ 2) b__040_)
+               a_1__041_) t_14__042_
       | Sub (i_6, n_1) ->
-          let t_15__042_ = Model.get state__005_ 0 in
+          let t_15__043_ = Model.get state__006_ 0 in
           if
             (try
-               let __t1__046_ =
+               let __t1__047_ =
                  Ortac_runtime.Gospelstdlib.(<=)
                    (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                    (Ortac_runtime.Gospelstdlib.integer_of_int i_6) in
-               let __t2__047_ =
+               let __t2__048_ =
                  Ortac_runtime.Gospelstdlib.(<=)
                    (Ortac_runtime.Gospelstdlib.integer_of_int i_6)
                    (Ortac_runtime.Gospelstdlib.Sequence.length
-                      t_15__042_.contents) in
-               __t1__046_ && __t2__047_
+                      t_15__043_.contents) in
+               __t1__047_ && __t2__048_
              with
              | e ->
                  raise
@@ -874,20 +917,20 @@ module Spec =
                         })))
               &&
               ((try
-                  let __t1__048_ =
+                  let __t1__049_ =
                     Ortac_runtime.Gospelstdlib.(<=)
                       (Ortac_runtime.Gospelstdlib.integer_of_int i_6)
                       (Ortac_runtime.Gospelstdlib.(+)
                          (Ortac_runtime.Gospelstdlib.integer_of_int i_6)
                          (Ortac_runtime.Gospelstdlib.integer_of_int n_1)) in
-                  let __t2__049_ =
+                  let __t2__050_ =
                     Ortac_runtime.Gospelstdlib.(<=)
                       (Ortac_runtime.Gospelstdlib.(+)
                          (Ortac_runtime.Gospelstdlib.integer_of_int i_6)
                          (Ortac_runtime.Gospelstdlib.integer_of_int n_1))
                       (Ortac_runtime.Gospelstdlib.Sequence.length
-                         t_15__042_.contents) in
-                  __t1__048_ && __t2__049_
+                         t_15__043_.contents) in
+                  __t1__049_ && __t2__050_
                 with
                 | e ->
                     raise
@@ -910,7 +953,7 @@ module Spec =
                                }
                            }))))
           then
-            let r__045_ =
+            let r__046_ =
               let open ModelElt in
                 {
                   contents =
@@ -921,7 +964,7 @@ module Spec =
                        then Ortac_runtime.Gospelstdlib.Sequence.empty
                        else
                          Ortac_runtime.Gospelstdlib.__mix_Buddub
-                           t_15__042_.contents
+                           t_15__043_.contents
                            (Ortac_runtime.Gospelstdlib.integer_of_int i_6)
                            (Ortac_runtime.Gospelstdlib.(-)
                               (Ortac_runtime.Gospelstdlib.(+)
@@ -952,17 +995,17 @@ module Spec =
                                     }
                                 })))
                 }
-            and t_15__044_ = t_15__042_ in
-            Model.push (Model.push (Model.drop_n state__005_ 1) t_15__044_)
-              r__045_
-          else state__005_
+            and t_15__045_ = t_15__043_ in
+            Model.push (Model.push (Model.drop_n state__006_ 1) t_15__045_)
+              r__046_
+          else state__006_
       | Copy ->
-          let t_16__050_ = Model.get state__005_ 0 in
-          let r_1__053_ =
+          let t_16__051_ = Model.get state__006_ 0 in
+          let r_1__054_ =
             let open ModelElt in
               {
                 contents =
-                  (try t_16__050_.contents
+                  (try t_16__051_.contents
                    with
                    | e ->
                        raise
@@ -985,31 +1028,31 @@ module Spec =
                                   }
                               })))
               }
-          and t_16__052_ = t_16__050_ in
-          Model.push (Model.push (Model.drop_n state__005_ 1) t_16__052_)
-            r_1__053_
+          and t_16__053_ = t_16__051_ in
+          Model.push (Model.push (Model.drop_n state__006_ 1) t_16__053_)
+            r_1__054_
       | Fill (pos, len, x_4) ->
-          let t_17__054_ = Model.get state__005_ 0 in
+          let t_17__055_ = Model.get state__006_ 0 in
           if
             (try
-               let __t1__058_ =
+               let __t1__059_ =
                  Ortac_runtime.Gospelstdlib.(<=)
                    (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                    (Ortac_runtime.Gospelstdlib.integer_of_int pos) in
-               let __t2__059_ =
-                 let __t1__060_ =
+               let __t2__060_ =
+                 let __t1__061_ =
                    Ortac_runtime.Gospelstdlib.(<=)
                      (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                      (Ortac_runtime.Gospelstdlib.integer_of_int len) in
-                 let __t2__061_ =
+                 let __t2__062_ =
                    Ortac_runtime.Gospelstdlib.(<)
                      (Ortac_runtime.Gospelstdlib.(+)
                         (Ortac_runtime.Gospelstdlib.integer_of_int pos)
                         (Ortac_runtime.Gospelstdlib.integer_of_int len))
                      (Ortac_runtime.Gospelstdlib.Sequence.length
-                        t_17__054_.contents) in
-                 __t1__060_ && __t2__061_ in
-               __t1__058_ && __t2__059_
+                        t_17__055_.contents) in
+                 __t1__061_ && __t2__062_ in
+               __t1__059_ && __t2__060_
              with
              | e ->
                  raise
@@ -1032,32 +1075,32 @@ module Spec =
                             }
                         })))
           then
-            let t_17__057_ =
+            let t_17__058_ =
               let open ModelElt in
                 {
                   contents =
                     (try
                        Ortac_runtime.Gospelstdlib.Sequence.init
                          (Ortac_runtime.Gospelstdlib.Sequence.length
-                            t_17__054_.contents)
+                            t_17__055_.contents)
                          (fun i_7 ->
                             if
-                              let __t1__055_ =
+                              let __t1__056_ =
                                 Ortac_runtime.Gospelstdlib.(<=)
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
                                      pos) i_7 in
-                              let __t2__056_ =
+                              let __t2__057_ =
                                 Ortac_runtime.Gospelstdlib.(<) i_7
                                   (Ortac_runtime.Gospelstdlib.(+)
                                      (Ortac_runtime.Gospelstdlib.integer_of_int
                                         pos)
                                      (Ortac_runtime.Gospelstdlib.integer_of_int
                                         len)) in
-                              __t1__055_ && __t2__056_
+                              __t1__056_ && __t2__057_
                             then proj x_4
                             else
                               Ortac_runtime.Gospelstdlib.__mix_Bub
-                                t_17__054_.contents i_7)
+                                t_17__055_.contents i_7)
                      with
                      | e ->
                          raise
@@ -1080,33 +1123,33 @@ module Spec =
                                     }
                                 })))
                 } in
-            Model.push (Model.drop_n state__005_ 1) t_17__057_
-          else state__005_
+            Model.push (Model.drop_n state__006_ 1) t_17__058_
+          else state__006_
       | Blit (src_pos, dst_pos, len_1) ->
-          let src__062_ = Model.get state__005_ 0
-          and dst__063_ = Model.get state__005_ 1 in
+          let src__063_ = Model.get state__006_ 0
+          and dst__064_ = Model.get state__006_ 1 in
           if
             (try
-               let __t1__066_ =
+               let __t1__067_ =
                  Ortac_runtime.Gospelstdlib.(<=)
                    (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                    (Ortac_runtime.Gospelstdlib.integer_of_int src_pos) in
-               let __t2__067_ =
-                 let __t1__068_ =
+               let __t2__068_ =
+                 let __t1__069_ =
                    Ortac_runtime.Gospelstdlib.(<=)
                      (Ortac_runtime.Gospelstdlib.integer_of_int src_pos)
                      (Ortac_runtime.Gospelstdlib.(+)
                         (Ortac_runtime.Gospelstdlib.integer_of_int src_pos)
                         (Ortac_runtime.Gospelstdlib.integer_of_int len_1)) in
-                 let __t2__069_ =
+                 let __t2__070_ =
                    Ortac_runtime.Gospelstdlib.(<=)
                      (Ortac_runtime.Gospelstdlib.(+)
                         (Ortac_runtime.Gospelstdlib.integer_of_int src_pos)
                         (Ortac_runtime.Gospelstdlib.integer_of_int len_1))
                      (Ortac_runtime.Gospelstdlib.Sequence.length
-                        src__062_.contents) in
-                 __t1__068_ && __t2__069_ in
-               __t1__066_ && __t2__067_
+                        src__063_.contents) in
+                 __t1__069_ && __t2__070_ in
+               __t1__067_ && __t2__068_
              with
              | e ->
                  raise
@@ -1130,26 +1173,26 @@ module Spec =
                         })))
               &&
               ((try
-                  let __t1__070_ =
+                  let __t1__071_ =
                     Ortac_runtime.Gospelstdlib.(<=)
                       (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                       (Ortac_runtime.Gospelstdlib.integer_of_int dst_pos) in
-                  let __t2__071_ =
-                    let __t1__072_ =
+                  let __t2__072_ =
+                    let __t1__073_ =
                       Ortac_runtime.Gospelstdlib.(<=)
                         (Ortac_runtime.Gospelstdlib.integer_of_int dst_pos)
                         (Ortac_runtime.Gospelstdlib.(+)
                            (Ortac_runtime.Gospelstdlib.integer_of_int dst_pos)
                            (Ortac_runtime.Gospelstdlib.integer_of_int len_1)) in
-                    let __t2__073_ =
+                    let __t2__074_ =
                       Ortac_runtime.Gospelstdlib.(<=)
                         (Ortac_runtime.Gospelstdlib.(+)
                            (Ortac_runtime.Gospelstdlib.integer_of_int dst_pos)
                            (Ortac_runtime.Gospelstdlib.integer_of_int len_1))
                         (Ortac_runtime.Gospelstdlib.Sequence.length
-                           dst__063_.contents) in
-                    __t1__072_ && __t2__073_ in
-                  __t1__070_ && __t2__071_
+                           dst__064_.contents) in
+                    __t1__073_ && __t2__074_ in
+                  __t1__071_ && __t2__072_
                 with
                 | e ->
                     raise
@@ -1172,8 +1215,8 @@ module Spec =
                                }
                            }))))
           then
-            let src__065_ = src__062_
-            and dst__064_ =
+            let src__066_ = src__063_
+            and dst__065_ =
               let open ModelElt in
                 {
                   contents =
@@ -1184,7 +1227,7 @@ module Spec =
                        then
                          Ortac_runtime.Gospelstdlib.(++)
                            (Ortac_runtime.Gospelstdlib.__mix_Buddub
-                              src__062_.contents
+                              src__063_.contents
                               (Ortac_runtime.Gospelstdlib.integer_of_int
                                  src_pos)
                               (Ortac_runtime.Gospelstdlib.(-)
@@ -1195,21 +1238,21 @@ module Spec =
                                        len_1))
                                  (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
                            (Ortac_runtime.Gospelstdlib.__mix_Buddb
-                              dst__063_.contents
+                              dst__064_.contents
                               (Ortac_runtime.Gospelstdlib.integer_of_int
                                  len_1))
                        else
                          Ortac_runtime.Gospelstdlib.(++)
                            (Ortac_runtime.Gospelstdlib.(++)
                               (Ortac_runtime.Gospelstdlib.__mix_Bddub
-                                 dst__063_.contents
+                                 dst__064_.contents
                                  (Ortac_runtime.Gospelstdlib.(-)
                                     (Ortac_runtime.Gospelstdlib.integer_of_int
                                        dst_pos)
                                     (Ortac_runtime.Gospelstdlib.integer_of_int
                                        1)))
                               (Ortac_runtime.Gospelstdlib.__mix_Buddub
-                                 src__062_.contents
+                                 src__063_.contents
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
                                     src_pos)
                                  (Ortac_runtime.Gospelstdlib.(-)
@@ -1221,7 +1264,7 @@ module Spec =
                                     (Ortac_runtime.Gospelstdlib.integer_of_int
                                        1))))
                            (Ortac_runtime.Gospelstdlib.__mix_Buddb
-                              dst__063_.contents
+                              dst__064_.contents
                               (Ortac_runtime.Gospelstdlib.(+)
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
                                     dst_pos)
@@ -1249,11 +1292,11 @@ module Spec =
                                     }
                                 })))
                 } in
-            Model.push (Model.push (Model.drop_n state__005_ 2) dst__064_)
-              src__065_
-          else state__005_
-    let precond cmd__138_ state__139_ =
-      match cmd__138_ with
+            Model.push (Model.push (Model.drop_n state__006_ 2) dst__065_)
+              src__066_
+          else state__006_
+    let precond cmd__139_ state__140_ =
+      match cmd__139_ with
       | Push_back x -> true
       | Pop_back -> true
       | Push_front x_1 -> true
@@ -1273,284 +1316,284 @@ module Spec =
       | Fill (pos, len, x_4) -> true
       | Blit (src_pos, dst_pos, len_1) -> true
     let postcond _ _ _ = true
-    let run cmd__140_ sut__141_ =
-      match cmd__140_ with
+    let run cmd__141_ sut__142_ =
+      match cmd__141_ with
       | Push_back x ->
           Res
             (unit,
-              (let t_1__142_ = SUT.pop sut__141_ in
-               let res__143_ = push_back t_1__142_ x in
-               (SUT.push sut__141_ t_1__142_; res__143_)))
+              (let t_1__143_ = SUT.pop sut__142_ in
+               let res__144_ = push_back t_1__143_ x in
+               (SUT.push sut__142_ t_1__143_; res__144_)))
       | Pop_back ->
           Res
             ((result (elt char) exn),
-              (let t_2__144_ = SUT.pop sut__141_ in
-               let res__145_ = protect (fun () -> pop_back t_2__144_) () in
-               (SUT.push sut__141_ t_2__144_; res__145_)))
+              (let t_2__145_ = SUT.pop sut__142_ in
+               let res__146_ = protect (fun () -> pop_back t_2__145_) () in
+               (SUT.push sut__142_ t_2__145_; res__146_)))
       | Push_front x_1 ->
           Res
             (unit,
-              (let t_3__146_ = SUT.pop sut__141_ in
-               let res__147_ = push_front t_3__146_ x_1 in
-               (SUT.push sut__141_ t_3__146_; res__147_)))
+              (let t_3__147_ = SUT.pop sut__142_ in
+               let res__148_ = push_front t_3__147_ x_1 in
+               (SUT.push sut__142_ t_3__147_; res__148_)))
       | Pop_front ->
           Res
             ((result (elt char) exn),
-              (let t_4__148_ = SUT.pop sut__141_ in
-               let res__149_ = protect (fun () -> pop_front t_4__148_) () in
-               (SUT.push sut__141_ t_4__148_; res__149_)))
+              (let t_4__149_ = SUT.pop sut__142_ in
+               let res__150_ = protect (fun () -> pop_front t_4__149_) () in
+               (SUT.push sut__142_ t_4__149_; res__150_)))
       | Insert_at (i_1, x_2) ->
           Res
             ((result unit exn),
-              (let t_5__150_ = SUT.pop sut__141_ in
-               let res__151_ =
-                 protect (fun () -> insert_at t_5__150_ i_1 x_2) () in
-               (SUT.push sut__141_ t_5__150_; res__151_)))
+              (let t_5__151_ = SUT.pop sut__142_ in
+               let res__152_ =
+                 protect (fun () -> insert_at t_5__151_ i_1 x_2) () in
+               (SUT.push sut__142_ t_5__151_; res__152_)))
       | Pop_at i_2 ->
           Res
             ((result (elt char) exn),
-              (let t_6__152_ = SUT.pop sut__141_ in
-               let res__153_ = protect (fun () -> pop_at t_6__152_ i_2) () in
-               (SUT.push sut__141_ t_6__152_; res__153_)))
+              (let t_6__153_ = SUT.pop sut__142_ in
+               let res__154_ = protect (fun () -> pop_at t_6__153_ i_2) () in
+               (SUT.push sut__142_ t_6__153_; res__154_)))
       | Delete_at i_3 ->
           Res
             ((result unit exn),
-              (let t_7__154_ = SUT.pop sut__141_ in
-               let res__155_ = protect (fun () -> delete_at t_7__154_ i_3) () in
-               (SUT.push sut__141_ t_7__154_; res__155_)))
+              (let t_7__155_ = SUT.pop sut__142_ in
+               let res__156_ = protect (fun () -> delete_at t_7__155_ i_3) () in
+               (SUT.push sut__142_ t_7__155_; res__156_)))
       | Get i_4 ->
           Res
             ((result (elt char) exn),
-              (let t_8__156_ = SUT.pop sut__141_ in
-               let res__157_ = protect (fun () -> get t_8__156_ i_4) () in
-               (SUT.push sut__141_ t_8__156_; res__157_)))
+              (let t_8__157_ = SUT.pop sut__142_ in
+               let res__158_ = protect (fun () -> get t_8__157_ i_4) () in
+               (SUT.push sut__142_ t_8__157_; res__158_)))
       | Set (i_5, v) ->
           Res
             ((result unit exn),
-              (let t_9__158_ = SUT.pop sut__141_ in
-               let res__159_ = protect (fun () -> set t_9__158_ i_5 v) () in
-               (SUT.push sut__141_ t_9__158_; res__159_)))
+              (let t_9__159_ = SUT.pop sut__142_ in
+               let res__160_ = protect (fun () -> set t_9__159_ i_5 v) () in
+               (SUT.push sut__142_ t_9__159_; res__160_)))
       | Length ->
           Res
             (int,
-              (let t_10__160_ = SUT.pop sut__141_ in
-               let res__161_ = length t_10__160_ in
-               (SUT.push sut__141_ t_10__160_; res__161_)))
+              (let t_10__161_ = SUT.pop sut__142_ in
+               let res__162_ = length t_10__161_ in
+               (SUT.push sut__142_ t_10__161_; res__162_)))
       | Make (n, x_3) ->
           Res
             ((result sut exn),
-              (let res__162_ = protect (fun () -> make n x_3) () in
-               ((match res__162_ with
-                 | Ok res -> SUT.push sut__141_ res
+              (let res__163_ = protect (fun () -> make n x_3) () in
+               ((match res__163_ with
+                 | Ok res -> SUT.push sut__142_ res
                  | Error _ -> ());
-                res__162_)))
+                res__163_)))
       | Empty () ->
           Res
             (sut,
-              (let res__163_ = empty () in
-               (SUT.push sut__141_ res__163_; res__163_)))
+              (let res__164_ = empty () in
+               (SUT.push sut__142_ res__164_; res__164_)))
       | Is_empty ->
           Res
             (bool,
-              (let t_13__164_ = SUT.pop sut__141_ in
-               let res__165_ = is_empty t_13__164_ in
-               (SUT.push sut__141_ t_13__164_; res__165_)))
+              (let t_13__165_ = SUT.pop sut__142_ in
+               let res__166_ = is_empty t_13__165_ in
+               (SUT.push sut__142_ t_13__165_; res__166_)))
       | Append ->
           Res
             (sut,
-              (let a_1__166_ = SUT.pop sut__141_ in
-               let b__167_ = SUT.pop sut__141_ in
-               let res__168_ = append a_1__166_ b__167_ in
-               (SUT.push sut__141_ b__167_;
-                SUT.push sut__141_ a_1__166_;
-                SUT.push sut__141_ res__168_;
-                res__168_)))
+              (let a_1__167_ = SUT.pop sut__142_ in
+               let b__168_ = SUT.pop sut__142_ in
+               let res__169_ = append a_1__167_ b__168_ in
+               (SUT.push sut__142_ b__168_;
+                SUT.push sut__142_ a_1__167_;
+                SUT.push sut__142_ res__169_;
+                res__169_)))
       | Sub (i_6, n_1) ->
           Res
             ((result sut exn),
-              (let t_15__169_ = SUT.pop sut__141_ in
-               let res__170_ = protect (fun () -> sub t_15__169_ i_6 n_1) () in
-               (SUT.push sut__141_ t_15__169_;
-                (match res__170_ with
-                 | Ok res -> SUT.push sut__141_ res
+              (let t_15__170_ = SUT.pop sut__142_ in
+               let res__171_ = protect (fun () -> sub t_15__170_ i_6 n_1) () in
+               (SUT.push sut__142_ t_15__170_;
+                (match res__171_ with
+                 | Ok res -> SUT.push sut__142_ res
                  | Error _ -> ());
-                res__170_)))
+                res__171_)))
       | Copy ->
           Res
             (sut,
-              (let t_16__171_ = SUT.pop sut__141_ in
-               let res__172_ = copy t_16__171_ in
-               (SUT.push sut__141_ t_16__171_;
-                SUT.push sut__141_ res__172_;
-                res__172_)))
+              (let t_16__172_ = SUT.pop sut__142_ in
+               let res__173_ = copy t_16__172_ in
+               (SUT.push sut__142_ t_16__172_;
+                SUT.push sut__142_ res__173_;
+                res__173_)))
       | Fill (pos, len, x_4) ->
           Res
             ((result unit exn),
-              (let t_17__173_ = SUT.pop sut__141_ in
-               let res__174_ =
-                 protect (fun () -> fill t_17__173_ pos len x_4) () in
-               (SUT.push sut__141_ t_17__173_; res__174_)))
+              (let t_17__174_ = SUT.pop sut__142_ in
+               let res__175_ =
+                 protect (fun () -> fill t_17__174_ pos len x_4) () in
+               (SUT.push sut__142_ t_17__174_; res__175_)))
       | Blit (src_pos, dst_pos, len_1) ->
           Res
             ((result unit exn),
-              (let src__175_ = SUT.pop sut__141_ in
-               let dst__176_ = SUT.pop sut__141_ in
-               let res__177_ =
+              (let src__176_ = SUT.pop sut__142_ in
+               let dst__177_ = SUT.pop sut__142_ in
+               let res__178_ =
                  protect
-                   (fun () -> blit src__175_ src_pos dst__176_ dst_pos len_1)
+                   (fun () -> blit src__176_ src_pos dst__177_ dst_pos len_1)
                    () in
-               (SUT.push sut__141_ dst__176_;
-                SUT.push sut__141_ src__175_;
-                res__177_)))
+               (SUT.push sut__142_ dst__177_;
+                SUT.push sut__142_ src__176_;
+                res__178_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__179_ state__180_ last__182_ res__181_ =
+let ortac_show_cmd cmd__180_ state__181_ last__183_ res__182_ =
   let open Spec in
     let open STM in
-      match (cmd__179_, res__181_) with
+      match (cmd__180_, res__182_) with
       | (Push_back x, Res ((Unit, _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__183_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "push_back"
-            (SUT.get_name state__180_ (0 + shift))
+            (SUT.get_name state__181_ (0 + shift))
             (Util.Pp.pp_elt Util.Pp.pp_char true) x
       | (Pop_back, Res ((Result (Elt (Char), Exn), _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__183_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "pop_back"
-            (SUT.get_name state__180_ (0 + shift))
+            (SUT.get_name state__181_ (0 + shift))
       | (Push_front x_1, Res ((Unit, _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__183_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "push_front"
-            (SUT.get_name state__180_ (0 + shift))
+            (SUT.get_name state__181_ (0 + shift))
             (Util.Pp.pp_elt Util.Pp.pp_char true) x_1
       | (Pop_front, Res ((Result (Elt (Char), Exn), _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__183_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs
-            "pop_front" (SUT.get_name state__180_ (0 + shift))
+            "pop_front" (SUT.get_name state__181_ (0 + shift))
       | (Insert_at (i_1, x_2), Res ((Result (Unit, Exn), _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__183_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "insert_at" (SUT.get_name state__180_ (0 + shift))
+            "insert_at" (SUT.get_name state__181_ (0 + shift))
             (Util.Pp.pp_int true) i_1 (Util.Pp.pp_elt Util.Pp.pp_char true)
             x_2
       | (Pop_at i_2, Res ((Result (Elt (Char), Exn), _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__183_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a)" lhs
-            "pop_at" (SUT.get_name state__180_ (0 + shift))
+            "pop_at" (SUT.get_name state__181_ (0 + shift))
             (Util.Pp.pp_int true) i_2
       | (Delete_at i_3, Res ((Result (Unit, Exn), _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__183_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a)" lhs
-            "delete_at" (SUT.get_name state__180_ (0 + shift))
+            "delete_at" (SUT.get_name state__181_ (0 + shift))
             (Util.Pp.pp_int true) i_3
       | (Get i_4, Res ((Result (Elt (Char), Exn), _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__183_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a)" lhs "get"
-            (SUT.get_name state__180_ (0 + shift)) (Util.Pp.pp_int true) i_4
+            (SUT.get_name state__181_ (0 + shift)) (Util.Pp.pp_int true) i_4
       | (Set (i_5, v), Res ((Result (Unit, Exn), _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__183_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "set" (SUT.get_name state__180_ (0 + shift))
+            "set" (SUT.get_name state__181_ (0 + shift))
             (Util.Pp.pp_int true) i_5 (Util.Pp.pp_elt Util.Pp.pp_char true) v
       | (Length, Res ((Int, _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__183_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "length"
-            (SUT.get_name state__180_ (0 + shift))
+            (SUT.get_name state__181_ (0 + shift))
       | (Make (n, x_3), Res ((Result (SUT, Exn), _), t_11)) ->
           let lhs =
-            if last__182_
+            if last__183_
             then "r"
             else
               (match t_11 with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__180_ 0)
+               | Ok _ -> "Ok " ^ (SUT.get_name state__181_ 0)
                | Error _ -> "_")
           and shift = match t_11 with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %a %a)" lhs "make"
             (Util.Pp.pp_int true) n (Util.Pp.pp_elt Util.Pp.pp_char true) x_3
       | (Empty (), Res ((SUT, _), t_12)) ->
-          let lhs = if last__182_ then "r" else SUT.get_name state__180_ 0
+          let lhs = if last__183_ then "r" else SUT.get_name state__181_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "empty" (Util.Pp.pp_unit true)
             ()
       | (Is_empty, Res ((Bool, _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__183_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "is_empty"
-            (SUT.get_name state__180_ (0 + shift))
+            (SUT.get_name state__181_ (0 + shift))
       | (Append, Res ((SUT, _), t_14)) ->
-          let lhs = if last__182_ then "r" else SUT.get_name state__180_ 0
+          let lhs = if last__183_ then "r" else SUT.get_name state__181_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s %s" lhs "append"
-            (SUT.get_name state__180_ (0 + shift))
-            (SUT.get_name state__180_ (1 + shift))
+            (SUT.get_name state__181_ (0 + shift))
+            (SUT.get_name state__181_ (1 + shift))
       | (Sub (i_6, n_1), Res ((Result (SUT, Exn), _), r)) ->
           let lhs =
-            if last__182_
+            if last__183_
             then "r"
             else
               (match r with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__180_ 0)
+               | Ok _ -> "Ok " ^ (SUT.get_name state__181_ 0)
                | Error _ -> "_")
           and shift = match r with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "sub" (SUT.get_name state__180_ (0 + shift))
+            "sub" (SUT.get_name state__181_ (0 + shift))
             (Util.Pp.pp_int true) i_6 (Util.Pp.pp_int true) n_1
       | (Copy, Res ((SUT, _), r_1)) ->
-          let lhs = if last__182_ then "r" else SUT.get_name state__180_ 0
+          let lhs = if last__183_ then "r" else SUT.get_name state__181_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s" lhs "copy"
-            (SUT.get_name state__180_ (0 + shift))
+            (SUT.get_name state__181_ (0 + shift))
       | (Fill (pos, len, x_4), Res ((Result (Unit, Exn), _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__183_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a %a)" lhs
-            "fill" (SUT.get_name state__180_ (0 + shift))
+            "fill" (SUT.get_name state__181_ (0 + shift))
             (Util.Pp.pp_int true) pos (Util.Pp.pp_int true) len
             (Util.Pp.pp_elt Util.Pp.pp_char true) x_4
       | (Blit (src_pos, dst_pos, len_1), Res ((Result (Unit, Exn), _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__183_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %s %a %a)"
-            lhs "blit" (SUT.get_name state__180_ (0 + shift))
+            lhs "blit" (SUT.get_name state__181_ (0 + shift))
             (Util.Pp.pp_int true) src_pos
-            (SUT.get_name state__180_ (1 + shift)) (Util.Pp.pp_int true)
+            (SUT.get_name state__181_ (1 + shift)) (Util.Pp.pp_int true)
             dst_pos (Util.Pp.pp_int true) len_1
       | _ -> assert false
-let ortac_postcond cmd__074_ state__075_ res__076_ =
+let ortac_postcond cmd__075_ state__076_ res__077_ =
   let open Spec in
     let open STM in
-      let new_state__077_ = lazy (next_state cmd__074_ state__075_) in
-      match (cmd__074_, res__076_) with
+      let new_state__078_ = lazy (next_state cmd__075_ state__076_) in
+      match (cmd__075_, res__077_) with
       | (Push_back x, Res ((Unit, _), _)) -> None
       | (Pop_back, Res ((Result (Elt (Char), Exn), _), x_5)) ->
           (match x_5 with
            | Ok x_5 ->
                if
-                 let t_old__079_ = Model.get state__075_ 0
-                 and t_new__080_ =
-                   lazy (Model.get (Lazy.force new_state__077_) 0) in
+                 let t_old__080_ = Model.get state__076_ 0
+                 and t_new__081_ =
+                   lazy (Model.get (Lazy.force new_state__078_) 0) in
                  (try
                     if
-                      t_old__079_.contents =
+                      t_old__080_.contents =
                         Ortac_runtime.Gospelstdlib.Sequence.empty
                     then false
                     else
                       (proj x_5) =
                         (Ortac_runtime.Gospelstdlib.__mix_Bub
-                           t_old__079_.contents
+                           t_old__080_.contents
                            (Ortac_runtime.Gospelstdlib.(-)
                               (Ortac_runtime.Gospelstdlib.Sequence.length
-                                 t_old__079_.contents)
+                                 t_old__080_.contents)
                               (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
                   with
                   | e ->
@@ -1598,17 +1641,17 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                          })])
            | Error (Not_found) ->
                if
-                 let t_old__081_ = Model.get state__075_ 0
-                 and t_new__082_ =
-                   lazy (Model.get (Lazy.force new_state__077_) 0) in
+                 let t_old__082_ = Model.get state__076_ 0
+                 and t_new__083_ =
+                   lazy (Model.get (Lazy.force new_state__078_) 0) in
                  (try
-                    let __t1__083_ =
-                      (Lazy.force t_new__082_).contents =
-                        t_old__081_.contents in
-                    let __t2__084_ =
-                      t_old__081_.contents =
+                    let __t1__084_ =
+                      (Lazy.force t_new__083_).contents =
+                        t_old__082_.contents in
+                    let __t2__085_ =
+                      t_old__082_.contents =
                         Ortac_runtime.Gospelstdlib.Sequence.empty in
-                    __t1__083_ && __t2__084_
+                    __t1__084_ && __t2__085_
                   with
                   | e ->
                       raise
@@ -1658,18 +1701,18 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
           (match x_6 with
            | Ok x_6 ->
                if
-                 let t_old__087_ = Model.get state__075_ 0
-                 and t_new__088_ =
-                   lazy (Model.get (Lazy.force new_state__077_) 0) in
+                 let t_old__088_ = Model.get state__076_ 0
+                 and t_new__089_ =
+                   lazy (Model.get (Lazy.force new_state__078_) 0) in
                  (try
                     if
-                      t_old__087_.contents =
+                      t_old__088_.contents =
                         Ortac_runtime.Gospelstdlib.Sequence.empty
                     then false
                     else
                       (proj x_6) =
                         (Ortac_runtime.Gospelstdlib.Sequence.hd
-                           t_old__087_.contents)
+                           t_old__088_.contents)
                   with
                   | e ->
                       raise
@@ -1716,17 +1759,17 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                          })])
            | Error (Not_found) ->
                if
-                 let t_old__089_ = Model.get state__075_ 0
-                 and t_new__090_ =
-                   lazy (Model.get (Lazy.force new_state__077_) 0) in
+                 let t_old__090_ = Model.get state__076_ 0
+                 and t_new__091_ =
+                   lazy (Model.get (Lazy.force new_state__078_) 0) in
                  (try
-                    let __t1__091_ =
-                      (Lazy.force t_new__090_).contents =
-                        t_old__089_.contents in
-                    let __t2__092_ =
-                      t_old__089_.contents =
+                    let __t1__092_ =
+                      (Lazy.force t_new__091_).contents =
+                        t_old__090_.contents in
+                    let __t2__093_ =
+                      t_old__090_.contents =
                         Ortac_runtime.Gospelstdlib.Sequence.empty in
-                    __t1__091_ && __t2__092_
+                    __t1__092_ && __t2__093_
                   with
                   | e ->
                       raise
@@ -1773,18 +1816,18 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
            | _ -> None)
       | (Insert_at (i_1, x_2), Res ((Result (Unit, Exn), _), res)) ->
           (match if
-                   let tmp__094_ = Model.get state__075_ 0 in
+                   let tmp__095_ = Model.get state__076_ 0 in
                    try
-                     let __t1__095_ =
+                     let __t1__096_ =
                        Ortac_runtime.Gospelstdlib.(<=)
                          (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                          (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
-                     let __t2__096_ =
+                     let __t2__097_ =
                        Ortac_runtime.Gospelstdlib.(<=)
                          (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
                          (Ortac_runtime.Gospelstdlib.Sequence.length
-                            tmp__094_.contents) in
-                     __t1__095_ && __t2__096_
+                            tmp__095_.contents) in
+                     __t1__096_ && __t2__097_
                    with
                    | e ->
                        raise
@@ -1837,18 +1880,18 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                 | Error (Invalid_argument _) -> None
                 | _ ->
                     if
-                      let tmp__094_ = Model.get state__075_ 0 in
+                      let tmp__095_ = Model.get state__076_ 0 in
                       (try
-                         let __t1__095_ =
+                         let __t1__096_ =
                            Ortac_runtime.Gospelstdlib.(<=)
                              (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                              (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
-                         let __t2__096_ =
+                         let __t2__097_ =
                            Ortac_runtime.Gospelstdlib.(<=)
                              (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
                              (Ortac_runtime.Gospelstdlib.Sequence.length
-                                tmp__094_.contents) in
-                         __t1__095_ && __t2__096_
+                                tmp__095_.contents) in
+                         __t1__096_ && __t2__097_
                        with
                        | e ->
                            raise
@@ -1898,10 +1941,10 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                               })])))
       | (Pop_at i_2, Res ((Result (Elt (Char), Exn), _), x_7)) ->
           (match if
-                   let tmp__099_ = Model.get state__075_ 0 in
+                   let tmp__100_ = Model.get state__076_ 0 in
                    try
                      (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
-                        tmp__099_.contents)
+                        tmp__100_.contents)
                        = true
                    with
                    | e ->
@@ -1952,13 +1995,13 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                (match x_7 with
                 | Ok x_7 ->
                     if
-                      let t_old__097_ = Model.get state__075_ 0
-                      and t_new__098_ =
-                        lazy (Model.get (Lazy.force new_state__077_) 0) in
+                      let t_old__098_ = Model.get state__076_ 0
+                      and t_new__099_ =
+                        lazy (Model.get (Lazy.force new_state__078_) 0) in
                       (try
                          (proj x_7) =
                            (Ortac_runtime.Gospelstdlib.__mix_Bub
-                              t_old__097_.contents
+                              t_old__098_.contents
                               (Ortac_runtime.Gospelstdlib.integer_of_int i_2))
                        with
                        | e ->
@@ -2013,11 +2056,11 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                 | Error (Invalid_argument _) -> None
                 | _ ->
                     if
-                      let tmp__099_ = Model.get state__075_ 0 in
+                      let tmp__100_ = Model.get state__076_ 0 in
                       (try
                          (inside
                             (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
-                            tmp__099_.contents)
+                            tmp__100_.contents)
                            = true
                        with
                        | e ->
@@ -2068,10 +2111,10 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                               })])))
       | (Delete_at i_3, Res ((Result (Unit, Exn), _), res)) ->
           (match if
-                   let tmp__102_ = Model.get state__075_ 0 in
+                   let tmp__103_ = Model.get state__076_ 0 in
                    try
                      (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
-                        tmp__102_.contents)
+                        tmp__103_.contents)
                        = true
                    with
                    | e ->
@@ -2123,16 +2166,16 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                (match res with
                 | Ok _ ->
                     if
-                      let t_old__100_ = Model.get state__075_ 0
-                      and t_new__101_ =
-                        lazy (Model.get (Lazy.force new_state__077_) 0) in
+                      let t_old__101_ = Model.get state__076_ 0
+                      and t_new__102_ =
+                        lazy (Model.get (Lazy.force new_state__078_) 0) in
                       (try
                          (Ortac_runtime.Gospelstdlib.Sequence.length
-                            (Lazy.force t_new__101_).contents)
+                            (Lazy.force t_new__102_).contents)
                            =
                            (Ortac_runtime.Gospelstdlib.(-)
                               (Ortac_runtime.Gospelstdlib.Sequence.length
-                                 t_old__100_.contents)
+                                 t_old__101_.contents)
                               (Ortac_runtime.Gospelstdlib.integer_of_int 1))
                        with
                        | e ->
@@ -2187,11 +2230,11 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                 | Error (Invalid_argument _) -> None
                 | _ ->
                     if
-                      let tmp__102_ = Model.get state__075_ 0 in
+                      let tmp__103_ = Model.get state__076_ 0 in
                       (try
                          (inside
                             (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
-                            tmp__102_.contents)
+                            tmp__103_.contents)
                            = true
                        with
                        | e ->
@@ -2242,10 +2285,10 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                               })])))
       | (Get i_4, Res ((Result (Elt (Char), Exn), _), x_8)) ->
           (match if
-                   let tmp__105_ = Model.get state__075_ 0 in
+                   let tmp__106_ = Model.get state__076_ 0 in
                    try
                      (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_4)
-                        tmp__105_.contents)
+                        tmp__106_.contents)
                        = true
                    with
                    | e ->
@@ -2296,13 +2339,13 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                (match x_8 with
                 | Ok x_8 ->
                     if
-                      let t_old__103_ = Model.get state__075_ 0
-                      and t_new__104_ =
-                        lazy (Model.get (Lazy.force new_state__077_) 0) in
+                      let t_old__104_ = Model.get state__076_ 0
+                      and t_new__105_ =
+                        lazy (Model.get (Lazy.force new_state__078_) 0) in
                       (try
                          (proj x_8) =
                            (Ortac_runtime.Gospelstdlib.__mix_Bub
-                              (Lazy.force t_new__104_).contents
+                              (Lazy.force t_new__105_).contents
                               (Ortac_runtime.Gospelstdlib.integer_of_int i_4))
                        with
                        | e ->
@@ -2357,11 +2400,11 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                 | Error (Invalid_argument _) -> None
                 | _ ->
                     if
-                      let tmp__105_ = Model.get state__075_ 0 in
+                      let tmp__106_ = Model.get state__076_ 0 in
                       (try
                          (inside
                             (Ortac_runtime.Gospelstdlib.integer_of_int i_4)
-                            tmp__105_.contents)
+                            tmp__106_.contents)
                            = true
                        with
                        | e ->
@@ -2411,10 +2454,10 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                               })])))
       | (Set (i_5, v), Res ((Result (Unit, Exn), _), res)) ->
           (match if
-                   let tmp__106_ = Model.get state__075_ 0 in
+                   let tmp__107_ = Model.get state__076_ 0 in
                    try
                      (inside (Ortac_runtime.Gospelstdlib.integer_of_int i_5)
-                        tmp__106_.contents)
+                        tmp__107_.contents)
                        = true
                    with
                    | e ->
@@ -2467,11 +2510,11 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                 | Error (Invalid_argument _) -> None
                 | _ ->
                     if
-                      let tmp__106_ = Model.get state__075_ 0 in
+                      let tmp__107_ = Model.get state__076_ 0 in
                       (try
                          (inside
                             (Ortac_runtime.Gospelstdlib.integer_of_int i_5)
-                            tmp__106_.contents)
+                            tmp__107_.contents)
                            = true
                        with
                        | e ->
@@ -2521,12 +2564,12 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                               })])))
       | (Length, Res ((Int, _), l)) ->
           if
-            let t_old__109_ = Model.get state__075_ 0
-            and t_new__110_ = lazy (Model.get (Lazy.force new_state__077_) 0) in
+            let t_old__110_ = Model.get state__076_ 0
+            and t_new__111_ = lazy (Model.get (Lazy.force new_state__078_) 0) in
             (try
                (Ortac_runtime.Gospelstdlib.integer_of_int l) =
                  (Ortac_runtime.Gospelstdlib.Sequence.length
-                    (Lazy.force t_new__110_).contents)
+                    (Lazy.force t_new__111_).contents)
              with
              | e ->
                  raise
@@ -2555,12 +2598,12 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  (Ortac_runtime.Value
                     (Res
                        (integer,
-                         (let t_old__107_ = Model.get state__075_ 0
-                          and t_new__108_ =
-                            lazy (Model.get (Lazy.force new_state__077_) 0) in
+                         (let t_old__108_ = Model.get state__076_ 0
+                          and t_new__109_ =
+                            lazy (Model.get (Lazy.force new_state__078_) 0) in
                           try
                             Ortac_runtime.Gospelstdlib.Sequence.length
-                              (Lazy.force t_new__108_).contents
+                              (Lazy.force t_new__109_).contents
                           with
                           | e ->
                               raise
@@ -2712,11 +2755,11 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
       | (Empty (), Res ((SUT, _), t_12)) -> None
       | (Is_empty, Res ((Bool, _), b_1)) ->
           if
-            let t_old__112_ = Model.get state__075_ 0
-            and t_new__113_ = lazy (Model.get (Lazy.force new_state__077_) 0) in
+            let t_old__113_ = Model.get state__076_ 0
+            and t_new__114_ = lazy (Model.get (Lazy.force new_state__078_) 0) in
             (try
                (b_1 = true) =
-                 ((Lazy.force t_new__113_).contents =
+                 ((Lazy.force t_new__114_).contents =
                     Ortac_runtime.Gospelstdlib.Sequence.empty)
              with
              | e ->
@@ -2766,18 +2809,18 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
       | (Sub (i_6, n_1), Res ((Result (SUT, Exn), _), r)) ->
           (match Ortac_runtime.append
                    (if
-                      let tmp__117_ = Model.get state__075_ 0 in
+                      let tmp__118_ = Model.get state__076_ 0 in
                       try
-                        let __t1__118_ =
+                        let __t1__119_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                             (Ortac_runtime.Gospelstdlib.integer_of_int i_6) in
-                        let __t2__119_ =
+                        let __t2__120_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.integer_of_int i_6)
                             (Ortac_runtime.Gospelstdlib.Sequence.length
-                               tmp__117_.contents) in
-                        __t1__118_ && __t2__119_
+                               tmp__118_.contents) in
+                        __t1__119_ && __t2__120_
                       with
                       | e ->
                           raise
@@ -2823,22 +2866,22 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                   }
                               })]))
                    (if
-                      let tmp__117_ = Model.get state__075_ 0 in
+                      let tmp__118_ = Model.get state__076_ 0 in
                       try
-                        let __t1__120_ =
+                        let __t1__121_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.integer_of_int i_6)
                             (Ortac_runtime.Gospelstdlib.(+)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_6)
                                (Ortac_runtime.Gospelstdlib.integer_of_int n_1)) in
-                        let __t2__121_ =
+                        let __t2__122_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.(+)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_6)
                                (Ortac_runtime.Gospelstdlib.integer_of_int n_1))
                             (Ortac_runtime.Gospelstdlib.Sequence.length
-                               tmp__117_.contents) in
-                        __t1__120_ && __t2__121_
+                               tmp__118_.contents) in
+                        __t1__121_ && __t2__122_
                       with
                       | e ->
                           raise
@@ -2891,18 +2934,18 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                 | _ ->
                     Ortac_runtime.append
                       (if
-                         let tmp__117_ = Model.get state__075_ 0 in
+                         let tmp__118_ = Model.get state__076_ 0 in
                          try
-                           let __t1__118_ =
+                           let __t1__119_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_6) in
-                           let __t2__119_ =
+                           let __t2__120_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_6)
                                (Ortac_runtime.Gospelstdlib.Sequence.length
-                                  tmp__117_.contents) in
-                           __t1__118_ && __t2__119_
+                                  tmp__118_.contents) in
+                           __t1__119_ && __t2__120_
                          with
                          | e ->
                              raise
@@ -2951,9 +2994,9 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                      }
                                  })]))
                       (if
-                         let tmp__117_ = Model.get state__075_ 0 in
+                         let tmp__118_ = Model.get state__076_ 0 in
                          try
-                           let __t1__120_ =
+                           let __t1__121_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_6)
                                (Ortac_runtime.Gospelstdlib.(+)
@@ -2961,7 +3004,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                      i_6)
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
                                      n_1)) in
-                           let __t2__121_ =
+                           let __t2__122_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.(+)
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
@@ -2969,8 +3012,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
                                      n_1))
                                (Ortac_runtime.Gospelstdlib.Sequence.length
-                                  tmp__117_.contents) in
-                           __t1__120_ && __t2__121_
+                                  tmp__118_.contents) in
+                           __t1__121_ && __t2__122_
                          with
                          | e ->
                              raise
@@ -3021,26 +3064,26 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
       | (Copy, Res ((SUT, _), r_1)) -> None
       | (Fill (pos, len, x_4), Res ((Result (Unit, Exn), _), res)) ->
           (match if
-                   let tmp__123_ = Model.get state__075_ 0 in
+                   let tmp__124_ = Model.get state__076_ 0 in
                    try
-                     let __t1__124_ =
+                     let __t1__125_ =
                        Ortac_runtime.Gospelstdlib.(<=)
                          (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                          (Ortac_runtime.Gospelstdlib.integer_of_int pos) in
-                     let __t2__125_ =
-                       let __t1__126_ =
+                     let __t2__126_ =
+                       let __t1__127_ =
                          Ortac_runtime.Gospelstdlib.(<=)
                            (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                            (Ortac_runtime.Gospelstdlib.integer_of_int len) in
-                       let __t2__127_ =
+                       let __t2__128_ =
                          Ortac_runtime.Gospelstdlib.(<)
                            (Ortac_runtime.Gospelstdlib.(+)
                               (Ortac_runtime.Gospelstdlib.integer_of_int pos)
                               (Ortac_runtime.Gospelstdlib.integer_of_int len))
                            (Ortac_runtime.Gospelstdlib.Sequence.length
-                              tmp__123_.contents) in
-                       __t1__126_ && __t2__127_ in
-                     __t1__124_ && __t2__125_
+                              tmp__124_.contents) in
+                       __t1__127_ && __t2__128_ in
+                     __t1__125_ && __t2__126_
                    with
                    | e ->
                        raise
@@ -3092,18 +3135,18 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                 | Error (Invalid_argument _) -> None
                 | _ ->
                     if
-                      let tmp__123_ = Model.get state__075_ 0 in
+                      let tmp__124_ = Model.get state__076_ 0 in
                       (try
-                         let __t1__124_ =
+                         let __t1__125_ =
                            Ortac_runtime.Gospelstdlib.(<=)
                              (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                              (Ortac_runtime.Gospelstdlib.integer_of_int pos) in
-                         let __t2__125_ =
-                           let __t1__126_ =
+                         let __t2__126_ =
+                           let __t1__127_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                                (Ortac_runtime.Gospelstdlib.integer_of_int len) in
-                           let __t2__127_ =
+                           let __t2__128_ =
                              Ortac_runtime.Gospelstdlib.(<)
                                (Ortac_runtime.Gospelstdlib.(+)
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
@@ -3111,9 +3154,9 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
                                      len))
                                (Ortac_runtime.Gospelstdlib.Sequence.length
-                                  tmp__123_.contents) in
-                           __t1__126_ && __t2__127_ in
-                         __t1__124_ && __t2__125_
+                                  tmp__124_.contents) in
+                           __t1__127_ && __t2__128_ in
+                         __t1__125_ && __t2__126_
                        with
                        | e ->
                            raise
@@ -3165,16 +3208,16 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
           ->
           (match Ortac_runtime.append
                    (if
-                      let tmp__128_ = Model.get state__075_ 0
-                      and tmp__129_ = Model.get state__075_ 1 in
+                      let tmp__129_ = Model.get state__076_ 0
+                      and tmp__130_ = Model.get state__076_ 1 in
                       try
-                        let __t1__130_ =
+                        let __t1__131_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                             (Ortac_runtime.Gospelstdlib.integer_of_int
                                src_pos) in
-                        let __t2__131_ =
-                          let __t1__132_ =
+                        let __t2__132_ =
+                          let __t1__133_ =
                             Ortac_runtime.Gospelstdlib.(<=)
                               (Ortac_runtime.Gospelstdlib.integer_of_int
                                  src_pos)
@@ -3183,7 +3226,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                     src_pos)
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
                                     len_1)) in
-                          let __t2__133_ =
+                          let __t2__134_ =
                             Ortac_runtime.Gospelstdlib.(<=)
                               (Ortac_runtime.Gospelstdlib.(+)
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
@@ -3191,9 +3234,9 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
                                     len_1))
                               (Ortac_runtime.Gospelstdlib.Sequence.length
-                                 tmp__128_.contents) in
-                          __t1__132_ && __t2__133_ in
-                        __t1__130_ && __t2__131_
+                                 tmp__129_.contents) in
+                          __t1__133_ && __t2__134_ in
+                        __t1__131_ && __t2__132_
                       with
                       | e ->
                           raise
@@ -3240,16 +3283,16 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                   }
                               })]))
                    (if
-                      let tmp__128_ = Model.get state__075_ 0
-                      and tmp__129_ = Model.get state__075_ 1 in
+                      let tmp__129_ = Model.get state__076_ 0
+                      and tmp__130_ = Model.get state__076_ 1 in
                       try
-                        let __t1__134_ =
+                        let __t1__135_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                             (Ortac_runtime.Gospelstdlib.integer_of_int
                                dst_pos) in
-                        let __t2__135_ =
-                          let __t1__136_ =
+                        let __t2__136_ =
+                          let __t1__137_ =
                             Ortac_runtime.Gospelstdlib.(<=)
                               (Ortac_runtime.Gospelstdlib.integer_of_int
                                  dst_pos)
@@ -3258,7 +3301,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                     dst_pos)
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
                                     len_1)) in
-                          let __t2__137_ =
+                          let __t2__138_ =
                             Ortac_runtime.Gospelstdlib.(<=)
                               (Ortac_runtime.Gospelstdlib.(+)
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
@@ -3266,9 +3309,9 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
                                     len_1))
                               (Ortac_runtime.Gospelstdlib.Sequence.length
-                                 tmp__129_.contents) in
-                          __t1__136_ && __t2__137_ in
-                        __t1__134_ && __t2__135_
+                                 tmp__130_.contents) in
+                          __t1__137_ && __t2__138_ in
+                        __t1__135_ && __t2__136_
                       with
                       | e ->
                           raise
@@ -3322,16 +3365,16 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                 | _ ->
                     Ortac_runtime.append
                       (if
-                         let tmp__128_ = Model.get state__075_ 0
-                         and tmp__129_ = Model.get state__075_ 1 in
+                         let tmp__129_ = Model.get state__076_ 0
+                         and tmp__130_ = Model.get state__076_ 1 in
                          try
-                           let __t1__130_ =
+                           let __t1__131_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                                (Ortac_runtime.Gospelstdlib.integer_of_int
                                   src_pos) in
-                           let __t2__131_ =
-                             let __t1__132_ =
+                           let __t2__132_ =
+                             let __t1__133_ =
                                Ortac_runtime.Gospelstdlib.(<=)
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
                                     src_pos)
@@ -3340,7 +3383,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                        src_pos)
                                     (Ortac_runtime.Gospelstdlib.integer_of_int
                                        len_1)) in
-                             let __t2__133_ =
+                             let __t2__134_ =
                                Ortac_runtime.Gospelstdlib.(<=)
                                  (Ortac_runtime.Gospelstdlib.(+)
                                     (Ortac_runtime.Gospelstdlib.integer_of_int
@@ -3348,9 +3391,9 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                     (Ortac_runtime.Gospelstdlib.integer_of_int
                                        len_1))
                                  (Ortac_runtime.Gospelstdlib.Sequence.length
-                                    tmp__128_.contents) in
-                             __t1__132_ && __t2__133_ in
-                           __t1__130_ && __t2__131_
+                                    tmp__129_.contents) in
+                             __t1__133_ && __t2__134_ in
+                           __t1__131_ && __t2__132_
                          with
                          | e ->
                              raise
@@ -3399,16 +3442,16 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                      }
                                  })]))
                       (if
-                         let tmp__128_ = Model.get state__075_ 0
-                         and tmp__129_ = Model.get state__075_ 1 in
+                         let tmp__129_ = Model.get state__076_ 0
+                         and tmp__130_ = Model.get state__076_ 1 in
                          try
-                           let __t1__134_ =
+                           let __t1__135_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                                (Ortac_runtime.Gospelstdlib.integer_of_int
                                   dst_pos) in
-                           let __t2__135_ =
-                             let __t1__136_ =
+                           let __t2__136_ =
+                             let __t1__137_ =
                                Ortac_runtime.Gospelstdlib.(<=)
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
                                     dst_pos)
@@ -3417,7 +3460,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                        dst_pos)
                                     (Ortac_runtime.Gospelstdlib.integer_of_int
                                        len_1)) in
-                             let __t2__137_ =
+                             let __t2__138_ =
                                Ortac_runtime.Gospelstdlib.(<=)
                                  (Ortac_runtime.Gospelstdlib.(+)
                                     (Ortac_runtime.Gospelstdlib.integer_of_int
@@ -3425,9 +3468,9 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                     (Ortac_runtime.Gospelstdlib.integer_of_int
                                        len_1))
                                  (Ortac_runtime.Gospelstdlib.Sequence.length
-                                    tmp__129_.contents) in
-                             __t1__136_ && __t2__137_ in
-                           __t1__134_ && __t2__135_
+                                    tmp__130_.contents) in
+                             __t1__137_ && __t2__138_ in
+                           __t1__135_ && __t2__136_
                          with
                          | e ->
                              raise

--- a/examples/varray_circular_spec_tests.ml
+++ b/examples/varray_circular_spec_tests.ml
@@ -111,6 +111,8 @@ module Spec =
           struct include Gen
                  let int = small_signed_int
                  let elt gen = gen end
+        module Shrink = struct include Shrink
+                               let elt shrink = shrink end
       end
     module Util =
       struct module Pp = struct include Util.Pp

--- a/plugins/qcheck-stm/src/config.ml
+++ b/plugins/qcheck-stm/src/config.ml
@@ -6,6 +6,7 @@ type config_under_construction = {
   sut_core_type' : Ppxlib.core_type option;
   init_sut' : Ppxlib.expression option;
   gen_mod' : Ppxlib.structure option;
+  shrink_mod' : Ppxlib.structure option;
   pp_mod' : Ppxlib.structure option;
   ty_mod' : Ppxlib.structure option;
   cleanup' : Ppxlib.structure_item option;
@@ -16,6 +17,7 @@ let config_under_construction =
     sut_core_type' = None;
     init_sut' = None;
     gen_mod' = None;
+    shrink_mod' = None;
     pp_mod' = None;
     ty_mod' = None;
     cleanup' = None;
@@ -27,6 +29,7 @@ type t = {
   init_sut : Ppxlib.expression;
   init_sut_txt : string;
   gen_mod : Ppxlib.structure option; (* Containing custom QCheck generators *)
+  shrink_mod : Ppxlib.structure option; (* Containing custom QCheck shrinkers *)
   pp_mod : Ppxlib.structure option; (* Containing custom pretty printers *)
   ty_mod : Ppxlib.structure option; (* Containing custom STM.ty extensions *)
   cleanup : Ppxlib.structure_item option;
@@ -45,6 +48,7 @@ let mk_config context cfg_uc =
   in
   let init_sut_txt = Fmt.str "%a" Pprintast.expression init_sut
   and gen_mod = cfg_uc.gen_mod'
+  and shrink_mod = cfg_uc.shrink_mod'
   and pp_mod = cfg_uc.pp_mod'
   and ty_mod = cfg_uc.ty_mod'
   and cleanup = cfg_uc.cleanup' in
@@ -55,6 +59,7 @@ let mk_config context cfg_uc =
       init_sut;
       init_sut_txt;
       gen_mod;
+      shrink_mod;
       pp_mod;
       ty_mod;
       cleanup;
@@ -160,6 +165,7 @@ let type_declarations cfg_uc =
 (* Inspect module definition in config module in order to collect information
    about:
      - the custom [QCheck] generators
+     - the custom [QCheck] shrinkers
      - the custom [STM] pretty printers
      - the custom [STM.ty] extensions and function constructors *)
 let module_binding cfg_uc (mb : Ppxlib.module_binding) =
@@ -177,6 +183,9 @@ let module_binding cfg_uc (mb : Ppxlib.module_binding) =
   | Some name when String.equal "Gen" name ->
       let* content = get_structure name mb in
       ok { cfg_uc with gen_mod' = Some content }
+  | Some name when String.equal "Shrink" name ->
+      let* content = get_structure name mb in
+      ok { cfg_uc with shrink_mod' = Some content }
   | Some name when String.equal "Pp" name ->
       let* content = get_structure name mb in
       ok { cfg_uc with pp_mod' = Some content }

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -1233,13 +1233,20 @@ let prepend_include_in_module name lident structure =
   [ pstr_module @@ module_binding ~name ~expr ]
 
 let qcheck config =
-  match config.Cfg.gen_mod with
-  | None -> []
-  | Some structure ->
-      let structure =
-        prepend_include_in_module "Gen" (lident "Gen") structure
-      in
-      prepend_include_in_module "QCheck" (lident "QCheck") structure
+  let gen =
+    match config.Cfg.gen_mod with
+    | None -> []
+    | Some structure -> prepend_include_in_module "Gen" (lident "Gen") structure
+  in
+  let shrink =
+    match config.Cfg.shrink_mod with
+    | None -> []
+    | Some structure ->
+        prepend_include_in_module "Shrink" (lident "Shrink") structure
+  in
+  let qcheck = gen @ shrink in
+  if qcheck = [] then []
+  else prepend_include_in_module "QCheck" (lident "QCheck") qcheck
 
 let util config =
   match config.Cfg.pp_mod with

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -246,6 +246,75 @@ let exp_of_core_type ?(use_small = false) inst typ =
 
 let exp_of_ident id = pexp_ident (lident (str_of_ident id))
 
+let shrink_cmd_case value =
+  let open Reserr in
+  let cstr =
+    let name = String.capitalize_ascii (str_of_ident value.id) |> lident in
+    pexp_construct name
+      (pexp_tuple_opt
+         (List.map
+            (function _, None -> eunit | _, Some id -> evar (str_of_ident id))
+            value.args))
+  in
+  let rec shrinker_of_ty ty =
+    match ty.ptyp_desc with
+    | Ptyp_constr (lid, xs) -> (
+        let* s = munge_longident false ty lid in
+        match s with
+        | "bool" -> ok (evar "nil")
+        | "list" | "array" ->
+            let* shrinker = shrinker_of_ty (List.hd xs) in
+            pexp_apply (evar s) [ (Labelled "shrink", shrinker) ] |> ok
+        | _ ->
+            (* TODO: check that a custom shrinker is actually defined *)
+            let* shrinkers = promote_map shrinker_of_ty xs in
+            eapply (evar s) shrinkers |> ok)
+    | Ptyp_tuple tys ->
+        let* shrinkers = promote_map shrinker_of_ty tys in
+        let tup_fun = evar ("tup" ^ (List.length tys |> string_of_int)) in
+        eapply tup_fun shrinkers |> ok
+    | _ -> ok (evar "nil")
+  in
+  let gen_itermap (ty, id) =
+    let name_expr, name_pat =
+      match id with
+      | None -> (eunit, punit)
+      | Some id ->
+          let name = str_of_ident id in
+          (evar name, pvar name)
+    in
+    let ty = subst_core_type value.inst ty in
+    let* shrinker = shrinker_of_ty ty in
+    let shrink_expr = eapply shrinker [ name_expr ] in
+    let cstr_fun = efun [ (Nolabel, name_pat) ] cstr in
+    eapply (evar "map") [ cstr_fun; shrink_expr ] |> ok
+  in
+  let* iter_maps = promote_map gen_itermap value.args in
+  let combine l r = eapply (evar "( <+> )") [ l; r ] in
+  let rhs =
+    match iter_maps with
+    | [] -> evar "empty"
+    | [ x ] -> x
+    | x :: xs -> List.fold_left combine x xs
+  in
+  let lhs = mk_cmd_pattern value in
+  case ~lhs ~guard:None ~rhs |> ok
+
+let shrink_cmd ir =
+  let open Reserr in
+  let cmd_name = gen_symbol ~prefix:"cmd" () in
+  let* cases = promote_map shrink_cmd_case ir.values in
+  let open Ppxlib in
+  let let_open str e =
+    pexp_open Ast_helper.(Opn.mk (Mod.ident (lident str |> noloc))) e
+  in
+  let body = pexp_match (evar cmd_name) cases in
+
+  let body = let_open "QCheck" (let_open "Shrink" (let_open "Iter" body)) in
+  let pat = pvar "shrink_cmd" in
+  let expr = efun [ (Nolabel, pvar cmd_name) ] body in
+  pstr_value Nonrecursive [ value_binding ~pat ~expr ] |> ok
+
 let arb_cmd_case config value =
   let open Reserr in
   let is_create = value.sut_vars = [] && Cfg.does_return_sut config value.ty in
@@ -290,7 +359,11 @@ let arb_cmd config ir =
   let body =
     let_open "QCheck"
       (pexp_apply (evar "make")
-         [ (Labelled "print", evar "show_cmd"); (Nolabel, oneof) ])
+         [
+           (Labelled "print", evar "show_cmd");
+           (Labelled "shrink", evar "shrink_cmd");
+           (Nolabel, oneof);
+         ])
   in
   let pat = pvar "arb_cmd" in
   let expr = efun [ (Nolabel, ppat_any (* for now we don't use it *)) ] body in
@@ -1556,6 +1629,7 @@ let stm config ir =
   let warn = [%stri [@@@ocaml.warning "-26-27-69-32-38"]] in
   let cmd = cmd_type ir in
   let* cmd_show = cmd_show config ir in
+  let* cmd_shrink = shrink_cmd ir in
   let* idx, next_state = next_state config ir in
   let* postcond = postcond config idx ir in
   let* precond = precond config ir in
@@ -1587,6 +1661,7 @@ let stm config ir =
       @ [
           cmd;
           cmd_show;
+          cmd_shrink;
           cleanup;
           arb_cmd;
           next_state;

--- a/plugins/qcheck-stm/test/array_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/array_stm_tests.expected.ml
@@ -123,10 +123,34 @@ module Spec =
       | To_list -> Format.asprintf "%s <sut>" "to_list"
       | Mem a_3 ->
           Format.asprintf "%s %a <sut>" "mem" (Util.Pp.pp_char true) a_3
+    let shrink_cmd cmd__002_ =
+      let open QCheck in
+        let open Shrink in
+          let open Iter in
+            match cmd__002_ with
+            | Length -> empty
+            | Get i -> map (fun i -> Get i) (int i)
+            | Set (i_1, a_1) ->
+                (map (fun i_1 -> Set (i_1, a_1)) (int i_1)) <+>
+                  (map (fun a_1 -> Set (i_1, a_1)) (char a_1))
+            | Make (i_2, a_2) ->
+                (map (fun i_2 -> Make (i_2, a_2)) (int i_2)) <+>
+                  (map (fun a_2 -> Make (i_2, a_2)) (char a_2))
+            | Append -> empty
+            | Sub (i_3, n) ->
+                (map (fun i_3 -> Sub (i_3, n)) (int i_3)) <+>
+                  (map (fun n -> Sub (i_3, n)) (int n))
+            | Copy -> empty
+            | Fill (pos, len, x) ->
+                ((map (fun pos -> Fill (pos, len, x)) (int pos)) <+>
+                   (map (fun len -> Fill (pos, len, x)) (int len)))
+                  <+> (map (fun x -> Fill (pos, len, x)) (char x))
+            | To_list -> empty
+            | Mem a_3 -> map (fun a_3 -> Mem a_3) (char a_3)
     let cleanup _ = ()
     let arb_cmd _ =
       let open QCheck in
-        make ~print:show_cmd
+        make ~print:show_cmd ~shrink:shrink_cmd
           (let open Gen in
              oneof
                [pure Length;
@@ -145,25 +169,25 @@ module Spec =
                  <*> char;
                pure To_list;
                (pure (fun a_3 -> Mem a_3)) <*> char])
-    let next_state cmd__002_ state__003_ =
-      match cmd__002_ with
+    let next_state cmd__003_ state__004_ =
+      match cmd__003_ with
       | Length ->
-          let t_1__004_ = Model.get state__003_ 0 in
-          let t_1__005_ = t_1__004_ in
-          Model.push (Model.drop_n state__003_ 1) t_1__005_
+          let t_1__005_ = Model.get state__004_ 0 in
+          let t_1__006_ = t_1__005_ in
+          Model.push (Model.drop_n state__004_ 1) t_1__006_
       | Get i ->
-          let t_2__006_ = Model.get state__003_ 0 in
+          let t_2__007_ = Model.get state__004_ 0 in
           if
             (try
-               let __t1__008_ =
+               let __t1__009_ =
                  Ortac_runtime.Gospelstdlib.(<=)
                    (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                    (Ortac_runtime.Gospelstdlib.integer_of_int i) in
-               let __t2__009_ =
+               let __t2__010_ =
                  Ortac_runtime.Gospelstdlib.(<)
                    (Ortac_runtime.Gospelstdlib.integer_of_int i)
-                   t_2__006_.size in
-               __t1__008_ && __t2__009_
+                   t_2__007_.size in
+               __t1__009_ && __t2__010_
              with
              | e ->
                  raise
@@ -186,22 +210,22 @@ module Spec =
                             }
                         })))
           then
-            let t_2__007_ = t_2__006_ in
-            Model.push (Model.drop_n state__003_ 1) t_2__007_
-          else state__003_
+            let t_2__008_ = t_2__007_ in
+            Model.push (Model.drop_n state__004_ 1) t_2__008_
+          else state__004_
       | Set (i_1, a_1) ->
-          let t_3__010_ = Model.get state__003_ 0 in
+          let t_3__011_ = Model.get state__004_ 0 in
           if
             (try
-               let __t1__012_ =
+               let __t1__013_ =
                  Ortac_runtime.Gospelstdlib.(<=)
                    (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                    (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
-               let __t2__013_ =
+               let __t2__014_ =
                  Ortac_runtime.Gospelstdlib.(<)
                    (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
-                   t_3__010_.size in
-               __t1__012_ && __t2__013_
+                   t_3__011_.size in
+               __t1__013_ && __t2__014_
              with
              | e ->
                  raise
@@ -224,14 +248,14 @@ module Spec =
                             }
                         })))
           then
-            let t_3__011_ =
+            let t_3__012_ =
               let open ModelElt in
                 {
-                  t_3__010_ with
+                  t_3__011_ with
                   contents =
                     (try
                        Ortac_runtime.Gospelstdlib.Sequence.set
-                         t_3__010_.contents
+                         t_3__011_.contents
                          (Ortac_runtime.Gospelstdlib.integer_of_int i_1) a_1
                      with
                      | e ->
@@ -255,8 +279,8 @@ module Spec =
                                     }
                                 })))
                 } in
-            Model.push (Model.drop_n state__003_ 1) t_3__011_
-          else state__003_
+            Model.push (Model.drop_n state__004_ 1) t_3__012_
+          else state__004_
       | Make (i_2, a_2) ->
           if
             (try
@@ -285,7 +309,7 @@ module Spec =
                             }
                         })))
           then
-            let t_4__015_ =
+            let t_4__016_ =
               let open ModelElt in
                 {
                   size =
@@ -338,18 +362,18 @@ module Spec =
                                     }
                                 })))
                 } in
-            Model.push (Model.drop_n state__003_ 0) t_4__015_
-          else state__003_
+            Model.push (Model.drop_n state__004_ 0) t_4__016_
+          else state__004_
       | Append ->
-          let a_4__016_ = Model.get state__003_ 0
-          and b__017_ = Model.get state__003_ 1 in
-          let t_5__021_ =
+          let a_4__017_ = Model.get state__004_ 0
+          and b__018_ = Model.get state__004_ 1 in
+          let t_5__022_ =
             let open ModelElt in
               {
                 size =
                   (try
-                     Ortac_runtime.Gospelstdlib.(+) a_4__016_.size
-                       b__017_.size
+                     Ortac_runtime.Gospelstdlib.(+) a_4__017_.size
+                       b__018_.size
                    with
                    | e ->
                        raise
@@ -373,8 +397,8 @@ module Spec =
                               })));
                 contents =
                   (try
-                     Ortac_runtime.Gospelstdlib.(++) a_4__016_.contents
-                       b__017_.contents
+                     Ortac_runtime.Gospelstdlib.(++) a_4__017_.contents
+                       b__018_.contents
                    with
                    | e ->
                        raise
@@ -397,25 +421,25 @@ module Spec =
                                   }
                               })))
               }
-          and a_4__020_ = a_4__016_
-          and b__019_ = b__017_ in
+          and a_4__021_ = a_4__017_
+          and b__020_ = b__018_ in
           Model.push
-            (Model.push (Model.push (Model.drop_n state__003_ 2) b__019_)
-               a_4__020_) t_5__021_
+            (Model.push (Model.push (Model.drop_n state__004_ 2) b__020_)
+               a_4__021_) t_5__022_
       | Sub (i_3, n) ->
-          let t_6__022_ = Model.get state__003_ 0 in
+          let t_6__023_ = Model.get state__004_ 0 in
           if
             (try
-               let __t1__026_ =
+               let __t1__027_ =
                  Ortac_runtime.Gospelstdlib.(<=)
                    (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                    (Ortac_runtime.Gospelstdlib.integer_of_int i_3) in
-               let __t2__027_ =
+               let __t2__028_ =
                  Ortac_runtime.Gospelstdlib.(<=)
                    (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                    (Ortac_runtime.Gospelstdlib.Sequence.length
-                      t_6__022_.contents) in
-               __t1__026_ && __t2__027_
+                      t_6__023_.contents) in
+               __t1__027_ && __t2__028_
              with
              | e ->
                  raise
@@ -439,20 +463,20 @@ module Spec =
                         })))
               &&
               ((try
-                  let __t1__028_ =
+                  let __t1__029_ =
                     Ortac_runtime.Gospelstdlib.(<=)
                       (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                       (Ortac_runtime.Gospelstdlib.(+)
                          (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                          (Ortac_runtime.Gospelstdlib.integer_of_int n)) in
-                  let __t2__029_ =
+                  let __t2__030_ =
                     Ortac_runtime.Gospelstdlib.(<=)
                       (Ortac_runtime.Gospelstdlib.(+)
                          (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                          (Ortac_runtime.Gospelstdlib.integer_of_int n))
                       (Ortac_runtime.Gospelstdlib.Sequence.length
-                         t_6__022_.contents) in
-                  __t1__028_ && __t2__029_
+                         t_6__023_.contents) in
+                  __t1__029_ && __t2__030_
                 with
                 | e ->
                     raise
@@ -475,7 +499,7 @@ module Spec =
                                }
                            }))))
           then
-            let r__025_ =
+            let r__026_ =
               let open ModelElt in
                 {
                   size =
@@ -509,7 +533,7 @@ module Spec =
                        then Ortac_runtime.Gospelstdlib.Sequence.empty
                        else
                          Ortac_runtime.Gospelstdlib.__mix_Buddub
-                           t_6__022_.contents
+                           t_6__023_.contents
                            (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                            (Ortac_runtime.Gospelstdlib.(-)
                               (Ortac_runtime.Gospelstdlib.(+)
@@ -539,17 +563,17 @@ module Spec =
                                     }
                                 })))
                 }
-            and t_6__024_ = t_6__022_ in
-            Model.push (Model.push (Model.drop_n state__003_ 1) t_6__024_)
-              r__025_
-          else state__003_
+            and t_6__025_ = t_6__023_ in
+            Model.push (Model.push (Model.drop_n state__004_ 1) t_6__025_)
+              r__026_
+          else state__004_
       | Copy ->
-          let t_7__030_ = Model.get state__003_ 0 in
-          let r_1__033_ =
+          let t_7__031_ = Model.get state__004_ 0 in
+          let r_1__034_ =
             let open ModelElt in
               {
                 size =
-                  (try t_7__030_.size
+                  (try t_7__031_.size
                    with
                    | e ->
                        raise
@@ -572,7 +596,7 @@ module Spec =
                                   }
                               })));
                 contents =
-                  (try t_7__030_.contents
+                  (try t_7__031_.contents
                    with
                    | e ->
                        raise
@@ -595,11 +619,11 @@ module Spec =
                                   }
                               })))
               }
-          and t_7__032_ = t_7__030_ in
-          Model.push (Model.push (Model.drop_n state__003_ 1) t_7__032_)
-            r_1__033_
+          and t_7__033_ = t_7__031_ in
+          Model.push (Model.push (Model.drop_n state__004_ 1) t_7__033_)
+            r_1__034_
       | Fill (pos, len, x) ->
-          let t_8__034_ = Model.get state__003_ 0 in
+          let t_8__035_ = Model.get state__004_ 0 in
           if
             (try
                Ortac_runtime.Gospelstdlib.(<=)
@@ -658,7 +682,7 @@ module Spec =
                        (Ortac_runtime.Gospelstdlib.(+)
                           (Ortac_runtime.Gospelstdlib.integer_of_int pos)
                           (Ortac_runtime.Gospelstdlib.integer_of_int len))
-                       t_8__034_.size
+                       t_8__035_.size
                    with
                    | e ->
                        raise
@@ -681,33 +705,33 @@ module Spec =
                                   }
                               })))))
           then
-            let t_8__037_ =
+            let t_8__038_ =
               let open ModelElt in
                 {
-                  t_8__034_ with
+                  t_8__035_ with
                   contents =
                     (try
                        Ortac_runtime.Gospelstdlib.Sequence.init
                          (Ortac_runtime.Gospelstdlib.Sequence.length
-                            t_8__034_.contents)
+                            t_8__035_.contents)
                          (fun i_4 ->
                             if
-                              let __t1__035_ =
+                              let __t1__036_ =
                                 Ortac_runtime.Gospelstdlib.(<=)
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
                                      pos) i_4 in
-                              let __t2__036_ =
+                              let __t2__037_ =
                                 Ortac_runtime.Gospelstdlib.(<) i_4
                                   (Ortac_runtime.Gospelstdlib.(+)
                                      (Ortac_runtime.Gospelstdlib.integer_of_int
                                         pos)
                                      (Ortac_runtime.Gospelstdlib.integer_of_int
                                         len)) in
-                              __t1__035_ && __t2__036_
+                              __t1__036_ && __t2__037_
                             then x
                             else
                               Ortac_runtime.Gospelstdlib.__mix_Bub
-                                t_8__034_.contents i_4)
+                                t_8__035_.contents i_4)
                      with
                      | e ->
                          raise
@@ -730,18 +754,18 @@ module Spec =
                                     }
                                 })))
                 } in
-            Model.push (Model.drop_n state__003_ 1) t_8__037_
-          else state__003_
+            Model.push (Model.drop_n state__004_ 1) t_8__038_
+          else state__004_
       | To_list ->
-          let t_9__038_ = Model.get state__003_ 0 in
-          let t_9__039_ = t_9__038_ in
-          Model.push (Model.drop_n state__003_ 1) t_9__039_
+          let t_9__039_ = Model.get state__004_ 0 in
+          let t_9__040_ = t_9__039_ in
+          Model.push (Model.drop_n state__004_ 1) t_9__040_
       | Mem a_3 ->
-          let t_10__040_ = Model.get state__003_ 0 in
-          let t_10__041_ = t_10__040_ in
-          Model.push (Model.drop_n state__003_ 1) t_10__041_
-    let precond cmd__078_ state__079_ =
-      match cmd__078_ with
+          let t_10__041_ = Model.get state__004_ 0 in
+          let t_10__042_ = t_10__041_ in
+          Model.push (Model.drop_n state__004_ 1) t_10__042_
+    let precond cmd__079_ state__080_ =
+      match cmd__079_ with
       | Length -> true
       | Get i -> true
       | Set (i_1, a_1) -> true
@@ -753,168 +777,168 @@ module Spec =
       | To_list -> true
       | Mem a_3 -> true
     let postcond _ _ _ = true
-    let run cmd__080_ sut__081_ =
-      match cmd__080_ with
+    let run cmd__081_ sut__082_ =
+      match cmd__081_ with
       | Length ->
           Res
             (int,
-              (let t_1__082_ = SUT.pop sut__081_ in
-               let res__083_ = length t_1__082_ in
-               (SUT.push sut__081_ t_1__082_; res__083_)))
+              (let t_1__083_ = SUT.pop sut__082_ in
+               let res__084_ = length t_1__083_ in
+               (SUT.push sut__082_ t_1__083_; res__084_)))
       | Get i ->
           Res
             ((result char exn),
-              (let t_2__084_ = SUT.pop sut__081_ in
-               let res__085_ = protect (fun () -> get t_2__084_ i) () in
-               (SUT.push sut__081_ t_2__084_; res__085_)))
+              (let t_2__085_ = SUT.pop sut__082_ in
+               let res__086_ = protect (fun () -> get t_2__085_ i) () in
+               (SUT.push sut__082_ t_2__085_; res__086_)))
       | Set (i_1, a_1) ->
           Res
             ((result unit exn),
-              (let t_3__086_ = SUT.pop sut__081_ in
-               let res__087_ = protect (fun () -> set t_3__086_ i_1 a_1) () in
-               (SUT.push sut__081_ t_3__086_; res__087_)))
+              (let t_3__087_ = SUT.pop sut__082_ in
+               let res__088_ = protect (fun () -> set t_3__087_ i_1 a_1) () in
+               (SUT.push sut__082_ t_3__087_; res__088_)))
       | Make (i_2, a_2) ->
           Res
             ((result sut exn),
-              (let res__088_ = protect (fun () -> make i_2 a_2) () in
-               ((match res__088_ with
-                 | Ok res -> SUT.push sut__081_ res
+              (let res__089_ = protect (fun () -> make i_2 a_2) () in
+               ((match res__089_ with
+                 | Ok res -> SUT.push sut__082_ res
                  | Error _ -> ());
-                res__088_)))
+                res__089_)))
       | Append ->
           Res
             (sut,
-              (let a_4__089_ = SUT.pop sut__081_ in
-               let b__090_ = SUT.pop sut__081_ in
-               let res__091_ = append a_4__089_ b__090_ in
-               (SUT.push sut__081_ b__090_;
-                SUT.push sut__081_ a_4__089_;
-                SUT.push sut__081_ res__091_;
-                res__091_)))
+              (let a_4__090_ = SUT.pop sut__082_ in
+               let b__091_ = SUT.pop sut__082_ in
+               let res__092_ = append a_4__090_ b__091_ in
+               (SUT.push sut__082_ b__091_;
+                SUT.push sut__082_ a_4__090_;
+                SUT.push sut__082_ res__092_;
+                res__092_)))
       | Sub (i_3, n) ->
           Res
             ((result sut exn),
-              (let t_6__092_ = SUT.pop sut__081_ in
-               let res__093_ = protect (fun () -> sub t_6__092_ i_3 n) () in
-               (SUT.push sut__081_ t_6__092_;
-                (match res__093_ with
-                 | Ok res -> SUT.push sut__081_ res
+              (let t_6__093_ = SUT.pop sut__082_ in
+               let res__094_ = protect (fun () -> sub t_6__093_ i_3 n) () in
+               (SUT.push sut__082_ t_6__093_;
+                (match res__094_ with
+                 | Ok res -> SUT.push sut__082_ res
                  | Error _ -> ());
-                res__093_)))
+                res__094_)))
       | Copy ->
           Res
             (sut,
-              (let t_7__094_ = SUT.pop sut__081_ in
-               let res__095_ = copy t_7__094_ in
-               (SUT.push sut__081_ t_7__094_;
-                SUT.push sut__081_ res__095_;
-                res__095_)))
+              (let t_7__095_ = SUT.pop sut__082_ in
+               let res__096_ = copy t_7__095_ in
+               (SUT.push sut__082_ t_7__095_;
+                SUT.push sut__082_ res__096_;
+                res__096_)))
       | Fill (pos, len, x) ->
           Res
             ((result unit exn),
-              (let t_8__096_ = SUT.pop sut__081_ in
-               let res__097_ =
-                 protect (fun () -> fill t_8__096_ pos len x) () in
-               (SUT.push sut__081_ t_8__096_; res__097_)))
+              (let t_8__097_ = SUT.pop sut__082_ in
+               let res__098_ =
+                 protect (fun () -> fill t_8__097_ pos len x) () in
+               (SUT.push sut__082_ t_8__097_; res__098_)))
       | To_list ->
           Res
             ((list char),
-              (let t_9__098_ = SUT.pop sut__081_ in
-               let res__099_ = to_list t_9__098_ in
-               (SUT.push sut__081_ t_9__098_; res__099_)))
+              (let t_9__099_ = SUT.pop sut__082_ in
+               let res__100_ = to_list t_9__099_ in
+               (SUT.push sut__082_ t_9__099_; res__100_)))
       | Mem a_3 ->
           Res
             (bool,
-              (let t_10__100_ = SUT.pop sut__081_ in
-               let res__101_ = mem a_3 t_10__100_ in
-               (SUT.push sut__081_ t_10__100_; res__101_)))
+              (let t_10__101_ = SUT.pop sut__082_ in
+               let res__102_ = mem a_3 t_10__101_ in
+               (SUT.push sut__082_ t_10__101_; res__102_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__103_ state__104_ last__106_ res__105_ =
+let ortac_show_cmd cmd__104_ state__105_ last__107_ res__106_ =
   let open Spec in
     let open STM in
-      match (cmd__103_, res__105_) with
+      match (cmd__104_, res__106_) with
       | (Length, Res ((Int, _), _)) ->
-          let lhs = if last__106_ then "r" else "_"
+          let lhs = if last__107_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "length"
-            (SUT.get_name state__104_ (0 + shift))
+            (SUT.get_name state__105_ (0 + shift))
       | (Get i, Res ((Result (Char, Exn), _), _)) ->
-          let lhs = if last__106_ then "r" else "_"
+          let lhs = if last__107_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a)" lhs "get"
-            (SUT.get_name state__104_ (0 + shift)) (Util.Pp.pp_int true) i
+            (SUT.get_name state__105_ (0 + shift)) (Util.Pp.pp_int true) i
       | (Set (i_1, a_1), Res ((Result (Unit, Exn), _), _)) ->
-          let lhs = if last__106_ then "r" else "_"
+          let lhs = if last__107_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "set" (SUT.get_name state__104_ (0 + shift))
+            "set" (SUT.get_name state__105_ (0 + shift))
             (Util.Pp.pp_int true) i_1 (Util.Pp.pp_char true) a_1
       | (Make (i_2, a_2), Res ((Result (SUT, Exn), _), t_4)) ->
           let lhs =
-            if last__106_
+            if last__107_
             then "r"
             else
               (match t_4 with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__104_ 0)
+               | Ok _ -> "Ok " ^ (SUT.get_name state__105_ 0)
                | Error _ -> "_")
           and shift = match t_4 with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %a %a)" lhs "make"
             (Util.Pp.pp_int true) i_2 (Util.Pp.pp_char true) a_2
       | (Append, Res ((SUT, _), t_5)) ->
-          let lhs = if last__106_ then "r" else SUT.get_name state__104_ 0
+          let lhs = if last__107_ then "r" else SUT.get_name state__105_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s %s" lhs "append"
-            (SUT.get_name state__104_ (0 + shift))
-            (SUT.get_name state__104_ (1 + shift))
+            (SUT.get_name state__105_ (0 + shift))
+            (SUT.get_name state__105_ (1 + shift))
       | (Sub (i_3, n), Res ((Result (SUT, Exn), _), r)) ->
           let lhs =
-            if last__106_
+            if last__107_
             then "r"
             else
               (match r with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__104_ 0)
+               | Ok _ -> "Ok " ^ (SUT.get_name state__105_ 0)
                | Error _ -> "_")
           and shift = match r with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "sub" (SUT.get_name state__104_ (0 + shift))
+            "sub" (SUT.get_name state__105_ (0 + shift))
             (Util.Pp.pp_int true) i_3 (Util.Pp.pp_int true) n
       | (Copy, Res ((SUT, _), r_1)) ->
-          let lhs = if last__106_ then "r" else SUT.get_name state__104_ 0
+          let lhs = if last__107_ then "r" else SUT.get_name state__105_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s" lhs "copy"
-            (SUT.get_name state__104_ (0 + shift))
+            (SUT.get_name state__105_ (0 + shift))
       | (Fill (pos, len, x), Res ((Result (Unit, Exn), _), _)) ->
-          let lhs = if last__106_ then "r" else "_"
+          let lhs = if last__107_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a %a)" lhs
-            "fill" (SUT.get_name state__104_ (0 + shift))
+            "fill" (SUT.get_name state__105_ (0 + shift))
             (Util.Pp.pp_int true) pos (Util.Pp.pp_int true) len
             (Util.Pp.pp_char true) x
       | (To_list, Res ((List (Char), _), _)) ->
-          let lhs = if last__106_ then "r" else "_"
+          let lhs = if last__107_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "to_list"
-            (SUT.get_name state__104_ (0 + shift))
+            (SUT.get_name state__105_ (0 + shift))
       | (Mem a_3, Res ((Bool, _), _)) ->
-          let lhs = if last__106_ then "r" else "_"
+          let lhs = if last__107_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "mem"
-            (Util.Pp.pp_char true) a_3 (SUT.get_name state__104_ (0 + shift))
+            (Util.Pp.pp_char true) a_3 (SUT.get_name state__105_ (0 + shift))
       | _ -> assert false
-let ortac_postcond cmd__042_ state__043_ res__044_ =
+let ortac_postcond cmd__043_ state__044_ res__045_ =
   let open Spec in
     let open STM in
-      let new_state__045_ = lazy (next_state cmd__042_ state__043_) in
-      match (cmd__042_, res__044_) with
+      let new_state__046_ = lazy (next_state cmd__043_ state__044_) in
+      match (cmd__043_, res__045_) with
       | (Length, Res ((Int, _), i_5)) ->
           if
-            let t_old__048_ = Model.get state__043_ 0
-            and t_new__049_ = lazy (Model.get (Lazy.force new_state__045_) 0) in
+            let t_old__049_ = Model.get state__044_ 0
+            and t_new__050_ = lazy (Model.get (Lazy.force new_state__046_) 0) in
             (try
                (Ortac_runtime.Gospelstdlib.integer_of_int i_5) =
-                 (Lazy.force t_new__049_).size
+                 (Lazy.force t_new__050_).size
              with
              | e ->
                  raise
@@ -943,10 +967,10 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                  (Ortac_runtime.Value
                     (Res
                        (integer,
-                         (let t_old__046_ = Model.get state__043_ 0
-                          and t_new__047_ =
-                            lazy (Model.get (Lazy.force new_state__045_) 0) in
-                          try (Lazy.force t_new__047_).size
+                         (let t_old__047_ = Model.get state__044_ 0
+                          and t_new__048_ =
+                            lazy (Model.get (Lazy.force new_state__046_) 0) in
+                          try (Lazy.force t_new__048_).size
                           with
                           | e ->
                               raise
@@ -987,17 +1011,17 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                     })])
       | (Get i, Res ((Result (Char, Exn), _), a_5)) ->
           (match if
-                   let tmp__055_ = Model.get state__043_ 0 in
+                   let tmp__056_ = Model.get state__044_ 0 in
                    try
-                     let __t1__056_ =
+                     let __t1__057_ =
                        Ortac_runtime.Gospelstdlib.(<=)
                          (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                          (Ortac_runtime.Gospelstdlib.integer_of_int i) in
-                     let __t2__057_ =
+                     let __t2__058_ =
                        Ortac_runtime.Gospelstdlib.(<)
                          (Ortac_runtime.Gospelstdlib.integer_of_int i)
-                         tmp__055_.size in
-                     __t1__056_ && __t2__057_
+                         tmp__056_.size in
+                     __t1__057_ && __t2__058_
                    with
                    | e ->
                        raise
@@ -1046,13 +1070,13 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                (match a_5 with
                 | Ok a_5 ->
                     if
-                      let t_old__053_ = Model.get state__043_ 0
-                      and t_new__054_ =
-                        lazy (Model.get (Lazy.force new_state__045_) 0) in
+                      let t_old__054_ = Model.get state__044_ 0
+                      and t_new__055_ =
+                        lazy (Model.get (Lazy.force new_state__046_) 0) in
                       (try
                          a_5 =
                            (Ortac_runtime.Gospelstdlib.__mix_Bub
-                              (Lazy.force t_new__054_).contents
+                              (Lazy.force t_new__055_).contents
                               (Ortac_runtime.Gospelstdlib.integer_of_int i))
                        with
                        | e ->
@@ -1082,14 +1106,14 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                            (Ortac_runtime.Protected_value
                               (Res
                                  (char,
-                                   (let t_old__051_ = Model.get state__043_ 0
-                                    and t_new__052_ =
+                                   (let t_old__052_ = Model.get state__044_ 0
+                                    and t_new__053_ =
                                       lazy
                                         (Model.get
-                                           (Lazy.force new_state__045_) 0) in
+                                           (Lazy.force new_state__046_) 0) in
                                     try
                                       Ortac_runtime.Gospelstdlib.__mix_Bub
-                                        (Lazy.force t_new__052_).contents
+                                        (Lazy.force t_new__053_).contents
                                         (Ortac_runtime.Gospelstdlib.integer_of_int
                                            i)
                                     with
@@ -1136,17 +1160,17 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                 | Error (Invalid_argument _) -> None
                 | _ ->
                     if
-                      let tmp__055_ = Model.get state__043_ 0 in
+                      let tmp__056_ = Model.get state__044_ 0 in
                       (try
-                         let __t1__056_ =
+                         let __t1__057_ =
                            Ortac_runtime.Gospelstdlib.(<=)
                              (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                              (Ortac_runtime.Gospelstdlib.integer_of_int i) in
-                         let __t2__057_ =
+                         let __t2__058_ =
                            Ortac_runtime.Gospelstdlib.(<)
                              (Ortac_runtime.Gospelstdlib.integer_of_int i)
-                             tmp__055_.size in
-                         __t1__056_ && __t2__057_
+                             tmp__056_.size in
+                         __t1__057_ && __t2__058_
                        with
                        | e ->
                            raise
@@ -1192,17 +1216,17 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                               })])))
       | (Set (i_1, a_1), Res ((Result (Unit, Exn), _), res)) ->
           (match if
-                   let tmp__058_ = Model.get state__043_ 0 in
+                   let tmp__059_ = Model.get state__044_ 0 in
                    try
-                     let __t1__059_ =
+                     let __t1__060_ =
                        Ortac_runtime.Gospelstdlib.(<=)
                          (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                          (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
-                     let __t2__060_ =
+                     let __t2__061_ =
                        Ortac_runtime.Gospelstdlib.(<)
                          (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
-                         tmp__058_.size in
-                     __t1__059_ && __t2__060_
+                         tmp__059_.size in
+                     __t1__060_ && __t2__061_
                    with
                    | e ->
                        raise
@@ -1253,17 +1277,17 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                 | Error (Invalid_argument _) -> None
                 | _ ->
                     if
-                      let tmp__058_ = Model.get state__043_ 0 in
+                      let tmp__059_ = Model.get state__044_ 0 in
                       (try
-                         let __t1__059_ =
+                         let __t1__060_ =
                            Ortac_runtime.Gospelstdlib.(<=)
                              (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                              (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
-                         let __t2__060_ =
+                         let __t2__061_ =
                            Ortac_runtime.Gospelstdlib.(<)
                              (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
-                             tmp__058_.size in
-                         __t1__059_ && __t2__060_
+                             tmp__059_.size in
+                         __t1__060_ && __t2__061_
                        with
                        | e ->
                            raise
@@ -1415,18 +1439,18 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
       | (Sub (i_3, n), Res ((Result (SUT, Exn), _), r)) ->
           (match Ortac_runtime.append
                    (if
-                      let tmp__063_ = Model.get state__043_ 0 in
+                      let tmp__064_ = Model.get state__044_ 0 in
                       try
-                        let __t1__064_ =
+                        let __t1__065_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                             (Ortac_runtime.Gospelstdlib.integer_of_int i_3) in
-                        let __t2__065_ =
+                        let __t2__066_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                             (Ortac_runtime.Gospelstdlib.Sequence.length
-                               tmp__063_.contents) in
-                        __t1__064_ && __t2__065_
+                               tmp__064_.contents) in
+                        __t1__065_ && __t2__066_
                       with
                       | e ->
                           raise
@@ -1471,22 +1495,22 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                                   }
                               })]))
                    (if
-                      let tmp__063_ = Model.get state__043_ 0 in
+                      let tmp__064_ = Model.get state__044_ 0 in
                       try
-                        let __t1__066_ =
+                        let __t1__067_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                             (Ortac_runtime.Gospelstdlib.(+)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                                (Ortac_runtime.Gospelstdlib.integer_of_int n)) in
-                        let __t2__067_ =
+                        let __t2__068_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.(+)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                                (Ortac_runtime.Gospelstdlib.integer_of_int n))
                             (Ortac_runtime.Gospelstdlib.Sequence.length
-                               tmp__063_.contents) in
-                        __t1__066_ && __t2__067_
+                               tmp__064_.contents) in
+                        __t1__067_ && __t2__068_
                       with
                       | e ->
                           raise
@@ -1538,18 +1562,18 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                 | _ ->
                     Ortac_runtime.append
                       (if
-                         let tmp__063_ = Model.get state__043_ 0 in
+                         let tmp__064_ = Model.get state__044_ 0 in
                          try
-                           let __t1__064_ =
+                           let __t1__065_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_3) in
-                           let __t2__065_ =
+                           let __t2__066_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                                (Ortac_runtime.Gospelstdlib.Sequence.length
-                                  tmp__063_.contents) in
-                           __t1__064_ && __t2__065_
+                                  tmp__064_.contents) in
+                           __t1__065_ && __t2__066_
                          with
                          | e ->
                              raise
@@ -1595,9 +1619,9 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                                      }
                                  })]))
                       (if
-                         let tmp__063_ = Model.get state__043_ 0 in
+                         let tmp__064_ = Model.get state__044_ 0 in
                          try
-                           let __t1__066_ =
+                           let __t1__067_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                                (Ortac_runtime.Gospelstdlib.(+)
@@ -1605,7 +1629,7 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                                      i_3)
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
                                      n)) in
-                           let __t2__067_ =
+                           let __t2__068_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.(+)
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
@@ -1613,8 +1637,8 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
                                      n))
                                (Ortac_runtime.Gospelstdlib.Sequence.length
-                                  tmp__063_.contents) in
-                           __t1__066_ && __t2__067_
+                                  tmp__064_.contents) in
+                           __t1__067_ && __t2__068_
                          with
                          | e ->
                              raise
@@ -1663,7 +1687,7 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
       | (Fill (pos, len, x), Res ((Result (Unit, Exn), _), res)) ->
           (match Ortac_runtime.append
                    (if
-                      let tmp__069_ = Model.get state__043_ 0 in
+                      let tmp__070_ = Model.get state__044_ 0 in
                       try
                         Ortac_runtime.Gospelstdlib.(<=)
                           (Ortac_runtime.Gospelstdlib.integer_of_int 0)
@@ -1714,7 +1738,7 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                               })]))
                    (Ortac_runtime.append
                       (if
-                         let tmp__069_ = Model.get state__043_ 0 in
+                         let tmp__070_ = Model.get state__044_ 0 in
                          try
                            Ortac_runtime.Gospelstdlib.(<=)
                              (Ortac_runtime.Gospelstdlib.integer_of_int 0)
@@ -1764,14 +1788,14 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                                      }
                                  })]))
                       (if
-                         let tmp__069_ = Model.get state__043_ 0 in
+                         let tmp__070_ = Model.get state__044_ 0 in
                          try
                            Ortac_runtime.Gospelstdlib.(<=)
                              (Ortac_runtime.Gospelstdlib.(+)
                                 (Ortac_runtime.Gospelstdlib.integer_of_int
                                    pos)
                                 (Ortac_runtime.Gospelstdlib.integer_of_int
-                                   len)) tmp__069_.size
+                                   len)) tmp__070_.size
                          with
                          | e ->
                              raise
@@ -1824,7 +1848,7 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                 | _ ->
                     Ortac_runtime.append
                       (if
-                         let tmp__069_ = Model.get state__043_ 0 in
+                         let tmp__070_ = Model.get state__044_ 0 in
                          try
                            Ortac_runtime.Gospelstdlib.(<=)
                              (Ortac_runtime.Gospelstdlib.integer_of_int 0)
@@ -1875,7 +1899,7 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                                  })]))
                       (Ortac_runtime.append
                          (if
-                            let tmp__069_ = Model.get state__043_ 0 in
+                            let tmp__070_ = Model.get state__044_ 0 in
                             try
                               Ortac_runtime.Gospelstdlib.(<=)
                                 (Ortac_runtime.Gospelstdlib.integer_of_int 0)
@@ -1926,14 +1950,14 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                                         }
                                     })]))
                          (if
-                            let tmp__069_ = Model.get state__043_ 0 in
+                            let tmp__070_ = Model.get state__044_ 0 in
                             try
                               Ortac_runtime.Gospelstdlib.(<=)
                                 (Ortac_runtime.Gospelstdlib.(+)
                                    (Ortac_runtime.Gospelstdlib.integer_of_int
                                       pos)
                                    (Ortac_runtime.Gospelstdlib.integer_of_int
-                                      len)) tmp__069_.size
+                                      len)) tmp__070_.size
                             with
                             | e ->
                                 raise
@@ -1980,12 +2004,12 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                                     })])))))
       | (To_list, Res ((List (Char), _), l)) ->
           if
-            let t_old__072_ = Model.get state__043_ 0
-            and t_new__073_ = lazy (Model.get (Lazy.force new_state__045_) 0) in
+            let t_old__073_ = Model.get state__044_ 0
+            and t_new__074_ = lazy (Model.get (Lazy.force new_state__046_) 0) in
             (try
                l =
                  (Ortac_runtime.Gospelstdlib.List.of_seq
-                    (Lazy.force t_new__073_).contents)
+                    (Lazy.force t_new__074_).contents)
              with
              | e ->
                  raise
@@ -2014,12 +2038,12 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                  (Ortac_runtime.Value
                     (Res
                        ((list char),
-                         (let t_old__070_ = Model.get state__043_ 0
-                          and t_new__071_ =
-                            lazy (Model.get (Lazy.force new_state__045_) 0) in
+                         (let t_old__071_ = Model.get state__044_ 0
+                          and t_new__072_ =
+                            lazy (Model.get (Lazy.force new_state__046_) 0) in
                           try
                             Ortac_runtime.Gospelstdlib.List.of_seq
-                              (Lazy.force t_new__071_).contents
+                              (Lazy.force t_new__072_).contents
                           with
                           | e ->
                               raise
@@ -2060,12 +2084,12 @@ let ortac_postcond cmd__042_ state__043_ res__044_ =
                     })])
       | (Mem a_3, Res ((Bool, _), b_1)) ->
           if
-            let t_old__075_ = Model.get state__043_ 0
-            and t_new__076_ = lazy (Model.get (Lazy.force new_state__045_) 0) in
+            let t_old__076_ = Model.get state__044_ 0
+            and t_new__077_ = lazy (Model.get (Lazy.force new_state__046_) 0) in
             (try
                (b_1 = true) =
                  (Ortac_runtime.Gospelstdlib.Sequence.mem
-                    (Lazy.force t_new__076_).contents a_3)
+                    (Lazy.force t_new__077_).contents a_3)
              with
              | e ->
                  raise

--- a/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
@@ -93,10 +93,21 @@ module Spec =
       | Set (i_2, a_3) ->
           Format.asprintf "protect (fun () -> %s <sut> %a %a)" "set"
             (Util.Pp.pp_int true) i_2 (Util.Pp.pp_char true) a_3
+    let shrink_cmd cmd__002_ =
+      let open QCheck in
+        let open Shrink in
+          let open Iter in
+            match cmd__002_ with
+            | Make (i_1, a_2) ->
+                (map (fun i_1 -> Make (i_1, a_2)) (int i_1)) <+>
+                  (map (fun a_2 -> Make (i_1, a_2)) (char a_2))
+            | Set (i_2, a_3) ->
+                (map (fun i_2 -> Set (i_2, a_3)) (int i_2)) <+>
+                  (map (fun a_3 -> Set (i_2, a_3)) (char a_3))
     let cleanup _ = ()
     let arb_cmd _ =
       let open QCheck in
-        make ~print:show_cmd
+        make ~print:show_cmd ~shrink:shrink_cmd
           (let open Gen in
              oneof
                [((pure (fun i_1 -> fun a_2 -> Make (i_1, a_2))) <*>
@@ -104,8 +115,8 @@ module Spec =
                   <*> char;
                ((pure (fun i_2 -> fun a_3 -> Set (i_2, a_3))) <*> int) <*>
                  char])
-    let next_state cmd__002_ state__003_ =
-      match cmd__002_ with
+    let next_state cmd__003_ state__004_ =
+      match cmd__003_ with
       | Make (i_1, a_2) ->
           if
             (try
@@ -134,7 +145,7 @@ module Spec =
                             }
                         })))
           then
-            let t_1__005_ =
+            let t_1__006_ =
               let open ModelElt in
                 {
                   contents =
@@ -164,21 +175,21 @@ module Spec =
                                     }
                                 })))
                 } in
-            Model.push (Model.drop_n state__003_ 0) t_1__005_
-          else state__003_
+            Model.push (Model.drop_n state__004_ 0) t_1__006_
+          else state__004_
       | Set (i_2, a_3) ->
-          let t_2__006_ = Model.get state__003_ 0 in
+          let t_2__007_ = Model.get state__004_ 0 in
           if
             (try
-               let __t1__008_ =
+               let __t1__009_ =
                  Ortac_runtime.Gospelstdlib.(<=)
                    (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                    (Ortac_runtime.Gospelstdlib.integer_of_int i_2) in
-               let __t2__009_ =
+               let __t2__010_ =
                  Ortac_runtime.Gospelstdlib.(<)
                    (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
-                   (Ortac_runtime.Gospelstdlib.List.length t_2__006_.contents) in
-               __t1__008_ && __t2__009_
+                   (Ortac_runtime.Gospelstdlib.List.length t_2__007_.contents) in
+               __t1__009_ && __t2__010_
              with
              | e ->
                  raise
@@ -201,12 +212,12 @@ module Spec =
                             }
                         })))
           then
-            let t_2__007_ =
+            let t_2__008_ =
               let open ModelElt in
                 {
                   contents =
                     (try
-                       set_contents t_2__006_.contents
+                       set_contents t_2__007_.contents
                          (Ortac_runtime.Gospelstdlib.integer_of_int i_2) a_3
                      with
                      | e ->
@@ -230,57 +241,57 @@ module Spec =
                                     }
                                 })))
                 } in
-            Model.push (Model.drop_n state__003_ 1) t_2__007_
-          else state__003_
-    let precond cmd__017_ state__018_ =
-      match cmd__017_ with | Make (i_1, a_2) -> true | Set (i_2, a_3) -> true
+            Model.push (Model.drop_n state__004_ 1) t_2__008_
+          else state__004_
+    let precond cmd__018_ state__019_ =
+      match cmd__018_ with | Make (i_1, a_2) -> true | Set (i_2, a_3) -> true
     let postcond _ _ _ = true
-    let run cmd__019_ sut__020_ =
-      match cmd__019_ with
+    let run cmd__020_ sut__021_ =
+      match cmd__020_ with
       | Make (i_1, a_2) ->
           Res
             ((result sut exn),
-              (let res__021_ = protect (fun () -> make i_1 a_2) () in
-               ((match res__021_ with
-                 | Ok res -> SUT.push sut__020_ res
+              (let res__022_ = protect (fun () -> make i_1 a_2) () in
+               ((match res__022_ with
+                 | Ok res -> SUT.push sut__021_ res
                  | Error _ -> ());
-                res__021_)))
+                res__022_)))
       | Set (i_2, a_3) ->
           Res
             ((result unit exn),
-              (let t_2__022_ = SUT.pop sut__020_ in
-               let res__023_ = protect (fun () -> set t_2__022_ i_2 a_3) () in
-               (SUT.push sut__020_ t_2__022_; res__023_)))
+              (let t_2__023_ = SUT.pop sut__021_ in
+               let res__024_ = protect (fun () -> set t_2__023_ i_2 a_3) () in
+               (SUT.push sut__021_ t_2__023_; res__024_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__025_ state__026_ last__028_ res__027_ =
+let ortac_show_cmd cmd__026_ state__027_ last__029_ res__028_ =
   let open Spec in
     let open STM in
-      match (cmd__025_, res__027_) with
+      match (cmd__026_, res__028_) with
       | (Make (i_1, a_2), Res ((Result (SUT, Exn), _), t_1)) ->
           let lhs =
-            if last__028_
+            if last__029_
             then "r"
             else
               (match t_1 with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__026_ 0)
+               | Ok _ -> "Ok " ^ (SUT.get_name state__027_ 0)
                | Error _ -> "_")
           and shift = match t_1 with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %a %a)" lhs "make"
             (Util.Pp.pp_int true) i_1 (Util.Pp.pp_char true) a_2
       | (Set (i_2, a_3), Res ((Result (Unit, Exn), _), _)) ->
-          let lhs = if last__028_ then "r" else "_"
+          let lhs = if last__029_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "set" (SUT.get_name state__026_ (0 + shift))
+            "set" (SUT.get_name state__027_ (0 + shift))
             (Util.Pp.pp_int true) i_2 (Util.Pp.pp_char true) a_3
       | _ -> assert false
-let ortac_postcond cmd__010_ state__011_ res__012_ =
+let ortac_postcond cmd__011_ state__012_ res__013_ =
   let open Spec in
     let open STM in
-      let new_state__013_ = lazy (next_state cmd__010_ state__011_) in
-      match (cmd__010_, res__012_) with
+      let new_state__014_ = lazy (next_state cmd__011_ state__012_) in
+      match (cmd__011_, res__013_) with
       | (Make (i_1, a_2), Res ((Result (SUT, Exn), _), t_1)) ->
           (match if
                    try
@@ -389,18 +400,18 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                               })])))
       | (Set (i_2, a_3), Res ((Result (Unit, Exn), _), res)) ->
           (match if
-                   let tmp__014_ = Model.get state__011_ 0 in
+                   let tmp__015_ = Model.get state__012_ 0 in
                    try
-                     let __t1__015_ =
+                     let __t1__016_ =
                        Ortac_runtime.Gospelstdlib.(<=)
                          (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                          (Ortac_runtime.Gospelstdlib.integer_of_int i_2) in
-                     let __t2__016_ =
+                     let __t2__017_ =
                        Ortac_runtime.Gospelstdlib.(<)
                          (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
                          (Ortac_runtime.Gospelstdlib.List.length
-                            tmp__014_.contents) in
-                     __t1__015_ && __t2__016_
+                            tmp__015_.contents) in
+                     __t1__016_ && __t2__017_
                    with
                    | e ->
                        raise
@@ -452,18 +463,18 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                 | Error (Invalid_argument _) -> None
                 | _ ->
                     if
-                      let tmp__014_ = Model.get state__011_ 0 in
+                      let tmp__015_ = Model.get state__012_ 0 in
                       (try
-                         let __t1__015_ =
+                         let __t1__016_ =
                            Ortac_runtime.Gospelstdlib.(<=)
                              (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                              (Ortac_runtime.Gospelstdlib.integer_of_int i_2) in
-                         let __t2__016_ =
+                         let __t2__017_ =
                            Ortac_runtime.Gospelstdlib.(<)
                              (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
                              (Ortac_runtime.Gospelstdlib.List.length
-                                tmp__014_.contents) in
-                         __t1__015_ && __t2__016_
+                                tmp__015_.contents) in
+                         __t1__016_ && __t2__017_
                        with
                        | e ->
                            raise

--- a/plugins/qcheck-stm/test/custom_config_config.ml
+++ b/plugins/qcheck-stm/test/custom_config_config.ml
@@ -7,6 +7,10 @@ module Gen = struct
   let elt gen = elt <$> gen
 end
 
+module Shrink = struct
+  let elt shrink elem = Iter.map elt (shrink (proj elem))
+end
+
 module Pp = struct
   let pp_elt pp par fmt e =
     let open Format in

--- a/plugins/qcheck-stm/test/custom_config_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/custom_config_stm_tests.expected.ml
@@ -96,21 +96,31 @@ module Spec =
           Format.asprintf "%s <sut> %a" "push"
             (Util.Pp.pp_elt Util.Pp.pp_int true) e
       | Top -> Format.asprintf "protect (fun () -> %s <sut>)" "top"
+    let shrink_cmd cmd__002_ =
+      let open QCheck in
+        let open Shrink in
+          let open Iter in
+            match cmd__002_ with
+            | Proj __arg0 ->
+                map (fun __arg0 -> Proj __arg0) (elt char __arg0)
+            | Empty () -> map (fun () -> Empty ()) (unit ())
+            | Push e -> map (fun e -> Push e) (elt int e)
+            | Top -> empty
     let cleanup _ = ()
     let arb_cmd _ =
       let open QCheck in
-        make ~print:show_cmd
+        make ~print:show_cmd ~shrink:shrink_cmd
           (let open Gen in
              oneof
                [(pure (fun __arg0 -> Proj __arg0)) <*> (elt char);
                (pure (fun () -> Empty ())) <*> unit;
                (pure (fun e -> Push e)) <*> (elt int);
                pure Top])
-    let next_state cmd__002_ state__003_ =
-      match cmd__002_ with
-      | Proj __arg0 -> state__003_
+    let next_state cmd__003_ state__004_ =
+      match cmd__003_ with
+      | Proj __arg0 -> state__004_
       | Empty () ->
-          let t_1__005_ =
+          let t_1__006_ =
             let open ModelElt in
               {
                 contents =
@@ -137,16 +147,16 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 0) t_1__005_
+          Model.push (Model.drop_n state__004_ 0) t_1__006_
       | Push e ->
-          let t_2__006_ = Model.get state__003_ 0 in
-          let t_2__007_ =
+          let t_2__007_ = Model.get state__004_ 0 in
+          let t_2__008_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      Ortac_runtime.Gospelstdlib.Sequence.cons (proj e)
-                       t_2__006_.contents
+                       t_2__007_.contents
                    with
                    | e ->
                        raise
@@ -169,13 +179,13 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) t_2__007_
+          Model.push (Model.drop_n state__004_ 1) t_2__008_
       | Top ->
-          let t_3__008_ = Model.get state__003_ 0 in
+          let t_3__009_ = Model.get state__004_ 0 in
           if
             (try
                not
-                 (t_3__008_.contents =
+                 (t_3__009_.contents =
                     Ortac_runtime.Gospelstdlib.Sequence.empty)
              with
              | e ->
@@ -199,79 +209,79 @@ module Spec =
                             }
                         })))
           then
-            let t_3__009_ = t_3__008_ in
-            Model.push (Model.drop_n state__003_ 1) t_3__009_
-          else state__003_
-    let precond cmd__018_ state__019_ =
-      match cmd__018_ with
+            let t_3__010_ = t_3__009_ in
+            Model.push (Model.drop_n state__004_ 1) t_3__010_
+          else state__004_
+    let precond cmd__019_ state__020_ =
+      match cmd__019_ with
       | Proj __arg0 -> true
       | Empty () -> true
       | Push e -> true
       | Top -> true
     let postcond _ _ _ = true
-    let run cmd__020_ sut__021_ =
-      match cmd__020_ with
-      | Proj __arg0 -> Res (char, (let res__022_ = proj __arg0 in res__022_))
+    let run cmd__021_ sut__022_ =
+      match cmd__021_ with
+      | Proj __arg0 -> Res (char, (let res__023_ = proj __arg0 in res__023_))
       | Empty () ->
           Res
             (sut,
-              (let res__023_ = empty () in
-               (SUT.push sut__021_ res__023_; res__023_)))
+              (let res__024_ = empty () in
+               (SUT.push sut__022_ res__024_; res__024_)))
       | Push e ->
           Res
             (unit,
-              (let t_2__024_ = SUT.pop sut__021_ in
-               let res__025_ = push t_2__024_ e in
-               (SUT.push sut__021_ t_2__024_; res__025_)))
+              (let t_2__025_ = SUT.pop sut__022_ in
+               let res__026_ = push t_2__025_ e in
+               (SUT.push sut__022_ t_2__025_; res__026_)))
       | Top ->
           Res
             ((result (elt int) exn),
-              (let t_3__026_ = SUT.pop sut__021_ in
-               let res__027_ = protect (fun () -> top t_3__026_) () in
-               (SUT.push sut__021_ t_3__026_; res__027_)))
+              (let t_3__027_ = SUT.pop sut__022_ in
+               let res__028_ = protect (fun () -> top t_3__027_) () in
+               (SUT.push sut__022_ t_3__027_; res__028_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__029_ state__030_ last__032_ res__031_ =
+let ortac_show_cmd cmd__030_ state__031_ last__033_ res__032_ =
   let open Spec in
     let open STM in
-      match (cmd__029_, res__031_) with
+      match (cmd__030_, res__032_) with
       | (Proj __arg0, Res ((Char, _), _)) ->
-          let lhs = if last__032_ then "r" else "_"
+          let lhs = if last__033_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a" lhs "proj"
             (Util.Pp.pp_elt Util.Pp.pp_char true) __arg0
       | (Empty (), Res ((SUT, _), t_1)) ->
-          let lhs = if last__032_ then "r" else SUT.get_name state__030_ 0
+          let lhs = if last__033_ then "r" else SUT.get_name state__031_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "empty" (Util.Pp.pp_unit true)
             ()
       | (Push e, Res ((Unit, _), _)) ->
-          let lhs = if last__032_ then "r" else "_"
+          let lhs = if last__033_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "push"
-            (SUT.get_name state__030_ (0 + shift))
+            (SUT.get_name state__031_ (0 + shift))
             (Util.Pp.pp_elt Util.Pp.pp_int true) e
       | (Top, Res ((Result (Elt (Int), Exn), _), _)) ->
-          let lhs = if last__032_ then "r" else "_"
+          let lhs = if last__033_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "top"
-            (SUT.get_name state__030_ (0 + shift))
+            (SUT.get_name state__031_ (0 + shift))
       | _ -> assert false
-let ortac_postcond cmd__010_ state__011_ res__012_ =
+let ortac_postcond cmd__011_ state__012_ res__013_ =
   let open Spec in
     let open STM in
-      let new_state__013_ = lazy (next_state cmd__010_ state__011_) in
-      match (cmd__010_, res__012_) with
+      let new_state__014_ = lazy (next_state cmd__011_ state__012_) in
+      match (cmd__011_, res__013_) with
       | (Proj __arg0, Res ((Char, _), result)) -> None
       | (Empty (), Res ((SUT, _), t_1)) -> None
       | (Push e, Res ((Unit, _), _)) -> None
       | (Top, Res ((Result (Elt (Int), Exn), _), a_1)) ->
           (match if
-                   let tmp__017_ = Model.get state__011_ 0 in
+                   let tmp__018_ = Model.get state__012_ 0 in
                    try
                      not
-                       (tmp__017_.contents =
+                       (tmp__018_.contents =
                           Ortac_runtime.Gospelstdlib.Sequence.empty)
                    with
                    | e ->
@@ -321,13 +331,13 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                (match a_1 with
                 | Ok a_1 ->
                     if
-                      let t_old__015_ = Model.get state__011_ 0
-                      and t_new__016_ =
-                        lazy (Model.get (Lazy.force new_state__013_) 0) in
+                      let t_old__016_ = Model.get state__012_ 0
+                      and t_new__017_ =
+                        lazy (Model.get (Lazy.force new_state__014_) 0) in
                       (try
                          (proj a_1) =
                            (Ortac_runtime.Gospelstdlib.Sequence.hd
-                              (Lazy.force t_new__016_).contents)
+                              (Lazy.force t_new__017_).contents)
                        with
                        | e ->
                            raise
@@ -378,10 +388,10 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                 | Error (Invalid_argument _) -> None
                 | _ ->
                     if
-                      let tmp__017_ = Model.get state__011_ 0 in
+                      let tmp__018_ = Model.get state__012_ 0 in
                       (try
                          not
-                           (tmp__017_.contents =
+                           (tmp__018_.contents =
                               Ortac_runtime.Gospelstdlib.Sequence.empty)
                        with
                        | e ->

--- a/plugins/qcheck-stm/test/custom_config_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/custom_config_stm_tests.expected.ml
@@ -51,6 +51,11 @@ module Spec =
             let int = small_signed_int
             let elt gen = elt <$> gen
           end
+        module Shrink =
+          struct
+            include Shrink
+            let elt shrink elem = Iter.map elt (shrink (proj elem))
+          end
       end
     module Util =
       struct

--- a/plugins/qcheck-stm/test/functional_model_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/functional_model_stm_tests.expected.ml
@@ -63,19 +63,28 @@ module Spec =
       | Add (a_1, b_1) ->
           Format.asprintf "%s <sut> %a %a" "add" (Util.Pp.pp_char true) a_1
             (Util.Pp.pp_int true) b_1
+    let shrink_cmd cmd__002_ =
+      let open QCheck in
+        let open Shrink in
+          let open Iter in
+            match cmd__002_ with
+            | Empty () -> map (fun () -> Empty ()) (unit ())
+            | Add (a_1, b_1) ->
+                (map (fun a_1 -> Add (a_1, b_1)) (char a_1)) <+>
+                  (map (fun b_1 -> Add (a_1, b_1)) (int b_1))
     let cleanup _ = ()
     let arb_cmd _ =
       let open QCheck in
-        make ~print:show_cmd
+        make ~print:show_cmd ~shrink:shrink_cmd
           (let open Gen in
              oneof
                [(pure (fun () -> Empty ())) <*> unit;
                ((pure (fun a_1 -> fun b_1 -> Add (a_1, b_1))) <*> char) <*>
                  int])
-    let next_state cmd__002_ state__003_ =
-      match cmd__002_ with
+    let next_state cmd__003_ state__004_ =
+      match cmd__003_ with
       | Empty () ->
-          let t_1__005_ =
+          let t_1__006_ =
             let open ModelElt in
               {
                 m =
@@ -102,14 +111,14 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 0) t_1__005_
+          Model.push (Model.drop_n state__004_ 0) t_1__006_
       | Add (a_1, b_1) ->
-          let t_2__006_ = Model.get state__003_ 0 in
-          let t_2__007_ =
+          let t_2__007_ = Model.get state__004_ 0 in
+          let t_2__008_ =
             let open ModelElt in
               {
                 m =
-                  (try fun x -> if x = a_1 then Some b_1 else t_2__006_.m x
+                  (try fun x -> if x = a_1 then Some b_1 else t_2__007_.m x
                    with
                    | e ->
                        raise
@@ -132,47 +141,47 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) t_2__007_
-    let precond cmd__013_ state__014_ =
-      match cmd__013_ with | Empty () -> true | Add (a_1, b_1) -> true
+          Model.push (Model.drop_n state__004_ 1) t_2__008_
+    let precond cmd__014_ state__015_ =
+      match cmd__014_ with | Empty () -> true | Add (a_1, b_1) -> true
     let postcond _ _ _ = true
-    let run cmd__015_ sut__016_ =
-      match cmd__015_ with
+    let run cmd__016_ sut__017_ =
+      match cmd__016_ with
       | Empty () ->
           Res
             (sut,
-              (let res__017_ = empty () in
-               (SUT.push sut__016_ res__017_; res__017_)))
+              (let res__018_ = empty () in
+               (SUT.push sut__017_ res__018_; res__018_)))
       | Add (a_1, b_1) ->
           Res
             (unit,
-              (let t_2__018_ = SUT.pop sut__016_ in
-               let res__019_ = add t_2__018_ a_1 b_1 in
-               (SUT.push sut__016_ t_2__018_; res__019_)))
+              (let t_2__019_ = SUT.pop sut__017_ in
+               let res__020_ = add t_2__019_ a_1 b_1 in
+               (SUT.push sut__017_ t_2__019_; res__020_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__021_ state__022_ last__024_ res__023_ =
+let ortac_show_cmd cmd__022_ state__023_ last__025_ res__024_ =
   let open Spec in
     let open STM in
-      match (cmd__021_, res__023_) with
+      match (cmd__022_, res__024_) with
       | (Empty (), Res ((SUT, _), t_1)) ->
-          let lhs = if last__024_ then "r" else SUT.get_name state__022_ 0
+          let lhs = if last__025_ then "r" else SUT.get_name state__023_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "empty" (Util.Pp.pp_unit true)
             ()
       | (Add (a_1, b_1), Res ((Unit, _), _)) ->
-          let lhs = if last__024_ then "r" else "_"
+          let lhs = if last__025_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a %a" lhs "add"
-            (SUT.get_name state__022_ (0 + shift)) (Util.Pp.pp_char true) a_1
+            (SUT.get_name state__023_ (0 + shift)) (Util.Pp.pp_char true) a_1
             (Util.Pp.pp_int true) b_1
       | _ -> assert false
-let ortac_postcond cmd__008_ state__009_ res__010_ =
+let ortac_postcond cmd__009_ state__010_ res__011_ =
   let open Spec in
     let open STM in
-      let new_state__011_ = lazy (next_state cmd__008_ state__009_) in
-      match (cmd__008_, res__010_) with
+      let new_state__012_ = lazy (next_state cmd__009_ state__010_) in
+      match (cmd__009_, res__011_) with
       | (Empty (), Res ((SUT, _), t_1)) -> None
       | (Add (a_1, b_1), Res ((Unit, _), _)) -> None
       | _ -> None

--- a/plugins/qcheck-stm/test/ghost_as_model_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/ghost_as_model_stm_tests.expected.ml
@@ -62,16 +62,23 @@ module Spec =
       | Create () ->
           Format.asprintf "%s %a" "create" (Util.Pp.pp_unit true) ()
       | Use -> Format.asprintf "%s <sut>" "use"
+    let shrink_cmd cmd__002_ =
+      let open QCheck in
+        let open Shrink in
+          let open Iter in
+            match cmd__002_ with
+            | Create () -> map (fun () -> Create ()) (unit ())
+            | Use -> empty
     let cleanup _ = ()
     let arb_cmd _ =
       let open QCheck in
-        make ~print:show_cmd
+        make ~print:show_cmd ~shrink:shrink_cmd
           (let open Gen in
              oneof [(pure (fun () -> Create ())) <*> unit; pure Use])
-    let next_state cmd__002_ state__003_ =
-      match cmd__002_ with
+    let next_state cmd__003_ state__004_ =
+      match cmd__003_ with
       | Create () ->
-          let t_1__005_ =
+          let t_1__006_ =
             let open ModelElt in
               {
                 m_1 =
@@ -98,15 +105,15 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 0) t_1__005_
+          Model.push (Model.drop_n state__004_ 0) t_1__006_
       | Use ->
-          let t_2__006_ = Model.get state__003_ 0 in
-          let t_2__007_ =
+          let t_2__007_ = Model.get state__004_ 0 in
+          let t_2__008_ =
             let open ModelElt in
               {
                 m_1 =
                   (try
-                     match t_2__006_.m_1 with
+                     match t_2__007_.m_1 with
                      | A x -> A (Ortac_runtime.Gospelstdlib.succ x)
                    with
                    | e ->
@@ -130,46 +137,46 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) t_2__007_
-    let precond cmd__013_ state__014_ =
-      match cmd__013_ with | Create () -> true | Use -> true
+          Model.push (Model.drop_n state__004_ 1) t_2__008_
+    let precond cmd__014_ state__015_ =
+      match cmd__014_ with | Create () -> true | Use -> true
     let postcond _ _ _ = true
-    let run cmd__015_ sut__016_ =
-      match cmd__015_ with
+    let run cmd__016_ sut__017_ =
+      match cmd__016_ with
       | Create () ->
           Res
             (sut,
-              (let res__017_ = create () in
-               (SUT.push sut__016_ res__017_; res__017_)))
+              (let res__018_ = create () in
+               (SUT.push sut__017_ res__018_; res__018_)))
       | Use ->
           Res
             (unit,
-              (let t_2__018_ = SUT.pop sut__016_ in
-               let res__019_ = use t_2__018_ in
-               (SUT.push sut__016_ t_2__018_; res__019_)))
+              (let t_2__019_ = SUT.pop sut__017_ in
+               let res__020_ = use t_2__019_ in
+               (SUT.push sut__017_ t_2__019_; res__020_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__021_ state__022_ last__024_ res__023_ =
+let ortac_show_cmd cmd__022_ state__023_ last__025_ res__024_ =
   let open Spec in
     let open STM in
-      match (cmd__021_, res__023_) with
+      match (cmd__022_, res__024_) with
       | (Create (), Res ((SUT, _), t_1)) ->
-          let lhs = if last__024_ then "r" else SUT.get_name state__022_ 0
+          let lhs = if last__025_ then "r" else SUT.get_name state__023_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "create"
             (Util.Pp.pp_unit true) ()
       | (Use, Res ((Unit, _), _)) ->
-          let lhs = if last__024_ then "r" else "_"
+          let lhs = if last__025_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "use"
-            (SUT.get_name state__022_ (0 + shift))
+            (SUT.get_name state__023_ (0 + shift))
       | _ -> assert false
-let ortac_postcond cmd__008_ state__009_ res__010_ =
+let ortac_postcond cmd__009_ state__010_ res__011_ =
   let open Spec in
     let open STM in
-      let new_state__011_ = lazy (next_state cmd__008_ state__009_) in
-      match (cmd__008_, res__010_) with
+      let new_state__012_ = lazy (next_state cmd__009_ state__010_) in
+      match (cmd__009_, res__011_) with
       | (Create (), Res ((SUT, _), t_1)) -> None
       | (Use, Res ((Unit, _), _)) -> None
       | _ -> None

--- a/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
@@ -121,10 +121,33 @@ module Spec =
           Format.asprintf "%s <sut> %a %a" "replace" (Util.Pp.pp_char true)
             a_8 (Util.Pp.pp_int true) b_3
       | Length -> Format.asprintf "%s <sut>" "length"
+    let shrink_cmd cmd__002_ =
+      let open QCheck in
+        let open Shrink in
+          let open Iter in
+            match cmd__002_ with
+            | Create (random, size) ->
+                (map (fun random -> Create (random, size)) (nil random)) <+>
+                  (map (fun size -> Create (random, size)) (int size))
+            | Clear -> empty
+            | Reset -> empty
+            | Copy -> empty
+            | Add (a_2, b_2) ->
+                (map (fun a_2 -> Add (a_2, b_2)) (char a_2)) <+>
+                  (map (fun b_2 -> Add (a_2, b_2)) (int b_2))
+            | Find a_3 -> map (fun a_3 -> Find a_3) (char a_3)
+            | Find_opt a_4 -> map (fun a_4 -> Find_opt a_4) (char a_4)
+            | Find_all a_5 -> map (fun a_5 -> Find_all a_5) (char a_5)
+            | Mem a_6 -> map (fun a_6 -> Mem a_6) (char a_6)
+            | Remove a_7 -> map (fun a_7 -> Remove a_7) (char a_7)
+            | Replace (a_8, b_3) ->
+                (map (fun a_8 -> Replace (a_8, b_3)) (char a_8)) <+>
+                  (map (fun b_3 -> Replace (a_8, b_3)) (int b_3))
+            | Length -> empty
     let cleanup _ = ()
     let arb_cmd _ =
       let open QCheck in
-        make ~print:show_cmd
+        make ~print:show_cmd ~shrink:shrink_cmd
           (let open Gen in
              oneof
                [((pure (fun random -> fun size -> Create (random, size))) <*>
@@ -143,10 +166,10 @@ module Spec =
                ((pure (fun a_8 -> fun b_3 -> Replace (a_8, b_3))) <*> char)
                  <*> int;
                pure Length])
-    let next_state cmd__002_ state__003_ =
-      match cmd__002_ with
+    let next_state cmd__003_ state__004_ =
+      match cmd__003_ with
       | Create (random, size) ->
-          let h__005_ =
+          let h__006_ =
             let open ModelElt in
               {
                 contents =
@@ -173,10 +196,10 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 0) h__005_
+          Model.push (Model.drop_n state__004_ 0) h__006_
       | Clear ->
-          let h_1__006_ = Model.get state__003_ 0 in
-          let h_1__007_ =
+          let h_1__007_ = Model.get state__004_ 0 in
+          let h_1__008_ =
             let open ModelElt in
               {
                 contents =
@@ -203,10 +226,10 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) h_1__007_
+          Model.push (Model.drop_n state__004_ 1) h_1__008_
       | Reset ->
-          let h_2__008_ = Model.get state__003_ 0 in
-          let h_2__009_ =
+          let h_2__009_ = Model.get state__004_ 0 in
+          let h_2__010_ =
             let open ModelElt in
               {
                 contents =
@@ -233,14 +256,14 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) h_2__009_
+          Model.push (Model.drop_n state__004_ 1) h_2__010_
       | Copy ->
-          let h1__010_ = Model.get state__003_ 0 in
-          let h2__013_ =
+          let h1__011_ = Model.get state__004_ 0 in
+          let h2__014_ =
             let open ModelElt in
               {
                 contents =
-                  (try h1__010_.contents
+                  (try h1__011_.contents
                    with
                    | e ->
                        raise
@@ -263,16 +286,16 @@ module Spec =
                                   }
                               })))
               }
-          and h1__012_ = h1__010_ in
-          Model.push (Model.push (Model.drop_n state__003_ 1) h1__012_)
-            h2__013_
+          and h1__013_ = h1__011_ in
+          Model.push (Model.push (Model.drop_n state__004_ 1) h1__013_)
+            h2__014_
       | Add (a_2, b_2) ->
-          let h_3__014_ = Model.get state__003_ 0 in
-          let h_3__015_ =
+          let h_3__015_ = Model.get state__004_ 0 in
+          let h_3__016_ =
             let open ModelElt in
               {
                 contents =
-                  (try (a_2, b_2) :: h_3__014_.contents
+                  (try (a_2, b_2) :: h_3__015_.contents
                    with
                    | e ->
                        raise
@@ -295,30 +318,30 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) h_3__015_
+          Model.push (Model.drop_n state__004_ 1) h_3__016_
       | Find a_3 ->
-          let h_4__016_ = Model.get state__003_ 0 in
-          let h_4__017_ = h_4__016_ in
-          Model.push (Model.drop_n state__003_ 1) h_4__017_
+          let h_4__017_ = Model.get state__004_ 0 in
+          let h_4__018_ = h_4__017_ in
+          Model.push (Model.drop_n state__004_ 1) h_4__018_
       | Find_opt a_4 ->
-          let h_5__018_ = Model.get state__003_ 0 in
-          let h_5__019_ = h_5__018_ in
-          Model.push (Model.drop_n state__003_ 1) h_5__019_
+          let h_5__019_ = Model.get state__004_ 0 in
+          let h_5__020_ = h_5__019_ in
+          Model.push (Model.drop_n state__004_ 1) h_5__020_
       | Find_all a_5 ->
-          let h_6__020_ = Model.get state__003_ 0 in
-          let h_6__021_ = h_6__020_ in
-          Model.push (Model.drop_n state__003_ 1) h_6__021_
+          let h_6__021_ = Model.get state__004_ 0 in
+          let h_6__022_ = h_6__021_ in
+          Model.push (Model.drop_n state__004_ 1) h_6__022_
       | Mem a_6 ->
-          let h_7__022_ = Model.get state__003_ 0 in
-          let h_7__023_ = h_7__022_ in
-          Model.push (Model.drop_n state__003_ 1) h_7__023_
+          let h_7__023_ = Model.get state__004_ 0 in
+          let h_7__024_ = h_7__023_ in
+          Model.push (Model.drop_n state__004_ 1) h_7__024_
       | Remove a_7 ->
-          let h_8__024_ = Model.get state__003_ 0 in
-          let h_8__025_ =
+          let h_8__025_ = Model.get state__004_ 0 in
+          let h_8__026_ =
             let open ModelElt in
               {
                 contents =
-                  (try remove_first a_7 h_8__024_.contents
+                  (try remove_first a_7 h_8__025_.contents
                    with
                    | e ->
                        raise
@@ -341,14 +364,14 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) h_8__025_
+          Model.push (Model.drop_n state__004_ 1) h_8__026_
       | Replace (a_8, b_3) ->
-          let h_9__026_ = Model.get state__003_ 0 in
-          let h_9__027_ =
+          let h_9__027_ = Model.get state__004_ 0 in
+          let h_9__028_ =
             let open ModelElt in
               {
                 contents =
-                  (try (a_8, b_3) :: (remove_first a_8 h_9__026_.contents)
+                  (try (a_8, b_3) :: (remove_first a_8 h_9__027_.contents)
                    with
                    | e ->
                        raise
@@ -371,13 +394,13 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) h_9__027_
+          Model.push (Model.drop_n state__004_ 1) h_9__028_
       | Length ->
-          let h_10__028_ = Model.get state__003_ 0 in
-          let h_10__029_ = h_10__028_ in
-          Model.push (Model.drop_n state__003_ 1) h_10__029_
-    let precond cmd__061_ state__062_ =
-      match cmd__061_ with
+          let h_10__029_ = Model.get state__004_ 0 in
+          let h_10__030_ = h_10__029_ in
+          Model.push (Model.drop_n state__004_ 1) h_10__030_
+    let precond cmd__062_ state__063_ =
+      match cmd__062_ with
       | Create (random, size) -> true
       | Clear -> true
       | Reset -> true
@@ -391,156 +414,156 @@ module Spec =
       | Replace (a_8, b_3) -> true
       | Length -> true
     let postcond _ _ _ = true
-    let run cmd__063_ sut__064_ =
-      match cmd__063_ with
+    let run cmd__064_ sut__065_ =
+      match cmd__064_ with
       | Create (random, size) ->
           Res
             (sut,
-              (let res__065_ = create ~random size in
-               (SUT.push sut__064_ res__065_; res__065_)))
+              (let res__066_ = create ~random size in
+               (SUT.push sut__065_ res__066_; res__066_)))
       | Clear ->
           Res
             (unit,
-              (let h_1__066_ = SUT.pop sut__064_ in
-               let res__067_ = clear h_1__066_ in
-               (SUT.push sut__064_ h_1__066_; res__067_)))
+              (let h_1__067_ = SUT.pop sut__065_ in
+               let res__068_ = clear h_1__067_ in
+               (SUT.push sut__065_ h_1__067_; res__068_)))
       | Reset ->
           Res
             (unit,
-              (let h_2__068_ = SUT.pop sut__064_ in
-               let res__069_ = reset h_2__068_ in
-               (SUT.push sut__064_ h_2__068_; res__069_)))
+              (let h_2__069_ = SUT.pop sut__065_ in
+               let res__070_ = reset h_2__069_ in
+               (SUT.push sut__065_ h_2__069_; res__070_)))
       | Copy ->
           Res
             (sut,
-              (let h1__070_ = SUT.pop sut__064_ in
-               let res__071_ = copy h1__070_ in
-               (SUT.push sut__064_ h1__070_;
-                SUT.push sut__064_ res__071_;
-                res__071_)))
+              (let h1__071_ = SUT.pop sut__065_ in
+               let res__072_ = copy h1__071_ in
+               (SUT.push sut__065_ h1__071_;
+                SUT.push sut__065_ res__072_;
+                res__072_)))
       | Add (a_2, b_2) ->
           Res
             (unit,
-              (let h_3__072_ = SUT.pop sut__064_ in
-               let res__073_ = add h_3__072_ a_2 b_2 in
-               (SUT.push sut__064_ h_3__072_; res__073_)))
+              (let h_3__073_ = SUT.pop sut__065_ in
+               let res__074_ = add h_3__073_ a_2 b_2 in
+               (SUT.push sut__065_ h_3__073_; res__074_)))
       | Find a_3 ->
           Res
             ((result int exn),
-              (let h_4__074_ = SUT.pop sut__064_ in
-               let res__075_ = protect (fun () -> find h_4__074_ a_3) () in
-               (SUT.push sut__064_ h_4__074_; res__075_)))
+              (let h_4__075_ = SUT.pop sut__065_ in
+               let res__076_ = protect (fun () -> find h_4__075_ a_3) () in
+               (SUT.push sut__065_ h_4__075_; res__076_)))
       | Find_opt a_4 ->
           Res
             ((option int),
-              (let h_5__076_ = SUT.pop sut__064_ in
-               let res__077_ = find_opt h_5__076_ a_4 in
-               (SUT.push sut__064_ h_5__076_; res__077_)))
+              (let h_5__077_ = SUT.pop sut__065_ in
+               let res__078_ = find_opt h_5__077_ a_4 in
+               (SUT.push sut__065_ h_5__077_; res__078_)))
       | Find_all a_5 ->
           Res
             ((list int),
-              (let h_6__078_ = SUT.pop sut__064_ in
-               let res__079_ = find_all h_6__078_ a_5 in
-               (SUT.push sut__064_ h_6__078_; res__079_)))
+              (let h_6__079_ = SUT.pop sut__065_ in
+               let res__080_ = find_all h_6__079_ a_5 in
+               (SUT.push sut__065_ h_6__079_; res__080_)))
       | Mem a_6 ->
           Res
             (bool,
-              (let h_7__080_ = SUT.pop sut__064_ in
-               let res__081_ = mem h_7__080_ a_6 in
-               (SUT.push sut__064_ h_7__080_; res__081_)))
+              (let h_7__081_ = SUT.pop sut__065_ in
+               let res__082_ = mem h_7__081_ a_6 in
+               (SUT.push sut__065_ h_7__081_; res__082_)))
       | Remove a_7 ->
           Res
             (unit,
-              (let h_8__082_ = SUT.pop sut__064_ in
-               let res__083_ = remove h_8__082_ a_7 in
-               (SUT.push sut__064_ h_8__082_; res__083_)))
+              (let h_8__083_ = SUT.pop sut__065_ in
+               let res__084_ = remove h_8__083_ a_7 in
+               (SUT.push sut__065_ h_8__083_; res__084_)))
       | Replace (a_8, b_3) ->
           Res
             (unit,
-              (let h_9__084_ = SUT.pop sut__064_ in
-               let res__085_ = replace h_9__084_ a_8 b_3 in
-               (SUT.push sut__064_ h_9__084_; res__085_)))
+              (let h_9__085_ = SUT.pop sut__065_ in
+               let res__086_ = replace h_9__085_ a_8 b_3 in
+               (SUT.push sut__065_ h_9__085_; res__086_)))
       | Length ->
           Res
             (int,
-              (let h_10__086_ = SUT.pop sut__064_ in
-               let res__087_ = length h_10__086_ in
-               (SUT.push sut__064_ h_10__086_; res__087_)))
+              (let h_10__087_ = SUT.pop sut__065_ in
+               let res__088_ = length h_10__087_ in
+               (SUT.push sut__065_ h_10__087_; res__088_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__089_ state__090_ last__092_ res__091_ =
+let ortac_show_cmd cmd__090_ state__091_ last__093_ res__092_ =
   let open Spec in
     let open STM in
-      match (cmd__089_, res__091_) with
+      match (cmd__090_, res__092_) with
       | (Create (random, size), Res ((SUT, _), h)) ->
-          let lhs = if last__092_ then "r" else SUT.get_name state__090_ 0
+          let lhs = if last__093_ then "r" else SUT.get_name state__091_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a %a" lhs "create"
             (Util.Pp.pp_bool true) random (Util.Pp.pp_int true) size
       | (Clear, Res ((Unit, _), _)) ->
-          let lhs = if last__092_ then "r" else "_"
+          let lhs = if last__093_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "clear"
-            (SUT.get_name state__090_ (0 + shift))
+            (SUT.get_name state__091_ (0 + shift))
       | (Reset, Res ((Unit, _), _)) ->
-          let lhs = if last__092_ then "r" else "_"
+          let lhs = if last__093_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "reset"
-            (SUT.get_name state__090_ (0 + shift))
+            (SUT.get_name state__091_ (0 + shift))
       | (Copy, Res ((SUT, _), h2)) ->
-          let lhs = if last__092_ then "r" else SUT.get_name state__090_ 0
+          let lhs = if last__093_ then "r" else SUT.get_name state__091_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s" lhs "copy"
-            (SUT.get_name state__090_ (0 + shift))
+            (SUT.get_name state__091_ (0 + shift))
       | (Add (a_2, b_2), Res ((Unit, _), _)) ->
-          let lhs = if last__092_ then "r" else "_"
+          let lhs = if last__093_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a %a" lhs "add"
-            (SUT.get_name state__090_ (0 + shift)) (Util.Pp.pp_char true) a_2
+            (SUT.get_name state__091_ (0 + shift)) (Util.Pp.pp_char true) a_2
             (Util.Pp.pp_int true) b_2
       | (Find a_3, Res ((Result (Int, Exn), _), _)) ->
-          let lhs = if last__092_ then "r" else "_"
+          let lhs = if last__093_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a)" lhs "find"
-            (SUT.get_name state__090_ (0 + shift)) (Util.Pp.pp_char true) a_3
+            (SUT.get_name state__091_ (0 + shift)) (Util.Pp.pp_char true) a_3
       | (Find_opt a_4, Res ((Option (Int), _), _)) ->
-          let lhs = if last__092_ then "r" else "_"
+          let lhs = if last__093_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "find_opt"
-            (SUT.get_name state__090_ (0 + shift)) (Util.Pp.pp_char true) a_4
+            (SUT.get_name state__091_ (0 + shift)) (Util.Pp.pp_char true) a_4
       | (Find_all a_5, Res ((List (Int), _), _)) ->
-          let lhs = if last__092_ then "r" else "_"
+          let lhs = if last__093_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "find_all"
-            (SUT.get_name state__090_ (0 + shift)) (Util.Pp.pp_char true) a_5
+            (SUT.get_name state__091_ (0 + shift)) (Util.Pp.pp_char true) a_5
       | (Mem a_6, Res ((Bool, _), _)) ->
-          let lhs = if last__092_ then "r" else "_"
+          let lhs = if last__093_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "mem"
-            (SUT.get_name state__090_ (0 + shift)) (Util.Pp.pp_char true) a_6
+            (SUT.get_name state__091_ (0 + shift)) (Util.Pp.pp_char true) a_6
       | (Remove a_7, Res ((Unit, _), _)) ->
-          let lhs = if last__092_ then "r" else "_"
+          let lhs = if last__093_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "remove"
-            (SUT.get_name state__090_ (0 + shift)) (Util.Pp.pp_char true) a_7
+            (SUT.get_name state__091_ (0 + shift)) (Util.Pp.pp_char true) a_7
       | (Replace (a_8, b_3), Res ((Unit, _), _)) ->
-          let lhs = if last__092_ then "r" else "_"
+          let lhs = if last__093_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a %a" lhs "replace"
-            (SUT.get_name state__090_ (0 + shift)) (Util.Pp.pp_char true) a_8
+            (SUT.get_name state__091_ (0 + shift)) (Util.Pp.pp_char true) a_8
             (Util.Pp.pp_int true) b_3
       | (Length, Res ((Int, _), _)) ->
-          let lhs = if last__092_ then "r" else "_"
+          let lhs = if last__093_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "length"
-            (SUT.get_name state__090_ (0 + shift))
+            (SUT.get_name state__091_ (0 + shift))
       | _ -> assert false
-let ortac_postcond cmd__030_ state__031_ res__032_ =
+let ortac_postcond cmd__031_ state__032_ res__033_ =
   let open Spec in
     let open STM in
-      let new_state__033_ = lazy (next_state cmd__030_ state__031_) in
-      match (cmd__030_, res__032_) with
+      let new_state__034_ = lazy (next_state cmd__031_ state__032_) in
+      match (cmd__031_, res__033_) with
       | (Create (random, size), Res ((SUT, _), h)) -> None
       | (Clear, Res ((Unit, _), _)) -> None
       | (Reset, Res ((Unit, _), _)) -> None
@@ -550,12 +573,12 @@ let ortac_postcond cmd__030_ state__031_ res__032_ =
           (match b_4 with
            | Ok b_4 ->
                if
-                 let h_old__038_ = Model.get state__031_ 0
-                 and h_new__039_ =
-                   lazy (Model.get (Lazy.force new_state__033_) 0) in
+                 let h_old__039_ = Model.get state__032_ 0
+                 and h_new__040_ =
+                   lazy (Model.get (Lazy.force new_state__034_) 0) in
                  (try
                     Ortac_runtime.Gospelstdlib.List.mem (a_3, b_4)
-                      (Lazy.force h_new__039_).contents
+                      (Lazy.force h_new__040_).contents
                   with
                   | e ->
                       raise
@@ -602,15 +625,15 @@ let ortac_postcond cmd__030_ state__031_ res__032_ =
                          })])
            | Error (Not_found) ->
                if
-                 let h_old__042_ = Model.get state__031_ 0
-                 and h_new__043_ =
-                   lazy (Model.get (Lazy.force new_state__033_) 0) in
+                 let h_old__043_ = Model.get state__032_ 0
+                 and h_new__044_ =
+                   lazy (Model.get (Lazy.force new_state__034_) 0) in
                  (try
                     not
                       (Ortac_runtime.Gospelstdlib.List.mem a_3
                          (Ortac_runtime.Gospelstdlib.List.map
                             Ortac_runtime.Gospelstdlib.fst
-                            (Lazy.force h_new__043_).contents))
+                            (Lazy.force h_new__044_).contents))
                   with
                   | e ->
                       raise
@@ -657,8 +680,8 @@ let ortac_postcond cmd__030_ state__031_ res__032_ =
            | _ -> None)
       | (Find_opt a_4, Res ((Option (Int), _), o)) ->
           if
-            let h_old__045_ = Model.get state__031_ 0
-            and h_new__046_ = lazy (Model.get (Lazy.force new_state__033_) 0) in
+            let h_old__046_ = Model.get state__032_ 0
+            and h_new__047_ = lazy (Model.get (Lazy.force new_state__034_) 0) in
             (try
                (match o with
                 | None ->
@@ -667,13 +690,13 @@ let ortac_postcond cmd__030_ state__031_ res__032_ =
                         (Ortac_runtime.Gospelstdlib.List.mem a_4
                            (Ortac_runtime.Gospelstdlib.List.map
                               Ortac_runtime.Gospelstdlib.fst
-                              (Lazy.force h_new__046_).contents))
+                              (Lazy.force h_new__047_).contents))
                     then true
                     else false
                 | Some b_5 ->
                     if
                       Ortac_runtime.Gospelstdlib.List.mem (a_4, b_5)
-                        (Lazy.force h_new__046_).contents
+                        (Lazy.force h_new__047_).contents
                     then true
                     else false)
                  = true
@@ -723,14 +746,14 @@ let ortac_postcond cmd__030_ state__031_ res__032_ =
                     })])
       | (Find_all a_5, Res ((List (Int), _), bs)) ->
           if
-            let h_old__048_ = Model.get state__031_ 0
-            and h_new__049_ = lazy (Model.get (Lazy.force new_state__033_) 0) in
+            let h_old__049_ = Model.get state__032_ 0
+            and h_new__050_ = lazy (Model.get (Lazy.force new_state__034_) 0) in
             (try
                (Ortac_runtime.Gospelstdlib.List.to_seq bs) =
                  (Ortac_runtime.Gospelstdlib.Sequence.filter_map
                     (fun (x_1, y) -> if x_1 = a_5 then Some y else None)
                     (Ortac_runtime.Gospelstdlib.List.to_seq
-                       (Lazy.force h_new__049_).contents))
+                       (Lazy.force h_new__050_).contents))
              with
              | e ->
                  raise
@@ -777,14 +800,14 @@ let ortac_postcond cmd__030_ state__031_ res__032_ =
                     })])
       | (Mem a_6, Res ((Bool, _), b_6)) ->
           if
-            let h_old__051_ = Model.get state__031_ 0
-            and h_new__052_ = lazy (Model.get (Lazy.force new_state__033_) 0) in
+            let h_old__052_ = Model.get state__032_ 0
+            and h_new__053_ = lazy (Model.get (Lazy.force new_state__034_) 0) in
             (try
                (b_6 = true) =
                  (Ortac_runtime.Gospelstdlib.List.mem a_6
                     (Ortac_runtime.Gospelstdlib.List.map
                        Ortac_runtime.Gospelstdlib.fst
-                       (Lazy.force h_new__052_).contents))
+                       (Lazy.force h_new__053_).contents))
              with
              | e ->
                  raise
@@ -832,12 +855,12 @@ let ortac_postcond cmd__030_ state__031_ res__032_ =
       | (Replace (a_8, b_3), Res ((Unit, _), _)) -> None
       | (Length, Res ((Int, _), i)) ->
           if
-            let h_old__058_ = Model.get state__031_ 0
-            and h_new__059_ = lazy (Model.get (Lazy.force new_state__033_) 0) in
+            let h_old__059_ = Model.get state__032_ 0
+            and h_new__060_ = lazy (Model.get (Lazy.force new_state__034_) 0) in
             (try
                (Ortac_runtime.Gospelstdlib.integer_of_int i) =
                  (Ortac_runtime.Gospelstdlib.List.length
-                    (Lazy.force h_new__059_).contents)
+                    (Lazy.force h_new__060_).contents)
              with
              | e ->
                  raise
@@ -866,12 +889,12 @@ let ortac_postcond cmd__030_ state__031_ res__032_ =
                  (Ortac_runtime.Value
                     (Res
                        (integer,
-                         (let h_old__056_ = Model.get state__031_ 0
-                          and h_new__057_ =
-                            lazy (Model.get (Lazy.force new_state__033_) 0) in
+                         (let h_old__057_ = Model.get state__032_ 0
+                          and h_new__058_ =
+                            lazy (Model.get (Lazy.force new_state__034_) 0) in
                           try
                             Ortac_runtime.Gospelstdlib.List.length
-                              (Lazy.force h_new__057_).contents
+                              (Lazy.force h_new__058_).contents
                           with
                           | e ->
                               raise

--- a/plugins/qcheck-stm/test/integer_in_model_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/integer_in_model_stm_tests.expected.ml
@@ -60,16 +60,23 @@ module Spec =
       | Create () ->
           Format.asprintf "%s %a" "create" (Util.Pp.pp_unit true) ()
       | Use -> Format.asprintf "%s <sut>" "use"
+    let shrink_cmd cmd__002_ =
+      let open QCheck in
+        let open Shrink in
+          let open Iter in
+            match cmd__002_ with
+            | Create () -> map (fun () -> Create ()) (unit ())
+            | Use -> empty
     let cleanup _ = ()
     let arb_cmd _ =
       let open QCheck in
-        make ~print:show_cmd
+        make ~print:show_cmd ~shrink:shrink_cmd
           (let open Gen in
              oneof [(pure (fun () -> Create ())) <*> unit; pure Use])
-    let next_state cmd__002_ state__003_ =
-      match cmd__002_ with
+    let next_state cmd__003_ state__004_ =
+      match cmd__003_ with
       | Create () ->
-          let t_1__005_ =
+          let t_1__006_ =
             let open ModelElt in
               {
                 i =
@@ -96,14 +103,14 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 0) t_1__005_
+          Model.push (Model.drop_n state__004_ 0) t_1__006_
       | Use ->
-          let t_2__006_ = Model.get state__003_ 0 in
-          let t_2__007_ =
+          let t_2__007_ = Model.get state__004_ 0 in
+          let t_2__008_ =
             let open ModelElt in
               {
                 i =
-                  (try Ortac_runtime.Gospelstdlib.succ t_2__006_.i
+                  (try Ortac_runtime.Gospelstdlib.succ t_2__007_.i
                    with
                    | e ->
                        raise
@@ -126,46 +133,46 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) t_2__007_
-    let precond cmd__013_ state__014_ =
-      match cmd__013_ with | Create () -> true | Use -> true
+          Model.push (Model.drop_n state__004_ 1) t_2__008_
+    let precond cmd__014_ state__015_ =
+      match cmd__014_ with | Create () -> true | Use -> true
     let postcond _ _ _ = true
-    let run cmd__015_ sut__016_ =
-      match cmd__015_ with
+    let run cmd__016_ sut__017_ =
+      match cmd__016_ with
       | Create () ->
           Res
             (sut,
-              (let res__017_ = create () in
-               (SUT.push sut__016_ res__017_; res__017_)))
+              (let res__018_ = create () in
+               (SUT.push sut__017_ res__018_; res__018_)))
       | Use ->
           Res
             (unit,
-              (let t_2__018_ = SUT.pop sut__016_ in
-               let res__019_ = use t_2__018_ in
-               (SUT.push sut__016_ t_2__018_; res__019_)))
+              (let t_2__019_ = SUT.pop sut__017_ in
+               let res__020_ = use t_2__019_ in
+               (SUT.push sut__017_ t_2__019_; res__020_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__021_ state__022_ last__024_ res__023_ =
+let ortac_show_cmd cmd__022_ state__023_ last__025_ res__024_ =
   let open Spec in
     let open STM in
-      match (cmd__021_, res__023_) with
+      match (cmd__022_, res__024_) with
       | (Create (), Res ((SUT, _), t_1)) ->
-          let lhs = if last__024_ then "r" else SUT.get_name state__022_ 0
+          let lhs = if last__025_ then "r" else SUT.get_name state__023_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "create"
             (Util.Pp.pp_unit true) ()
       | (Use, Res ((Unit, _), _)) ->
-          let lhs = if last__024_ then "r" else "_"
+          let lhs = if last__025_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "use"
-            (SUT.get_name state__022_ (0 + shift))
+            (SUT.get_name state__023_ (0 + shift))
       | _ -> assert false
-let ortac_postcond cmd__008_ state__009_ res__010_ =
+let ortac_postcond cmd__009_ state__010_ res__011_ =
   let open Spec in
     let open STM in
-      let new_state__011_ = lazy (next_state cmd__008_ state__009_) in
-      match (cmd__008_, res__010_) with
+      let new_state__012_ = lazy (next_state cmd__009_ state__010_) in
+      match (cmd__009_, res__011_) with
       | (Create (), Res ((SUT, _), t_1)) -> None
       | (Use, Res ((Unit, _), _)) -> None
       | _ -> None

--- a/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
@@ -69,10 +69,22 @@ module Spec =
       | Sub (i, n) ->
           Format.asprintf "protect (fun () -> %s <sut> %a %a)" "sub"
             (Util.Pp.pp_int true) i (Util.Pp.pp_int true) n
+    let shrink_cmd cmd__002_ =
+      let open QCheck in
+        let open Shrink in
+          let open Iter in
+            match cmd__002_ with
+            | Create a_1 -> map (fun a_1 -> Create a_1) (int a_1)
+            | Push a_2 -> map (fun a_2 -> Push a_2) (int a_2)
+            | Transfer -> empty
+            | Copy -> empty
+            | Sub (i, n) ->
+                (map (fun i -> Sub (i, n)) (int i)) <+>
+                  (map (fun n -> Sub (i, n)) (int n))
     let cleanup _ = ()
     let arb_cmd _ =
       let open QCheck in
-        make ~print:show_cmd
+        make ~print:show_cmd ~shrink:shrink_cmd
           (let open Gen in
              oneof
                [(pure (fun a_1 -> Create a_1)) <*> small_signed_int;
@@ -80,10 +92,10 @@ module Spec =
                pure Transfer;
                pure Copy;
                ((pure (fun i -> fun n -> Sub (i, n))) <*> int) <*> int])
-    let next_state cmd__002_ state__003_ =
-      match cmd__002_ with
+    let next_state cmd__003_ state__004_ =
+      match cmd__003_ with
       | Create a_1 ->
-          let t_1__005_ =
+          let t_1__006_ =
             let open ModelElt in
               {
                 contents =
@@ -110,16 +122,16 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 0) t_1__005_
+          Model.push (Model.drop_n state__004_ 0) t_1__006_
       | Push a_2 ->
-          let t_2__006_ = Model.get state__003_ 0 in
-          let t_2__007_ =
+          let t_2__007_ = Model.get state__004_ 0 in
+          let t_2__008_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      Ortac_runtime.Gospelstdlib.Sequence.cons a_2
-                       t_2__006_.contents
+                       t_2__007_.contents
                    with
                    | e ->
                        raise
@@ -142,18 +154,18 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) t_2__007_
+          Model.push (Model.drop_n state__004_ 1) t_2__008_
       | Transfer ->
-          let t1__008_ = Model.get state__003_ 0
-          and t2__009_ = Model.get state__003_ 1 in
-          let t1__011_ =
+          let t1__009_ = Model.get state__004_ 0
+          and t2__010_ = Model.get state__004_ 1 in
+          let t1__012_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      Ortac_runtime.Gospelstdlib.Sequence.singleton
                        (Ortac_runtime.Gospelstdlib.Sequence.hd
-                          t1__008_.contents)
+                          t1__009_.contents)
                    with
                    | e ->
                        raise
@@ -176,14 +188,14 @@ module Spec =
                                   }
                               })))
               }
-          and t2__010_ =
+          and t2__011_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      Ortac_runtime.Gospelstdlib.(++)
                        (Ortac_runtime.Gospelstdlib.Sequence.tl
-                          t1__008_.contents) t2__009_.contents
+                          t1__009_.contents) t2__010_.contents
                    with
                    | e ->
                        raise
@@ -206,15 +218,15 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.push (Model.drop_n state__003_ 2) t2__010_)
-            t1__011_
+          Model.push (Model.push (Model.drop_n state__004_ 2) t2__011_)
+            t1__012_
       | Copy ->
-          let t_3__012_ = Model.get state__003_ 0 in
-          let r__015_ =
+          let t_3__013_ = Model.get state__004_ 0 in
+          let r__016_ =
             let open ModelElt in
               {
                 contents =
-                  (try t_3__012_.contents
+                  (try t_3__013_.contents
                    with
                    | e ->
                        raise
@@ -237,23 +249,23 @@ module Spec =
                                   }
                               })))
               }
-          and t_3__014_ = t_3__012_ in
-          Model.push (Model.push (Model.drop_n state__003_ 1) t_3__014_)
-            r__015_
+          and t_3__015_ = t_3__013_ in
+          Model.push (Model.push (Model.drop_n state__004_ 1) t_3__015_)
+            r__016_
       | Sub (i, n) ->
-          let t_4__016_ = Model.get state__003_ 0 in
+          let t_4__017_ = Model.get state__004_ 0 in
           if
             (try
-               let __t1__020_ =
+               let __t1__021_ =
                  Ortac_runtime.Gospelstdlib.(<=)
                    (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                    (Ortac_runtime.Gospelstdlib.integer_of_int i) in
-               let __t2__021_ =
+               let __t2__022_ =
                  Ortac_runtime.Gospelstdlib.(<=)
                    (Ortac_runtime.Gospelstdlib.integer_of_int i)
                    (Ortac_runtime.Gospelstdlib.Sequence.length
-                      t_4__016_.contents) in
-               __t1__020_ && __t2__021_
+                      t_4__017_.contents) in
+               __t1__021_ && __t2__022_
              with
              | e ->
                  raise
@@ -277,20 +289,20 @@ module Spec =
                         })))
               &&
               ((try
-                  let __t1__022_ =
+                  let __t1__023_ =
                     Ortac_runtime.Gospelstdlib.(<=)
                       (Ortac_runtime.Gospelstdlib.integer_of_int i)
                       (Ortac_runtime.Gospelstdlib.(+)
                          (Ortac_runtime.Gospelstdlib.integer_of_int i)
                          (Ortac_runtime.Gospelstdlib.integer_of_int n)) in
-                  let __t2__023_ =
+                  let __t2__024_ =
                     Ortac_runtime.Gospelstdlib.(<=)
                       (Ortac_runtime.Gospelstdlib.(+)
                          (Ortac_runtime.Gospelstdlib.integer_of_int i)
                          (Ortac_runtime.Gospelstdlib.integer_of_int n))
                       (Ortac_runtime.Gospelstdlib.Sequence.length
-                         t_4__016_.contents) in
-                  __t1__022_ && __t2__023_
+                         t_4__017_.contents) in
+                  __t1__023_ && __t2__024_
                 with
                 | e ->
                     raise
@@ -339,7 +351,7 @@ module Spec =
                                   }
                               })))))
           then
-            let r_1__019_ =
+            let r_1__020_ =
               let open ModelElt in
                 {
                   contents =
@@ -350,7 +362,7 @@ module Spec =
                        then Ortac_runtime.Gospelstdlib.Sequence.empty
                        else
                          Ortac_runtime.Gospelstdlib.__mix_Buddub
-                           t_4__016_.contents
+                           t_4__017_.contents
                            (Ortac_runtime.Gospelstdlib.integer_of_int i)
                            (Ortac_runtime.Gospelstdlib.(-)
                               (Ortac_runtime.Gospelstdlib.(+)
@@ -379,67 +391,67 @@ module Spec =
                                     }
                                 })))
                 }
-            and t_4__018_ = t_4__016_ in
-            Model.push (Model.push (Model.drop_n state__003_ 1) t_4__018_)
-              r_1__019_
-          else state__003_
-    let precond cmd__045_ state__046_ =
-      match cmd__045_ with
+            and t_4__019_ = t_4__017_ in
+            Model.push (Model.push (Model.drop_n state__004_ 1) t_4__019_)
+              r_1__020_
+          else state__004_
+    let precond cmd__046_ state__047_ =
+      match cmd__046_ with
       | Create a_1 -> true
       | Push a_2 -> true
       | Transfer -> true
       | Copy -> true
       | Sub (i, n) -> true
     let postcond _ _ _ = true
-    let run cmd__047_ sut__048_ =
-      match cmd__047_ with
+    let run cmd__048_ sut__049_ =
+      match cmd__048_ with
       | Create a_1 ->
           Res
             (sut,
-              (let res__049_ = create a_1 in
-               (SUT.push sut__048_ res__049_; res__049_)))
+              (let res__050_ = create a_1 in
+               (SUT.push sut__049_ res__050_; res__050_)))
       | Push a_2 ->
           Res
             (unit,
-              (let t_2__050_ = SUT.pop sut__048_ in
-               let res__051_ = push a_2 t_2__050_ in
-               (SUT.push sut__048_ t_2__050_; res__051_)))
+              (let t_2__051_ = SUT.pop sut__049_ in
+               let res__052_ = push a_2 t_2__051_ in
+               (SUT.push sut__049_ t_2__051_; res__052_)))
       | Transfer ->
           Res
             (unit,
-              (let t1__052_ = SUT.pop sut__048_ in
-               let t2__053_ = SUT.pop sut__048_ in
-               let res__054_ = transfer t1__052_ t2__053_ in
-               (SUT.push sut__048_ t2__053_;
-                SUT.push sut__048_ t1__052_;
-                res__054_)))
+              (let t1__053_ = SUT.pop sut__049_ in
+               let t2__054_ = SUT.pop sut__049_ in
+               let res__055_ = transfer t1__053_ t2__054_ in
+               (SUT.push sut__049_ t2__054_;
+                SUT.push sut__049_ t1__053_;
+                res__055_)))
       | Copy ->
           Res
             (sut,
-              (let t_3__055_ = SUT.pop sut__048_ in
-               let res__056_ = copy t_3__055_ in
-               (SUT.push sut__048_ t_3__055_;
-                SUT.push sut__048_ res__056_;
-                res__056_)))
+              (let t_3__056_ = SUT.pop sut__049_ in
+               let res__057_ = copy t_3__056_ in
+               (SUT.push sut__049_ t_3__056_;
+                SUT.push sut__049_ res__057_;
+                res__057_)))
       | Sub (i, n) ->
           Res
             ((result sut exn),
-              (let t_4__057_ = SUT.pop sut__048_ in
-               let res__058_ = protect (fun () -> sub t_4__057_ i n) () in
-               (SUT.push sut__048_ t_4__057_;
-                (match res__058_ with
-                 | Ok res -> SUT.push sut__048_ res
+              (let t_4__058_ = SUT.pop sut__049_ in
+               let res__059_ = protect (fun () -> sub t_4__058_ i n) () in
+               (SUT.push sut__049_ t_4__058_;
+                (match res__059_ with
+                 | Ok res -> SUT.push sut__049_ res
                  | Error _ -> ());
-                res__058_)))
+                res__059_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () =
-  let __state__059_ = Model.get Spec.init_state 0 in
+  let __state__060_ = Model.get Spec.init_state 0 in
   if
     not
       (try
          Ortac_runtime.Gospelstdlib.(>)
-           (Ortac_runtime.Gospelstdlib.Sequence.length __state__059_.contents)
+           (Ortac_runtime.Gospelstdlib.Sequence.length __state__060_.contents)
            (Ortac_runtime.Gospelstdlib.integer_of_int 0)
        with
        | e ->
@@ -463,56 +475,56 @@ let check_init_state () =
                       }
                   })))
   then QCheck.Test.fail_report "INIT_SUT violates type invariants for SUT"
-let ortac_show_cmd cmd__060_ state__061_ last__063_ res__062_ =
+let ortac_show_cmd cmd__061_ state__062_ last__064_ res__063_ =
   let open Spec in
     let open STM in
-      match (cmd__060_, res__062_) with
+      match (cmd__061_, res__063_) with
       | (Create a_1, Res ((SUT, _), t_1)) ->
-          let lhs = if last__063_ then "r" else SUT.get_name state__061_ 0
+          let lhs = if last__064_ then "r" else SUT.get_name state__062_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "create" (Util.Pp.pp_int true)
             a_1
       | (Push a_2, Res ((Unit, _), _)) ->
-          let lhs = if last__063_ then "r" else "_"
+          let lhs = if last__064_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "push"
-            (Util.Pp.pp_int true) a_2 (SUT.get_name state__061_ (0 + shift))
+            (Util.Pp.pp_int true) a_2 (SUT.get_name state__062_ (0 + shift))
       | (Transfer, Res ((Unit, _), _)) ->
-          let lhs = if last__063_ then "r" else "_"
+          let lhs = if last__064_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %s" lhs "transfer"
-            (SUT.get_name state__061_ (0 + shift))
-            (SUT.get_name state__061_ (1 + shift))
+            (SUT.get_name state__062_ (0 + shift))
+            (SUT.get_name state__062_ (1 + shift))
       | (Copy, Res ((SUT, _), r)) ->
-          let lhs = if last__063_ then "r" else SUT.get_name state__061_ 0
+          let lhs = if last__064_ then "r" else SUT.get_name state__062_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s" lhs "copy"
-            (SUT.get_name state__061_ (0 + shift))
+            (SUT.get_name state__062_ (0 + shift))
       | (Sub (i, n), Res ((Result (SUT, Exn), _), r_1)) ->
           let lhs =
-            if last__063_
+            if last__064_
             then "r"
             else
               (match r_1 with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__061_ 0)
+               | Ok _ -> "Ok " ^ (SUT.get_name state__062_ 0)
                | Error _ -> "_")
           and shift = match r_1 with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "sub" (SUT.get_name state__061_ (0 + shift))
+            "sub" (SUT.get_name state__062_ (0 + shift))
             (Util.Pp.pp_int true) i (Util.Pp.pp_int true) n
       | _ -> assert false
-let ortac_postcond cmd__024_ state__025_ res__026_ =
+let ortac_postcond cmd__025_ state__026_ res__027_ =
   let open Spec in
     let open STM in
-      let new_state__027_ = lazy (next_state cmd__024_ state__025_) in
-      match (cmd__024_, res__026_) with
+      let new_state__028_ = lazy (next_state cmd__025_ state__026_) in
+      match (cmd__025_, res__027_) with
       | (Create a_1, Res ((SUT, _), t_1)) ->
           if
-            let t__028_ = lazy (Model.get (Lazy.force new_state__027_) 0) in
+            let t__029_ = lazy (Model.get (Lazy.force new_state__028_) 0) in
             (try
                Ortac_runtime.Gospelstdlib.(>)
                  (Ortac_runtime.Gospelstdlib.Sequence.length
-                    (Lazy.force t__028_).contents)
+                    (Lazy.force t__029_).contents)
                  (Ortac_runtime.Gospelstdlib.integer_of_int 0)
              with
              | e ->
@@ -560,11 +572,11 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                     })])
       | (Push a_2, Res ((Unit, _), _)) ->
           if
-            let t__029_ = lazy (Model.get (Lazy.force new_state__027_) 0) in
+            let t__030_ = lazy (Model.get (Lazy.force new_state__028_) 0) in
             (try
                Ortac_runtime.Gospelstdlib.(>)
                  (Ortac_runtime.Gospelstdlib.Sequence.length
-                    (Lazy.force t__029_).contents)
+                    (Lazy.force t__030_).contents)
                  (Ortac_runtime.Gospelstdlib.integer_of_int 0)
              with
              | e ->
@@ -612,11 +624,11 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
       | (Transfer, Res ((Unit, _), _)) ->
           Ortac_runtime.append
             (if
-               let t1__031_ = lazy (Model.get (Lazy.force new_state__027_) 0) in
+               let t1__032_ = lazy (Model.get (Lazy.force new_state__028_) 0) in
                try
                  Ortac_runtime.Gospelstdlib.(>)
                    (Ortac_runtime.Gospelstdlib.Sequence.length
-                      (Lazy.force t1__031_).contents)
+                      (Lazy.force t1__032_).contents)
                    (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                with
                | e ->
@@ -662,11 +674,11 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                            }
                        })]))
             (if
-               let t2__032_ = lazy (Model.get (Lazy.force new_state__027_) 1) in
+               let t2__033_ = lazy (Model.get (Lazy.force new_state__028_) 1) in
                try
                  Ortac_runtime.Gospelstdlib.(>)
                    (Ortac_runtime.Gospelstdlib.Sequence.length
-                      (Lazy.force t2__032_).contents)
+                      (Lazy.force t2__033_).contents)
                    (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                with
                | e ->
@@ -714,11 +726,11 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
       | (Copy, Res ((SUT, _), r)) ->
           Ortac_runtime.append
             (if
-               let r__035_ = lazy (Model.get (Lazy.force new_state__027_) 0) in
+               let r__036_ = lazy (Model.get (Lazy.force new_state__028_) 0) in
                try
                  Ortac_runtime.Gospelstdlib.(>)
                    (Ortac_runtime.Gospelstdlib.Sequence.length
-                      (Lazy.force r__035_).contents)
+                      (Lazy.force r__036_).contents)
                    (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                with
                | e ->
@@ -765,11 +777,11 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                            }
                        })]))
             (if
-               let t__036_ = lazy (Model.get (Lazy.force new_state__027_) 1) in
+               let t__037_ = lazy (Model.get (Lazy.force new_state__028_) 1) in
                try
                  Ortac_runtime.Gospelstdlib.(>)
                    (Ortac_runtime.Gospelstdlib.Sequence.length
-                      (Lazy.force t__036_).contents)
+                      (Lazy.force t__037_).contents)
                    (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                with
                | e ->
@@ -818,18 +830,18 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
       | (Sub (i, n), Res ((Result (SUT, Exn), _), r_1)) ->
           (match Ortac_runtime.append
                    (if
-                      let tmp__040_ = Model.get state__025_ 0 in
+                      let tmp__041_ = Model.get state__026_ 0 in
                       try
-                        let __t1__041_ =
+                        let __t1__042_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                             (Ortac_runtime.Gospelstdlib.integer_of_int i) in
-                        let __t2__042_ =
+                        let __t2__043_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.integer_of_int i)
                             (Ortac_runtime.Gospelstdlib.Sequence.length
-                               tmp__040_.contents) in
-                        __t1__041_ && __t2__042_
+                               tmp__041_.contents) in
+                        __t1__042_ && __t2__043_
                       with
                       | e ->
                           raise
@@ -875,9 +887,9 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                               })]))
                    (Ortac_runtime.append
                       (if
-                         let tmp__040_ = Model.get state__025_ 0 in
+                         let tmp__041_ = Model.get state__026_ 0 in
                          try
-                           let __t1__043_ =
+                           let __t1__044_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i)
                                (Ortac_runtime.Gospelstdlib.(+)
@@ -885,7 +897,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                                      i)
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
                                      n)) in
-                           let __t2__044_ =
+                           let __t2__045_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.(+)
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
@@ -893,8 +905,8 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
                                      n))
                                (Ortac_runtime.Gospelstdlib.Sequence.length
-                                  tmp__040_.contents) in
-                           __t1__043_ && __t2__044_
+                                  tmp__041_.contents) in
+                           __t1__044_ && __t2__045_
                          with
                          | e ->
                              raise
@@ -940,7 +952,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                                      }
                                  })]))
                       (if
-                         let tmp__040_ = Model.get state__025_ 0 in
+                         let tmp__041_ = Model.get state__026_ 0 in
                          try
                            Ortac_runtime.Gospelstdlib.(>=)
                              (Ortac_runtime.Gospelstdlib.integer_of_int n)
@@ -995,12 +1007,12 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                 | Ok r_1 ->
                     Ortac_runtime.append
                       (if
-                         let r__038_ =
-                           lazy (Model.get (Lazy.force new_state__027_) 0) in
+                         let r__039_ =
+                           lazy (Model.get (Lazy.force new_state__028_) 0) in
                          try
                            Ortac_runtime.Gospelstdlib.(>)
                              (Ortac_runtime.Gospelstdlib.Sequence.length
-                                (Lazy.force r__038_).contents)
+                                (Lazy.force r__039_).contents)
                              (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                          with
                          | e ->
@@ -1047,12 +1059,12 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                                      }
                                  })]))
                       (if
-                         let t__039_ =
-                           lazy (Model.get (Lazy.force new_state__027_) 1) in
+                         let t__040_ =
+                           lazy (Model.get (Lazy.force new_state__028_) 1) in
                          try
                            Ortac_runtime.Gospelstdlib.(>)
                              (Ortac_runtime.Gospelstdlib.Sequence.length
-                                (Lazy.force t__039_).contents)
+                                (Lazy.force t__040_).contents)
                              (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                          with
                          | e ->
@@ -1105,18 +1117,18 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                 | _ ->
                     Ortac_runtime.append
                       (if
-                         let tmp__040_ = Model.get state__025_ 0 in
+                         let tmp__041_ = Model.get state__026_ 0 in
                          try
-                           let __t1__041_ =
+                           let __t1__042_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i) in
-                           let __t2__042_ =
+                           let __t2__043_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i)
                                (Ortac_runtime.Gospelstdlib.Sequence.length
-                                  tmp__040_.contents) in
-                           __t1__041_ && __t2__042_
+                                  tmp__041_.contents) in
+                           __t1__042_ && __t2__043_
                          with
                          | e ->
                              raise
@@ -1163,9 +1175,9 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                                  })]))
                       (Ortac_runtime.append
                          (if
-                            let tmp__040_ = Model.get state__025_ 0 in
+                            let tmp__041_ = Model.get state__026_ 0 in
                             try
-                              let __t1__043_ =
+                              let __t1__044_ =
                                 Ortac_runtime.Gospelstdlib.(<=)
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
                                      i)
@@ -1174,7 +1186,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                                         i)
                                      (Ortac_runtime.Gospelstdlib.integer_of_int
                                         n)) in
-                              let __t2__044_ =
+                              let __t2__045_ =
                                 Ortac_runtime.Gospelstdlib.(<=)
                                   (Ortac_runtime.Gospelstdlib.(+)
                                      (Ortac_runtime.Gospelstdlib.integer_of_int
@@ -1182,8 +1194,8 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                                      (Ortac_runtime.Gospelstdlib.integer_of_int
                                         n))
                                   (Ortac_runtime.Gospelstdlib.Sequence.length
-                                     tmp__040_.contents) in
-                              __t1__043_ && __t2__044_
+                                     tmp__041_.contents) in
+                              __t1__044_ && __t2__045_
                             with
                             | e ->
                                 raise
@@ -1229,7 +1241,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                                         }
                                     })]))
                          (if
-                            let tmp__040_ = Model.get state__025_ 0 in
+                            let tmp__041_ = Model.get state__026_ 0 in
                             try
                               Ortac_runtime.Gospelstdlib.(>=)
                                 (Ortac_runtime.Gospelstdlib.integer_of_int n)

--- a/plugins/qcheck-stm/test/queue_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/queue_stm_tests.expected.ml
@@ -79,10 +79,23 @@ module Spec =
       | Clear -> Format.asprintf "%s <sut>" "clear"
       | Is_empty -> Format.asprintf "%s <sut>" "is_empty"
       | Transfer -> Format.asprintf "%s <sut> <sut>" "transfer"
+    let shrink_cmd cmd__002_ =
+      let open QCheck in
+        let open Shrink in
+          let open Iter in
+            match cmd__002_ with
+            | Create () -> map (fun () -> Create ()) (unit ())
+            | Push v -> map (fun v -> Push v) (int v)
+            | Pop -> empty
+            | Peek -> empty
+            | Peek_opt -> empty
+            | Clear -> empty
+            | Is_empty -> empty
+            | Transfer -> empty
     let cleanup _ = ()
     let arb_cmd _ =
       let open QCheck in
-        make ~print:show_cmd
+        make ~print:show_cmd ~shrink:shrink_cmd
           (let open Gen in
              oneof
                [(pure (fun () -> Create ())) <*> unit;
@@ -93,10 +106,10 @@ module Spec =
                pure Clear;
                pure Is_empty;
                pure Transfer])
-    let next_state cmd__002_ state__003_ =
-      match cmd__002_ with
+    let next_state cmd__003_ state__004_ =
+      match cmd__003_ with
       | Create () ->
-          let t_1__005_ =
+          let t_1__006_ =
             let open ModelElt in
               {
                 contents =
@@ -123,16 +136,16 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 0) t_1__005_
+          Model.push (Model.drop_n state__004_ 0) t_1__006_
       | Push v ->
-          let t_2__006_ = Model.get state__003_ 0 in
-          let t_2__007_ =
+          let t_2__007_ = Model.get state__004_ 0 in
+          let t_2__008_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      Ortac_runtime.Gospelstdlib.Sequence.snoc
-                       t_2__006_.contents v
+                       t_2__007_.contents v
                    with
                    | e ->
                        raise
@@ -155,24 +168,24 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) t_2__007_
+          Model.push (Model.drop_n state__004_ 1) t_2__008_
       | Pop ->
-          let t_3__008_ = Model.get state__003_ 0 in
-          let t_3__010_ =
+          let t_3__009_ = Model.get state__004_ 0 in
+          let t_3__011_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      match Ortac_runtime.Gospelstdlib.Sequence.length
-                             t_3__008_.contents
+                             t_3__009_.contents
                      with
-                     | __x__009_ when
-                         (=) __x__009_
+                     | __x__010_ when
+                         (=) __x__010_
                            (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                          -> Ortac_runtime.Gospelstdlib.Sequence.empty
                      | _ ->
                          Ortac_runtime.Gospelstdlib.Sequence.tl
-                           t_3__008_.contents
+                           t_3__009_.contents
                    with
                    | e ->
                        raise
@@ -195,18 +208,18 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) t_3__010_
+          Model.push (Model.drop_n state__004_ 1) t_3__011_
       | Peek ->
-          let t_4__011_ = Model.get state__003_ 0 in
-          let t_4__012_ = t_4__011_ in
-          Model.push (Model.drop_n state__003_ 1) t_4__012_
+          let t_4__012_ = Model.get state__004_ 0 in
+          let t_4__013_ = t_4__012_ in
+          Model.push (Model.drop_n state__004_ 1) t_4__013_
       | Peek_opt ->
-          let t_5__013_ = Model.get state__003_ 0 in
-          let t_5__014_ = t_5__013_ in
-          Model.push (Model.drop_n state__003_ 1) t_5__014_
+          let t_5__014_ = Model.get state__004_ 0 in
+          let t_5__015_ = t_5__014_ in
+          Model.push (Model.drop_n state__004_ 1) t_5__015_
       | Clear ->
-          let t_6__015_ = Model.get state__003_ 0 in
-          let t_6__016_ =
+          let t_6__016_ = Model.get state__004_ 0 in
+          let t_6__017_ =
             let open ModelElt in
               {
                 contents =
@@ -233,15 +246,15 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) t_6__016_
+          Model.push (Model.drop_n state__004_ 1) t_6__017_
       | Is_empty ->
-          let t_7__017_ = Model.get state__003_ 0 in
-          let t_7__018_ = t_7__017_ in
-          Model.push (Model.drop_n state__003_ 1) t_7__018_
+          let t_7__018_ = Model.get state__004_ 0 in
+          let t_7__019_ = t_7__018_ in
+          Model.push (Model.drop_n state__004_ 1) t_7__019_
       | Transfer ->
-          let t1__019_ = Model.get state__003_ 0
-          and t2__020_ = Model.get state__003_ 1 in
-          let t1__022_ =
+          let t1__020_ = Model.get state__004_ 0
+          and t2__021_ = Model.get state__004_ 1 in
+          let t1__023_ =
             let open ModelElt in
               {
                 contents =
@@ -268,13 +281,13 @@ module Spec =
                                   }
                               })))
               }
-          and t2__021_ =
+          and t2__022_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      Ortac_runtime.Gospelstdlib.Sequence.append
-                       t1__019_.contents t2__020_.contents
+                       t1__020_.contents t2__021_.contents
                    with
                    | e ->
                        raise
@@ -297,10 +310,10 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.push (Model.drop_n state__003_ 2) t2__021_)
-            t1__022_
-    let precond cmd__061_ state__062_ =
-      match cmd__061_ with
+          Model.push (Model.push (Model.drop_n state__004_ 2) t2__022_)
+            t1__023_
+    let precond cmd__062_ state__063_ =
+      match cmd__062_ with
       | Create () -> true
       | Push v -> true
       | Pop -> true
@@ -310,112 +323,112 @@ module Spec =
       | Is_empty -> true
       | Transfer -> true
     let postcond _ _ _ = true
-    let run cmd__063_ sut__064_ =
-      match cmd__063_ with
+    let run cmd__064_ sut__065_ =
+      match cmd__064_ with
       | Create () ->
           Res
             (sut,
-              (let res__065_ = create () in
-               (SUT.push sut__064_ res__065_; res__065_)))
+              (let res__066_ = create () in
+               (SUT.push sut__065_ res__066_; res__066_)))
       | Push v ->
           Res
             (unit,
-              (let t_2__066_ = SUT.pop sut__064_ in
-               let res__067_ = push v t_2__066_ in
-               (SUT.push sut__064_ t_2__066_; res__067_)))
+              (let t_2__067_ = SUT.pop sut__065_ in
+               let res__068_ = push v t_2__067_ in
+               (SUT.push sut__065_ t_2__067_; res__068_)))
       | Pop ->
           Res
             ((result int exn),
-              (let t_3__068_ = SUT.pop sut__064_ in
-               let res__069_ = protect (fun () -> pop t_3__068_) () in
-               (SUT.push sut__064_ t_3__068_; res__069_)))
+              (let t_3__069_ = SUT.pop sut__065_ in
+               let res__070_ = protect (fun () -> pop t_3__069_) () in
+               (SUT.push sut__065_ t_3__069_; res__070_)))
       | Peek ->
           Res
             ((result int exn),
-              (let t_4__070_ = SUT.pop sut__064_ in
-               let res__071_ = protect (fun () -> peek t_4__070_) () in
-               (SUT.push sut__064_ t_4__070_; res__071_)))
+              (let t_4__071_ = SUT.pop sut__065_ in
+               let res__072_ = protect (fun () -> peek t_4__071_) () in
+               (SUT.push sut__065_ t_4__071_; res__072_)))
       | Peek_opt ->
           Res
             ((option int),
-              (let t_5__072_ = SUT.pop sut__064_ in
-               let res__073_ = peek_opt t_5__072_ in
-               (SUT.push sut__064_ t_5__072_; res__073_)))
+              (let t_5__073_ = SUT.pop sut__065_ in
+               let res__074_ = peek_opt t_5__073_ in
+               (SUT.push sut__065_ t_5__073_; res__074_)))
       | Clear ->
           Res
             (unit,
-              (let t_6__074_ = SUT.pop sut__064_ in
-               let res__075_ = clear t_6__074_ in
-               (SUT.push sut__064_ t_6__074_; res__075_)))
+              (let t_6__075_ = SUT.pop sut__065_ in
+               let res__076_ = clear t_6__075_ in
+               (SUT.push sut__065_ t_6__075_; res__076_)))
       | Is_empty ->
           Res
             (bool,
-              (let t_7__076_ = SUT.pop sut__064_ in
-               let res__077_ = is_empty t_7__076_ in
-               (SUT.push sut__064_ t_7__076_; res__077_)))
+              (let t_7__077_ = SUT.pop sut__065_ in
+               let res__078_ = is_empty t_7__077_ in
+               (SUT.push sut__065_ t_7__077_; res__078_)))
       | Transfer ->
           Res
             (unit,
-              (let t1__078_ = SUT.pop sut__064_ in
-               let t2__079_ = SUT.pop sut__064_ in
-               let res__080_ = transfer t1__078_ t2__079_ in
-               (SUT.push sut__064_ t2__079_;
-                SUT.push sut__064_ t1__078_;
-                res__080_)))
+              (let t1__079_ = SUT.pop sut__065_ in
+               let t2__080_ = SUT.pop sut__065_ in
+               let res__081_ = transfer t1__079_ t2__080_ in
+               (SUT.push sut__065_ t2__080_;
+                SUT.push sut__065_ t1__079_;
+                res__081_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__082_ state__083_ last__085_ res__084_ =
+let ortac_show_cmd cmd__083_ state__084_ last__086_ res__085_ =
   let open Spec in
     let open STM in
-      match (cmd__082_, res__084_) with
+      match (cmd__083_, res__085_) with
       | (Create (), Res ((SUT, _), t_1)) ->
-          let lhs = if last__085_ then "r" else SUT.get_name state__083_ 0
+          let lhs = if last__086_ then "r" else SUT.get_name state__084_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "create"
             (Util.Pp.pp_unit true) ()
       | (Push v, Res ((Unit, _), _)) ->
-          let lhs = if last__085_ then "r" else "_"
+          let lhs = if last__086_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "push"
-            (Util.Pp.pp_int true) v (SUT.get_name state__083_ (0 + shift))
+            (Util.Pp.pp_int true) v (SUT.get_name state__084_ (0 + shift))
       | (Pop, Res ((Result (Int, Exn), _), _)) ->
-          let lhs = if last__085_ then "r" else "_"
+          let lhs = if last__086_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "pop"
-            (SUT.get_name state__083_ (0 + shift))
+            (SUT.get_name state__084_ (0 + shift))
       | (Peek, Res ((Result (Int, Exn), _), _)) ->
-          let lhs = if last__085_ then "r" else "_"
+          let lhs = if last__086_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "peek"
-            (SUT.get_name state__083_ (0 + shift))
+            (SUT.get_name state__084_ (0 + shift))
       | (Peek_opt, Res ((Option (Int), _), _)) ->
-          let lhs = if last__085_ then "r" else "_"
+          let lhs = if last__086_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "peek_opt"
-            (SUT.get_name state__083_ (0 + shift))
+            (SUT.get_name state__084_ (0 + shift))
       | (Clear, Res ((Unit, _), _)) ->
-          let lhs = if last__085_ then "r" else "_"
+          let lhs = if last__086_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "clear"
-            (SUT.get_name state__083_ (0 + shift))
+            (SUT.get_name state__084_ (0 + shift))
       | (Is_empty, Res ((Bool, _), _)) ->
-          let lhs = if last__085_ then "r" else "_"
+          let lhs = if last__086_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "is_empty"
-            (SUT.get_name state__083_ (0 + shift))
+            (SUT.get_name state__084_ (0 + shift))
       | (Transfer, Res ((Unit, _), _)) ->
-          let lhs = if last__085_ then "r" else "_"
+          let lhs = if last__086_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %s" lhs "transfer"
-            (SUT.get_name state__083_ (0 + shift))
-            (SUT.get_name state__083_ (1 + shift))
+            (SUT.get_name state__084_ (0 + shift))
+            (SUT.get_name state__084_ (1 + shift))
       | _ -> assert false
-let ortac_postcond cmd__023_ state__024_ res__025_ =
+let ortac_postcond cmd__024_ state__025_ res__026_ =
   let open Spec in
     let open STM in
-      let new_state__026_ = lazy (next_state cmd__023_ state__024_) in
-      match (cmd__023_, res__025_) with
+      let new_state__027_ = lazy (next_state cmd__024_ state__025_) in
+      match (cmd__024_, res__026_) with
       | (Create (), Res ((SUT, _), t_1)) -> None
       | (Push v, Res ((Unit, _), _)) -> None
       | (Pop, Res ((Result (Int, Exn), _), v_1)) ->
@@ -423,13 +436,13 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
            | Ok v_1 ->
                Ortac_runtime.append
                  (if
-                    let t_old__030_ = Model.get state__024_ 0
-                    and t_new__031_ =
-                      lazy (Model.get (Lazy.force new_state__026_) 0) in
+                    let t_old__031_ = Model.get state__025_ 0
+                    and t_new__032_ =
+                      lazy (Model.get (Lazy.force new_state__027_) 0) in
                     try
                       v_1 =
                         (Ortac_runtime.Gospelstdlib.Sequence.hd
-                           t_old__030_.contents)
+                           t_old__031_.contents)
                     with
                     | e ->
                         raise
@@ -458,14 +471,14 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                          (Ortac_runtime.Protected_value
                             (Res
                                (int,
-                                 (let t_old__028_ = Model.get state__024_ 0
-                                  and t_new__029_ =
+                                 (let t_old__029_ = Model.get state__025_ 0
+                                  and t_new__030_ =
                                     lazy
-                                      (Model.get (Lazy.force new_state__026_)
+                                      (Model.get (Lazy.force new_state__027_)
                                          0) in
                                   try
                                     Ortac_runtime.Gospelstdlib.Sequence.hd
-                                      t_old__028_.contents
+                                      t_old__029_.contents
                                   with
                                   | e ->
                                       raise
@@ -505,12 +518,12 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                                 }
                             })]))
                  (if
-                    let t_old__032_ = Model.get state__024_ 0
-                    and t_new__033_ =
-                      lazy (Model.get (Lazy.force new_state__026_) 0) in
+                    let t_old__033_ = Model.get state__025_ 0
+                    and t_new__034_ =
+                      lazy (Model.get (Lazy.force new_state__027_) 0) in
                     try
                       not
-                        (t_old__032_.contents =
+                        (t_old__033_.contents =
                            Ortac_runtime.Gospelstdlib.Sequence.empty)
                     with
                     | e ->
@@ -540,14 +553,14 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                          (Ortac_runtime.Protected_value
                             (Res
                                (int,
-                                 (let t_old__028_ = Model.get state__024_ 0
-                                  and t_new__029_ =
+                                 (let t_old__029_ = Model.get state__025_ 0
+                                  and t_new__030_ =
                                     lazy
-                                      (Model.get (Lazy.force new_state__026_)
+                                      (Model.get (Lazy.force new_state__027_)
                                          0) in
                                   try
                                     Ortac_runtime.Gospelstdlib.Sequence.hd
-                                      t_old__028_.contents
+                                      t_old__029_.contents
                                   with
                                   | e ->
                                       raise
@@ -588,17 +601,17 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                             })]))
            | Error (Empty) ->
                if
-                 let t_old__034_ = Model.get state__024_ 0
-                 and t_new__035_ =
-                   lazy (Model.get (Lazy.force new_state__026_) 0) in
+                 let t_old__035_ = Model.get state__025_ 0
+                 and t_new__036_ =
+                   lazy (Model.get (Lazy.force new_state__027_) 0) in
                  (try
-                    let __t1__036_ =
-                      (Lazy.force t_new__035_).contents =
-                        t_old__034_.contents in
-                    let __t2__037_ =
-                      t_old__034_.contents =
+                    let __t1__037_ =
+                      (Lazy.force t_new__036_).contents =
+                        t_old__035_.contents in
+                    let __t2__038_ =
+                      t_old__035_.contents =
                         Ortac_runtime.Gospelstdlib.Sequence.empty in
-                    __t1__036_ && __t2__037_
+                    __t1__037_ && __t2__038_
                   with
                   | e ->
                       raise
@@ -647,13 +660,13 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
           (match v_2 with
            | Ok v_2 ->
                if
-                 let t_old__041_ = Model.get state__024_ 0
-                 and t_new__042_ =
-                   lazy (Model.get (Lazy.force new_state__026_) 0) in
+                 let t_old__042_ = Model.get state__025_ 0
+                 and t_new__043_ =
+                   lazy (Model.get (Lazy.force new_state__027_) 0) in
                  (try
                     v_2 =
                       (Ortac_runtime.Gospelstdlib.Sequence.hd
-                         (Lazy.force t_new__042_).contents)
+                         (Lazy.force t_new__043_).contents)
                   with
                   | e ->
                       raise
@@ -682,13 +695,13 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                       (Ortac_runtime.Protected_value
                          (Res
                             (int,
-                              (let t_old__039_ = Model.get state__024_ 0
-                               and t_new__040_ =
+                              (let t_old__040_ = Model.get state__025_ 0
+                               and t_new__041_ =
                                  lazy
-                                   (Model.get (Lazy.force new_state__026_) 0) in
+                                   (Model.get (Lazy.force new_state__027_) 0) in
                                try
                                  Ortac_runtime.Gospelstdlib.Sequence.hd
-                                   (Lazy.force t_new__040_).contents
+                                   (Lazy.force t_new__041_).contents
                                with
                                | e ->
                                    raise
@@ -729,17 +742,17 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                          })])
            | Error (Empty) ->
                if
-                 let t_old__043_ = Model.get state__024_ 0
-                 and t_new__044_ =
-                   lazy (Model.get (Lazy.force new_state__026_) 0) in
+                 let t_old__044_ = Model.get state__025_ 0
+                 and t_new__045_ =
+                   lazy (Model.get (Lazy.force new_state__027_) 0) in
                  (try
-                    let __t1__045_ =
-                      (Lazy.force t_new__044_).contents =
-                        t_old__043_.contents in
-                    let __t2__046_ =
-                      t_old__043_.contents =
+                    let __t1__046_ =
+                      (Lazy.force t_new__045_).contents =
+                        t_old__044_.contents in
+                    let __t2__047_ =
+                      t_old__044_.contents =
                         Ortac_runtime.Gospelstdlib.Sequence.empty in
-                    __t1__045_ && __t2__046_
+                    __t1__046_ && __t2__047_
                   with
                   | e ->
                       raise
@@ -786,13 +799,13 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
            | _ -> None)
       | (Peek_opt, Res ((Option (Int), _), v_3)) ->
           if
-            let t_old__048_ = Model.get state__024_ 0
-            and t_new__049_ = lazy (Model.get (Lazy.force new_state__026_) 0) in
+            let t_old__049_ = Model.get state__025_ 0
+            and t_new__050_ = lazy (Model.get (Lazy.force new_state__027_) 0) in
             (try
                (match v_3 with
                 | None ->
                     if
-                      (Lazy.force t_new__049_).contents =
+                      (Lazy.force t_new__050_).contents =
                         Ortac_runtime.Gospelstdlib.Sequence.empty
                     then true
                     else false
@@ -800,7 +813,7 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                     if
                       a_1 =
                         (Ortac_runtime.Gospelstdlib.Sequence.hd
-                           (Lazy.force t_new__049_).contents)
+                           (Lazy.force t_new__050_).contents)
                     then true
                     else false)
                  = true
@@ -851,15 +864,15 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
       | (Clear, Res ((Unit, _), _)) -> None
       | (Is_empty, Res ((Bool, _), b)) ->
           if
-            let t_old__055_ = Model.get state__024_ 0
-            and t_new__056_ = lazy (Model.get (Lazy.force new_state__026_) 0) in
+            let t_old__056_ = Model.get state__025_ 0
+            and t_new__057_ = lazy (Model.get (Lazy.force new_state__027_) 0) in
             (try
                b =
                  (match Ortac_runtime.Gospelstdlib.Sequence.length
-                          (Lazy.force t_new__056_).contents
+                          (Lazy.force t_new__057_).contents
                   with
-                  | __x__057_ when
-                      (=) __x__057_
+                  | __x__058_ when
+                      (=) __x__058_
                         (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                       -> true
                   | _ -> false)
@@ -891,15 +904,15 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                  (Ortac_runtime.Value
                     (Res
                        (bool,
-                         (let t_old__052_ = Model.get state__024_ 0
-                          and t_new__053_ =
-                            lazy (Model.get (Lazy.force new_state__026_) 0) in
+                         (let t_old__053_ = Model.get state__025_ 0
+                          and t_new__054_ =
+                            lazy (Model.get (Lazy.force new_state__027_) 0) in
                           try
                             match Ortac_runtime.Gospelstdlib.Sequence.length
-                                    (Lazy.force t_new__053_).contents
+                                    (Lazy.force t_new__054_).contents
                             with
-                            | __x__054_ when
-                                (=) __x__054_
+                            | __x__055_ when
+                                (=) __x__055_
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
                                      0)
                                 -> true

--- a/plugins/qcheck-stm/test/record_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/record_stm_tests.expected.ml
@@ -90,20 +90,29 @@ module Spec =
       | Plus2 i_3 ->
           Format.asprintf "%s %a" "plus2" (Util.Pp.pp_int true) i_3
       | Get -> Format.asprintf "%s <sut>" "get"
+    let shrink_cmd cmd__002_ =
+      let open QCheck in
+        let open Shrink in
+          let open Iter in
+            match cmd__002_ with
+            | Make i_1 -> map (fun i_1 -> Make i_1) (int i_1)
+            | Plus1 i_2 -> map (fun i_2 -> Plus1 i_2) (int i_2)
+            | Plus2 i_3 -> map (fun i_3 -> Plus2 i_3) (int i_3)
+            | Get -> empty
     let cleanup _ = ()
     let arb_cmd _ =
       let open QCheck in
-        make ~print:show_cmd
+        make ~print:show_cmd ~shrink:shrink_cmd
           (let open Gen in
              oneof
                [(pure (fun i_1 -> Make i_1)) <*> small_signed_int;
                (pure (fun i_2 -> Plus1 i_2)) <*> int;
                (pure (fun i_3 -> Plus2 i_3)) <*> int;
                pure Get])
-    let next_state cmd__002_ state__003_ =
-      match cmd__002_ with
+    let next_state cmd__003_ state__004_ =
+      match cmd__003_ with
       | Make i_1 ->
-          let r__005_ =
+          let r__006_ =
             let open ModelElt in
               {
                 value =
@@ -130,68 +139,68 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 0) r__005_
-      | Plus1 i_2 -> state__003_
-      | Plus2 i_3 -> state__003_
+          Model.push (Model.drop_n state__004_ 0) r__006_
+      | Plus1 i_2 -> state__004_
+      | Plus2 i_3 -> state__004_
       | Get ->
-          let r_1__006_ = Model.get state__003_ 0 in
-          let r_1__007_ = r_1__006_ in
-          Model.push (Model.drop_n state__003_ 1) r_1__007_
-    let precond cmd__027_ state__028_ =
-      match cmd__027_ with
+          let r_1__007_ = Model.get state__004_ 0 in
+          let r_1__008_ = r_1__007_ in
+          Model.push (Model.drop_n state__004_ 1) r_1__008_
+    let precond cmd__028_ state__029_ =
+      match cmd__028_ with
       | Make i_1 -> true
       | Plus1 i_2 -> true
       | Plus2 i_3 -> true
       | Get -> true
     let postcond _ _ _ = true
-    let run cmd__029_ sut__030_ =
-      match cmd__029_ with
+    let run cmd__030_ sut__031_ =
+      match cmd__030_ with
       | Make i_1 ->
           Res
             (sut,
-              (let res__031_ = make i_1 in
-               (SUT.push sut__030_ res__031_; res__031_)))
-      | Plus1 i_2 -> Res (int, (let res__032_ = plus1 i_2 in res__032_))
-      | Plus2 i_3 -> Res (int, (let res__033_ = plus2 i_3 in res__033_))
+              (let res__032_ = make i_1 in
+               (SUT.push sut__031_ res__032_; res__032_)))
+      | Plus1 i_2 -> Res (int, (let res__033_ = plus1 i_2 in res__033_))
+      | Plus2 i_3 -> Res (int, (let res__034_ = plus2 i_3 in res__034_))
       | Get ->
           Res
             (int,
-              (let r_1__034_ = SUT.pop sut__030_ in
-               let res__035_ = get r_1__034_ in
-               (SUT.push sut__030_ r_1__034_; res__035_)))
+              (let r_1__035_ = SUT.pop sut__031_ in
+               let res__036_ = get r_1__035_ in
+               (SUT.push sut__031_ r_1__035_; res__036_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__037_ state__038_ last__040_ res__039_ =
+let ortac_show_cmd cmd__038_ state__039_ last__041_ res__040_ =
   let open Spec in
     let open STM in
-      match (cmd__037_, res__039_) with
+      match (cmd__038_, res__040_) with
       | (Make i_1, Res ((SUT, _), r)) ->
-          let lhs = if last__040_ then "r" else SUT.get_name state__038_ 0
+          let lhs = if last__041_ then "r" else SUT.get_name state__039_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "make" (Util.Pp.pp_int true)
             i_1
       | (Plus1 i_2, Res ((Int, _), _)) ->
-          let lhs = if last__040_ then "r" else "_"
+          let lhs = if last__041_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a" lhs "plus1" (Util.Pp.pp_int true)
             i_2
       | (Plus2 i_3, Res ((Int, _), _)) ->
-          let lhs = if last__040_ then "r" else "_"
+          let lhs = if last__041_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a" lhs "plus2" (Util.Pp.pp_int true)
             i_3
       | (Get, Res ((Int, _), _)) ->
-          let lhs = if last__040_ then "r" else "_"
+          let lhs = if last__041_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "get"
-            (SUT.get_name state__038_ (0 + shift))
+            (SUT.get_name state__039_ (0 + shift))
       | _ -> assert false
-let ortac_postcond cmd__008_ state__009_ res__010_ =
+let ortac_postcond cmd__009_ state__010_ res__011_ =
   let open Spec in
     let open STM in
-      let new_state__011_ = lazy (next_state cmd__008_ state__009_) in
-      match (cmd__008_, res__010_) with
+      let new_state__012_ = lazy (next_state cmd__009_ state__010_) in
+      match (cmd__009_, res__011_) with
       | (Make i_1, Res ((SUT, _), r)) -> None
       | (Plus1 i_2, Res ((Int, _), i1)) ->
           if
@@ -350,12 +359,12 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
       | (Get, Res ((Int, _), i_4)) ->
           Ortac_runtime.append
             (if
-               let r_old__017_ = Model.get state__009_ 0
-               and r_new__018_ =
-                 lazy (Model.get (Lazy.force new_state__011_) 0) in
+               let r_old__018_ = Model.get state__010_ 0
+               and r_new__019_ =
+                 lazy (Model.get (Lazy.force new_state__012_) 0) in
                try
                  (Ortac_runtime.Gospelstdlib.integer_of_int i_4) =
-                   (Lazy.force r_new__018_).value
+                   (Lazy.force r_new__019_).value
                with
                | e ->
                    raise
@@ -384,11 +393,11 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                     (Ortac_runtime.Value
                        (Res
                           (integer,
-                            (let r_old__013_ = Model.get state__009_ 0
-                             and r_new__014_ =
+                            (let r_old__014_ = Model.get state__010_ 0
+                             and r_new__015_ =
                                lazy
-                                 (Model.get (Lazy.force new_state__011_) 0) in
-                             try (Lazy.force r_new__014_).value
+                                 (Model.get (Lazy.force new_state__012_) 0) in
+                             try (Lazy.force r_new__015_).value
                              with
                              | e ->
                                  raise
@@ -429,9 +438,9 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                        })]))
             (Ortac_runtime.append
                (if
-                  let r_old__021_ = Model.get state__009_ 0
-                  and r_new__022_ =
-                    lazy (Model.get (Lazy.force new_state__011_) 0) in
+                  let r_old__022_ = Model.get state__010_ 0
+                  and r_new__023_ =
+                    lazy (Model.get (Lazy.force new_state__012_) 0) in
                   try
                     (plus1_1 (Ortac_runtime.Gospelstdlib.integer_of_int i_4))
                       =
@@ -466,11 +475,11 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                        (Ortac_runtime.Value
                           (Res
                              (integer,
-                               (let r_old__013_ = Model.get state__009_ 0
-                                and r_new__014_ =
+                               (let r_old__014_ = Model.get state__010_ 0
+                                and r_new__015_ =
                                   lazy
-                                    (Model.get (Lazy.force new_state__011_) 0) in
-                                try (Lazy.force r_new__014_).value
+                                    (Model.get (Lazy.force new_state__012_) 0) in
+                                try (Lazy.force r_new__015_).value
                                 with
                                 | e ->
                                     raise
@@ -510,9 +519,9 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                               }
                           })]))
                (if
-                  let r_old__023_ = Model.get state__009_ 0
-                  and r_new__024_ =
-                    lazy (Model.get (Lazy.force new_state__011_) 0) in
+                  let r_old__024_ = Model.get state__010_ 0
+                  and r_new__025_ =
+                    lazy (Model.get (Lazy.force new_state__012_) 0) in
                   try
                     (Ortac_runtime.Gospelstdlib.integer_of_int (plus2 i_4)) =
                       (Ortac_runtime.Gospelstdlib.(+)
@@ -546,11 +555,11 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                        (Ortac_runtime.Value
                           (Res
                              (integer,
-                               (let r_old__013_ = Model.get state__009_ 0
-                                and r_new__014_ =
+                               (let r_old__014_ = Model.get state__010_ 0
+                                and r_new__015_ =
                                   lazy
-                                    (Model.get (Lazy.force new_state__011_) 0) in
-                                try (Lazy.force r_new__014_).value
+                                    (Model.get (Lazy.force new_state__012_) 0) in
+                                try (Lazy.force r_new__015_).value
                                 with
                                 | e ->
                                     raise

--- a/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
@@ -59,16 +59,23 @@ module Spec =
       match cmd__001_ with
       | Make i -> Format.asprintf "%s %a" "make" (Util.Pp.pp_int true) i
       | Get -> Format.asprintf "%s <sut>" "get"
+    let shrink_cmd cmd__002_ =
+      let open QCheck in
+        let open Shrink in
+          let open Iter in
+            match cmd__002_ with
+            | Make i -> map (fun i -> Make i) (int i)
+            | Get -> empty
     let cleanup _ = ()
     let arb_cmd _ =
       let open QCheck in
-        make ~print:show_cmd
+        make ~print:show_cmd ~shrink:shrink_cmd
           (let open Gen in
              oneof [(pure (fun i -> Make i)) <*> small_signed_int; pure Get])
-    let next_state cmd__002_ state__003_ =
-      match cmd__002_ with
+    let next_state cmd__003_ state__004_ =
+      match cmd__003_ with
       | Make i ->
-          let r__005_ =
+          let r__006_ =
             let open ModelElt in
               {
                 value =
@@ -95,57 +102,57 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 0) r__005_
+          Model.push (Model.drop_n state__004_ 0) r__006_
       | Get ->
-          let r_1__006_ = Model.get state__003_ 0 in
-          let r_1__007_ = r_1__006_ in
-          Model.push (Model.drop_n state__003_ 1) r_1__007_
-    let precond cmd__019_ state__020_ =
-      match cmd__019_ with | Make i -> true | Get -> true
+          let r_1__007_ = Model.get state__004_ 0 in
+          let r_1__008_ = r_1__007_ in
+          Model.push (Model.drop_n state__004_ 1) r_1__008_
+    let precond cmd__020_ state__021_ =
+      match cmd__020_ with | Make i -> true | Get -> true
     let postcond _ _ _ = true
-    let run cmd__021_ sut__022_ =
-      match cmd__021_ with
+    let run cmd__022_ sut__023_ =
+      match cmd__022_ with
       | Make i ->
           Res
             (sut,
-              (let res__023_ = make i in
-               (SUT.push sut__022_ res__023_; res__023_)))
+              (let res__024_ = make i in
+               (SUT.push sut__023_ res__024_; res__024_)))
       | Get ->
           Res
             (int,
-              (let r_1__024_ = SUT.pop sut__022_ in
-               let res__025_ = get r_1__024_ in
-               (SUT.push sut__022_ r_1__024_; res__025_)))
+              (let r_1__025_ = SUT.pop sut__023_ in
+               let res__026_ = get r_1__025_ in
+               (SUT.push sut__023_ r_1__025_; res__026_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__027_ state__028_ last__030_ res__029_ =
+let ortac_show_cmd cmd__028_ state__029_ last__031_ res__030_ =
   let open Spec in
     let open STM in
-      match (cmd__027_, res__029_) with
+      match (cmd__028_, res__030_) with
       | (Make i, Res ((SUT, _), r)) ->
-          let lhs = if last__030_ then "r" else SUT.get_name state__028_ 0
+          let lhs = if last__031_ then "r" else SUT.get_name state__029_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "make" (Util.Pp.pp_int true) i
       | (Get, Res ((Int, _), _)) ->
-          let lhs = if last__030_ then "r" else "_"
+          let lhs = if last__031_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "get"
-            (SUT.get_name state__028_ (0 + shift))
+            (SUT.get_name state__029_ (0 + shift))
       | _ -> assert false
-let ortac_postcond cmd__008_ state__009_ res__010_ =
+let ortac_postcond cmd__009_ state__010_ res__011_ =
   let open Spec in
     let open STM in
-      let new_state__011_ = lazy (next_state cmd__008_ state__009_) in
-      match (cmd__008_, res__010_) with
+      let new_state__012_ = lazy (next_state cmd__009_ state__010_) in
+      match (cmd__009_, res__011_) with
       | (Make i, Res ((SUT, _), r)) -> None
       | (Get, Res ((Int, _), i_1)) ->
           if
-            let r_old__014_ = Model.get state__009_ 0
-            and r_new__015_ = lazy (Model.get (Lazy.force new_state__011_) 0) in
+            let r_old__015_ = Model.get state__010_ 0
+            and r_new__016_ = lazy (Model.get (Lazy.force new_state__012_) 0) in
             (try
                (Ortac_runtime.Gospelstdlib.integer_of_int i_1) =
-                 (Lazy.force r_new__015_).value
+                 (Lazy.force r_new__016_).value
              with
              | e ->
                  raise
@@ -174,10 +181,10 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                  (Ortac_runtime.Value
                     (Res
                        (integer,
-                         (let r_old__012_ = Model.get state__009_ 0
-                          and r_new__013_ =
-                            lazy (Model.get (Lazy.force new_state__011_) 0) in
-                          try (Lazy.force r_new__013_).value
+                         (let r_old__013_ = Model.get state__010_ 0
+                          and r_new__014_ =
+                            lazy (Model.get (Lazy.force new_state__012_) 0) in
+                          try (Lazy.force r_new__014_).value
                           with
                           | e ->
                               raise

--- a/plugins/qcheck-stm/test/sequence_model_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/sequence_model_stm_tests.expected.ml
@@ -89,20 +89,29 @@ module Spec =
       | Add v -> Format.asprintf "%s %a <sut>" "add" (Util.Pp.pp_char true) v
       | Remove -> Format.asprintf "%s <sut>" "remove"
       | Remove_ -> Format.asprintf "%s <sut>" "remove_"
+    let shrink_cmd cmd__002_ =
+      let open QCheck in
+        let open Shrink in
+          let open Iter in
+            match cmd__002_ with
+            | Create () -> map (fun () -> Create ()) (unit ())
+            | Add v -> map (fun v -> Add v) (char v)
+            | Remove -> empty
+            | Remove_ -> empty
     let cleanup _ = ()
     let arb_cmd _ =
       let open QCheck in
-        make ~print:show_cmd
+        make ~print:show_cmd ~shrink:shrink_cmd
           (let open Gen in
              oneof
                [(pure (fun () -> Create ())) <*> unit;
                (pure (fun v -> Add v)) <*> char;
                pure Remove;
                pure Remove_])
-    let next_state cmd__002_ state__003_ =
-      match cmd__002_ with
+    let next_state cmd__003_ state__004_ =
+      match cmd__003_ with
       | Create () ->
-          let t_1__005_ =
+          let t_1__006_ =
             let open ModelElt in
               {
                 contents =
@@ -129,16 +138,16 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 0) t_1__005_
+          Model.push (Model.drop_n state__004_ 0) t_1__006_
       | Add v ->
-          let t_2__006_ = Model.get state__003_ 0 in
-          let t_2__007_ =
+          let t_2__007_ = Model.get state__004_ 0 in
+          let t_2__008_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      Ortac_runtime.Gospelstdlib.Sequence.cons v
-                       t_2__006_.contents
+                       t_2__007_.contents
                    with
                    | e ->
                        raise
@@ -161,24 +170,24 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) t_2__007_
+          Model.push (Model.drop_n state__004_ 1) t_2__008_
       | Remove ->
-          let t_3__008_ = Model.get state__003_ 0 in
-          let t_3__010_ =
+          let t_3__009_ = Model.get state__004_ 0 in
+          let t_3__011_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      match Ortac_runtime.Gospelstdlib.Sequence.length
-                             t_3__008_.contents
+                             t_3__009_.contents
                      with
-                     | __x__009_ when
-                         (=) __x__009_
+                     | __x__010_ when
+                         (=) __x__010_
                            (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                          -> Ortac_runtime.Gospelstdlib.Sequence.empty
                      | _ ->
                          Ortac_runtime.Gospelstdlib.Sequence.tl
-                           t_3__008_.contents
+                           t_3__009_.contents
                    with
                    | e ->
                        raise
@@ -201,22 +210,22 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) t_3__010_
+          Model.push (Model.drop_n state__004_ 1) t_3__011_
       | Remove_ ->
-          let t_4__011_ = Model.get state__003_ 0 in
-          let t_4__013_ =
+          let t_4__012_ = Model.get state__004_ 0 in
+          let t_4__014_ =
             let open ModelElt in
               {
                 contents =
                   (try
-                     match length_opt t_4__011_.contents with
-                     | Some __x__012_ when
-                         (=) __x__012_
+                     match length_opt t_4__012_.contents with
+                     | Some __x__013_ when
+                         (=) __x__013_
                            (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                          -> Ortac_runtime.Gospelstdlib.Sequence.empty
                      | _ ->
                          Ortac_runtime.Gospelstdlib.Sequence.tl
-                           t_4__011_.contents
+                           t_4__012_.contents
                    with
                    | e ->
                        raise
@@ -239,72 +248,72 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) t_4__013_
-    let precond cmd__021_ state__022_ =
-      match cmd__021_ with
+          Model.push (Model.drop_n state__004_ 1) t_4__014_
+    let precond cmd__022_ state__023_ =
+      match cmd__022_ with
       | Create () -> true
       | Add v -> true
       | Remove -> true
       | Remove_ -> true
     let postcond _ _ _ = true
-    let run cmd__023_ sut__024_ =
-      match cmd__023_ with
+    let run cmd__024_ sut__025_ =
+      match cmd__024_ with
       | Create () ->
           Res
             (sut,
-              (let res__025_ = create () in
-               (SUT.push sut__024_ res__025_; res__025_)))
+              (let res__026_ = create () in
+               (SUT.push sut__025_ res__026_; res__026_)))
       | Add v ->
           Res
             (unit,
-              (let t_2__026_ = SUT.pop sut__024_ in
-               let res__027_ = add v t_2__026_ in
-               (SUT.push sut__024_ t_2__026_; res__027_)))
+              (let t_2__027_ = SUT.pop sut__025_ in
+               let res__028_ = add v t_2__027_ in
+               (SUT.push sut__025_ t_2__027_; res__028_)))
       | Remove ->
           Res
             ((option char),
-              (let t_3__028_ = SUT.pop sut__024_ in
-               let res__029_ = remove t_3__028_ in
-               (SUT.push sut__024_ t_3__028_; res__029_)))
+              (let t_3__029_ = SUT.pop sut__025_ in
+               let res__030_ = remove t_3__029_ in
+               (SUT.push sut__025_ t_3__029_; res__030_)))
       | Remove_ ->
           Res
             ((option char),
-              (let t_4__030_ = SUT.pop sut__024_ in
-               let res__031_ = remove_ t_4__030_ in
-               (SUT.push sut__024_ t_4__030_; res__031_)))
+              (let t_4__031_ = SUT.pop sut__025_ in
+               let res__032_ = remove_ t_4__031_ in
+               (SUT.push sut__025_ t_4__031_; res__032_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__033_ state__034_ last__036_ res__035_ =
+let ortac_show_cmd cmd__034_ state__035_ last__037_ res__036_ =
   let open Spec in
     let open STM in
-      match (cmd__033_, res__035_) with
+      match (cmd__034_, res__036_) with
       | (Create (), Res ((SUT, _), t_1)) ->
-          let lhs = if last__036_ then "r" else SUT.get_name state__034_ 0
+          let lhs = if last__037_ then "r" else SUT.get_name state__035_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "create"
             (Util.Pp.pp_unit true) ()
       | (Add v, Res ((Unit, _), _)) ->
-          let lhs = if last__036_ then "r" else "_"
+          let lhs = if last__037_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "add"
-            (Util.Pp.pp_char true) v (SUT.get_name state__034_ (0 + shift))
+            (Util.Pp.pp_char true) v (SUT.get_name state__035_ (0 + shift))
       | (Remove, Res ((Option (Char), _), _)) ->
-          let lhs = if last__036_ then "r" else "_"
+          let lhs = if last__037_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "remove"
-            (SUT.get_name state__034_ (0 + shift))
+            (SUT.get_name state__035_ (0 + shift))
       | (Remove_, Res ((Option (Char), _), _)) ->
-          let lhs = if last__036_ then "r" else "_"
+          let lhs = if last__037_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "remove_"
-            (SUT.get_name state__034_ (0 + shift))
+            (SUT.get_name state__035_ (0 + shift))
       | _ -> assert false
-let ortac_postcond cmd__014_ state__015_ res__016_ =
+let ortac_postcond cmd__015_ state__016_ res__017_ =
   let open Spec in
     let open STM in
-      let new_state__017_ = lazy (next_state cmd__014_ state__015_) in
-      match (cmd__014_, res__016_) with
+      let new_state__018_ = lazy (next_state cmd__015_ state__016_) in
+      match (cmd__015_, res__017_) with
       | (Create (), Res ((SUT, _), t_1)) -> None
       | (Add v, Res ((Unit, _), _)) -> None
       | (Remove, Res ((Option (Char), _), o)) -> None

--- a/plugins/qcheck-stm/test/sut_in_type_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/sut_in_type_stm_tests.expected.ml
@@ -68,17 +68,25 @@ module Spec =
       | Make (i, a_1) ->
           Format.asprintf "protect (fun () -> %s %a %a)" "make"
             (Util.Pp.pp_int true) i (Util.Pp.pp_int true) a_1
+    let shrink_cmd cmd__002_ =
+      let open QCheck in
+        let open Shrink in
+          let open Iter in
+            match cmd__002_ with
+            | Make (i, a_1) ->
+                (map (fun i -> Make (i, a_1)) (int i)) <+>
+                  (map (fun a_1 -> Make (i, a_1)) (int a_1))
     let cleanup _ = ()
     let arb_cmd _ =
       let open QCheck in
-        make ~print:show_cmd
+        make ~print:show_cmd ~shrink:shrink_cmd
           (let open Gen in
              oneof
                [((pure (fun i -> fun a_1 -> Make (i, a_1))) <*>
                    small_signed_int)
                   <*> small_signed_int])
-    let next_state cmd__002_ state__003_ =
-      match cmd__002_ with
+    let next_state cmd__003_ state__004_ =
+      match cmd__003_ with
       | Make (i, a_1) ->
           if
             (try
@@ -107,7 +115,7 @@ module Spec =
                             }
                         })))
           then
-            let t_1__005_ =
+            let t_1__006_ =
               let open ModelElt in
                 {
                   contents =
@@ -137,45 +145,45 @@ module Spec =
                                     }
                                 })))
                 } in
-            Model.push (Model.drop_n state__003_ 0) t_1__005_
-          else state__003_
-    let precond cmd__010_ state__011_ =
-      match cmd__010_ with | Make (i, a_1) -> true
+            Model.push (Model.drop_n state__004_ 0) t_1__006_
+          else state__004_
+    let precond cmd__011_ state__012_ =
+      match cmd__011_ with | Make (i, a_1) -> true
     let postcond _ _ _ = true
-    let run cmd__012_ sut__013_ =
-      match cmd__012_ with
+    let run cmd__013_ sut__014_ =
+      match cmd__013_ with
       | Make (i, a_1) ->
           Res
             ((result sut exn),
-              (let res__014_ = protect (fun () -> make i a_1) () in
-               ((match res__014_ with
-                 | Ok res -> SUT.push sut__013_ res
+              (let res__015_ = protect (fun () -> make i a_1) () in
+               ((match res__015_ with
+                 | Ok res -> SUT.push sut__014_ res
                  | Error _ -> ());
-                res__014_)))
+                res__015_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__016_ state__017_ last__019_ res__018_ =
+let ortac_show_cmd cmd__017_ state__018_ last__020_ res__019_ =
   let open Spec in
     let open STM in
-      match (cmd__016_, res__018_) with
+      match (cmd__017_, res__019_) with
       | (Make (i, a_1), Res ((Result (SUT, Exn), _), t_1)) ->
           let lhs =
-            if last__019_
+            if last__020_
             then "r"
             else
               (match t_1 with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__017_ 0)
+               | Ok _ -> "Ok " ^ (SUT.get_name state__018_ 0)
                | Error _ -> "_")
           and shift = match t_1 with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %a %a)" lhs "make"
             (Util.Pp.pp_int true) i (Util.Pp.pp_int true) a_1
       | _ -> assert false
-let ortac_postcond cmd__006_ state__007_ res__008_ =
+let ortac_postcond cmd__007_ state__008_ res__009_ =
   let open Spec in
     let open STM in
-      let new_state__009_ = lazy (next_state cmd__006_ state__007_) in
-      match (cmd__006_, res__008_) with
+      let new_state__010_ = lazy (next_state cmd__007_ state__008_) in
+      match (cmd__007_, res__009_) with
       | (Make (i, a_1), Res ((Result (SUT, Exn), _), t_1)) ->
           (match if
                    try

--- a/plugins/qcheck-stm/test/test_cleanup_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/test_cleanup_stm_tests.expected.ml
@@ -60,16 +60,23 @@ module Spec =
       | Create () ->
           Format.asprintf "%s %a" "create" (Util.Pp.pp_unit true) ()
       | Use -> Format.asprintf "%s <sut>" "use"
+    let shrink_cmd cmd__002_ =
+      let open QCheck in
+        let open Shrink in
+          let open Iter in
+            match cmd__002_ with
+            | Create () -> map (fun () -> Create ()) (unit ())
+            | Use -> empty
     let cleanup t = ignore t
     let arb_cmd _ =
       let open QCheck in
-        make ~print:show_cmd
+        make ~print:show_cmd ~shrink:shrink_cmd
           (let open Gen in
              oneof [(pure (fun () -> Create ())) <*> unit; pure Use])
-    let next_state cmd__002_ state__003_ =
-      match cmd__002_ with
+    let next_state cmd__003_ state__004_ =
+      match cmd__003_ with
       | Create () ->
-          let t_1__005_ =
+          let t_1__006_ =
             let open ModelElt in
               {
                 m =
@@ -96,17 +103,17 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 0) t_1__005_
+          Model.push (Model.drop_n state__004_ 0) t_1__006_
       | Use ->
-          let t_2__006_ = Model.get state__003_ 0 in
-          let t_2__007_ =
+          let t_2__007_ = Model.get state__004_ 0 in
+          let t_2__008_ =
             let open ModelElt in
               {
                 m =
                   (try
                      Ortac_runtime.Gospelstdlib.(+)
                        (Ortac_runtime.Gospelstdlib.integer_of_int 1)
-                       t_2__006_.m
+                       t_2__007_.m
                    with
                    | e ->
                        raise
@@ -129,46 +136,46 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) t_2__007_
-    let precond cmd__013_ state__014_ =
-      match cmd__013_ with | Create () -> true | Use -> true
+          Model.push (Model.drop_n state__004_ 1) t_2__008_
+    let precond cmd__014_ state__015_ =
+      match cmd__014_ with | Create () -> true | Use -> true
     let postcond _ _ _ = true
-    let run cmd__015_ sut__016_ =
-      match cmd__015_ with
+    let run cmd__016_ sut__017_ =
+      match cmd__016_ with
       | Create () ->
           Res
             (sut,
-              (let res__017_ = create () in
-               (SUT.push sut__016_ res__017_; res__017_)))
+              (let res__018_ = create () in
+               (SUT.push sut__017_ res__018_; res__018_)))
       | Use ->
           Res
             (unit,
-              (let t_2__018_ = SUT.pop sut__016_ in
-               let res__019_ = use t_2__018_ in
-               (SUT.push sut__016_ t_2__018_; res__019_)))
+              (let t_2__019_ = SUT.pop sut__017_ in
+               let res__020_ = use t_2__019_ in
+               (SUT.push sut__017_ t_2__019_; res__020_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__021_ state__022_ last__024_ res__023_ =
+let ortac_show_cmd cmd__022_ state__023_ last__025_ res__024_ =
   let open Spec in
     let open STM in
-      match (cmd__021_, res__023_) with
+      match (cmd__022_, res__024_) with
       | (Create (), Res ((SUT, _), t_1)) ->
-          let lhs = if last__024_ then "r" else SUT.get_name state__022_ 0
+          let lhs = if last__025_ then "r" else SUT.get_name state__023_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "create"
             (Util.Pp.pp_unit true) ()
       | (Use, Res ((Unit, _), _)) ->
-          let lhs = if last__024_ then "r" else "_"
+          let lhs = if last__025_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "use"
-            (SUT.get_name state__022_ (0 + shift))
+            (SUT.get_name state__023_ (0 + shift))
       | _ -> assert false
-let ortac_postcond cmd__008_ state__009_ res__010_ =
+let ortac_postcond cmd__009_ state__010_ res__011_ =
   let open Spec in
     let open STM in
-      let new_state__011_ = lazy (next_state cmd__008_ state__009_) in
-      match (cmd__008_, res__010_) with
+      let new_state__012_ = lazy (next_state cmd__009_ state__010_) in
+      match (cmd__009_, res__011_) with
       | (Create (), Res ((SUT, _), t_1)) -> None
       | (Use, Res ((Unit, _), _)) -> None
       | _ -> None

--- a/plugins/qcheck-stm/test/test_without_sut_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/test_without_sut_stm_tests.expected.ml
@@ -72,18 +72,29 @@ module Spec =
       | Add (a_2, b) ->
           Format.asprintf "%s %a %a" "add" (Util.Pp.pp_int true) a_2
             (Util.Pp.pp_int true) b
+    let shrink_cmd cmd__002_ =
+      let open QCheck in
+        let open Shrink in
+          let open Iter in
+            match cmd__002_ with
+            | Make (i, a_1) ->
+                (map (fun i -> Make (i, a_1)) (int i)) <+>
+                  (map (fun a_1 -> Make (i, a_1)) (int a_1))
+            | Add (a_2, b) ->
+                (map (fun a_2 -> Add (a_2, b)) (int a_2)) <+>
+                  (map (fun b -> Add (a_2, b)) (int b))
     let cleanup _ = ()
     let arb_cmd _ =
       let open QCheck in
-        make ~print:show_cmd
+        make ~print:show_cmd ~shrink:shrink_cmd
           (let open Gen in
              oneof
                [((pure (fun i -> fun a_1 -> Make (i, a_1))) <*>
                    small_signed_int)
                   <*> small_signed_int;
                ((pure (fun a_2 -> fun b -> Add (a_2, b))) <*> int) <*> int])
-    let next_state cmd__002_ state__003_ =
-      match cmd__002_ with
+    let next_state cmd__003_ state__004_ =
+      match cmd__003_ with
       | Make (i, a_1) ->
           if
             (try
@@ -112,7 +123,7 @@ module Spec =
                             }
                         })))
           then
-            let t_1__005_ =
+            let t_1__006_ =
               let open ModelElt in
                 {
                   contents =
@@ -142,52 +153,52 @@ module Spec =
                                     }
                                 })))
                 } in
-            Model.push (Model.drop_n state__003_ 0) t_1__005_
-          else state__003_
-      | Add (a_2, b) -> state__003_
-    let precond cmd__010_ state__011_ =
-      match cmd__010_ with | Make (i, a_1) -> true | Add (a_2, b) -> true
+            Model.push (Model.drop_n state__004_ 0) t_1__006_
+          else state__004_
+      | Add (a_2, b) -> state__004_
+    let precond cmd__011_ state__012_ =
+      match cmd__011_ with | Make (i, a_1) -> true | Add (a_2, b) -> true
     let postcond _ _ _ = true
-    let run cmd__012_ sut__013_ =
-      match cmd__012_ with
+    let run cmd__013_ sut__014_ =
+      match cmd__013_ with
       | Make (i, a_1) ->
           Res
             ((result sut exn),
-              (let res__014_ = protect (fun () -> make i a_1) () in
-               ((match res__014_ with
-                 | Ok res -> SUT.push sut__013_ res
+              (let res__015_ = protect (fun () -> make i a_1) () in
+               ((match res__015_ with
+                 | Ok res -> SUT.push sut__014_ res
                  | Error _ -> ());
-                res__014_)))
-      | Add (a_2, b) -> Res (int, (let res__015_ = add a_2 b in res__015_))
+                res__015_)))
+      | Add (a_2, b) -> Res (int, (let res__016_ = add a_2 b in res__016_))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__017_ state__018_ last__020_ res__019_ =
+let ortac_show_cmd cmd__018_ state__019_ last__021_ res__020_ =
   let open Spec in
     let open STM in
-      match (cmd__017_, res__019_) with
+      match (cmd__018_, res__020_) with
       | (Make (i, a_1), Res ((Result (SUT, Exn), _), t_1)) ->
           let lhs =
-            if last__020_
+            if last__021_
             then "r"
             else
               (match t_1 with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__018_ 0)
+               | Ok _ -> "Ok " ^ (SUT.get_name state__019_ 0)
                | Error _ -> "_")
           and shift = match t_1 with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %a %a)" lhs "make"
             (Util.Pp.pp_int true) i (Util.Pp.pp_int true) a_1
       | (Add (a_2, b), Res ((Int, _), _)) ->
-          let lhs = if last__020_ then "r" else "_"
+          let lhs = if last__021_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %a" lhs "add" (Util.Pp.pp_int true)
             a_2 (Util.Pp.pp_int true) b
       | _ -> assert false
-let ortac_postcond cmd__006_ state__007_ res__008_ =
+let ortac_postcond cmd__007_ state__008_ res__009_ =
   let open Spec in
     let open STM in
-      let new_state__009_ = lazy (next_state cmd__006_ state__007_) in
-      match (cmd__006_, res__008_) with
+      let new_state__010_ = lazy (next_state cmd__007_ state__008_) in
+      match (cmd__007_, res__009_) with
       | (Make (i, a_1), Res ((Result (SUT, Exn), _), t_1)) ->
           (match if
                    try

--- a/plugins/qcheck-stm/test/tuples_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/tuples_stm_tests.expected.ml
@@ -97,10 +97,25 @@ module Spec =
                (Util.Pp.pp_tuple2 Util.Pp.pp_char Util.Pp.pp_int) true) tup_2
       | Size_tup -> Format.asprintf "%s <sut>" "size_tup"
       | Size_tup' -> Format.asprintf "%s <sut>" "size_tup'"
+    let shrink_cmd cmd__002_ =
+      let open QCheck in
+        let open Shrink in
+          let open Iter in
+            match cmd__002_ with
+            | Create () -> map (fun () -> Create ()) (unit ())
+            | Clear -> empty
+            | Add tup -> map (fun tup -> Add tup) (tup2 char int tup)
+            | Add' tup_1 ->
+                map (fun tup_1 -> Add' tup_1) (tup3 nil char int tup_1)
+            | Add'' tup_2 ->
+                map (fun tup_2 -> Add'' tup_2)
+                  (tup2 nil (tup2 char int) tup_2)
+            | Size_tup -> empty
+            | Size_tup' -> empty
     let cleanup _ = ()
     let arb_cmd _ =
       let open QCheck in
-        make ~print:show_cmd
+        make ~print:show_cmd ~shrink:shrink_cmd
           (let open Gen in
              oneof
                [(pure (fun () -> Create ())) <*> unit;
@@ -111,10 +126,10 @@ module Spec =
                  (tup2 bool (tup2 char int));
                pure Size_tup;
                pure Size_tup'])
-    let next_state cmd__002_ state__003_ =
-      match cmd__002_ with
+    let next_state cmd__003_ state__004_ =
+      match cmd__003_ with
       | Create () ->
-          let h__005_ =
+          let h__006_ =
             let open ModelElt in
               {
                 contents =
@@ -141,10 +156,10 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 0) h__005_
+          Model.push (Model.drop_n state__004_ 0) h__006_
       | Clear ->
-          let h_1__006_ = Model.get state__003_ 0 in
-          let h_1__007_ =
+          let h_1__007_ = Model.get state__004_ 0 in
+          let h_1__008_ =
             let open ModelElt in
               {
                 contents =
@@ -171,16 +186,16 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) h_1__007_
+          Model.push (Model.drop_n state__004_ 1) h_1__008_
       | Add tup ->
-          let h_2__008_ = Model.get state__003_ 0 in
-          let h_2__009_ =
+          let h_2__009_ = Model.get state__004_ 0 in
+          let h_2__010_ =
             let open ModelElt in
               {
                 contents =
                   (try
                      match tup with
-                     | (a_1, b_1) -> (a_1, b_1) :: h_2__008_.contents
+                     | (a_1, b_1) -> (a_1, b_1) :: h_2__009_.contents
                    with
                    | e ->
                        raise
@@ -203,10 +218,10 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) h_2__009_
+          Model.push (Model.drop_n state__004_ 1) h_2__010_
       | Add' tup_1 ->
-          let h_3__010_ = Model.get state__003_ 0 in
-          let h_3__011_ =
+          let h_3__011_ = Model.get state__004_ 0 in
+          let h_3__012_ =
             let open ModelElt in
               {
                 contents =
@@ -214,8 +229,8 @@ module Spec =
                      match tup_1 with
                      | (c, a_2, b_2) ->
                          if c = true
-                         then (a_2, b_2) :: h_3__010_.contents
-                         else h_3__010_.contents
+                         then (a_2, b_2) :: h_3__011_.contents
+                         else h_3__011_.contents
                    with
                    | e ->
                        raise
@@ -238,10 +253,10 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) h_3__011_
+          Model.push (Model.drop_n state__004_ 1) h_3__012_
       | Add'' tup_2 ->
-          let h_4__012_ = Model.get state__003_ 0 in
-          let h_4__013_ =
+          let h_4__013_ = Model.get state__004_ 0 in
+          let h_4__014_ =
             let open ModelElt in
               {
                 contents =
@@ -249,8 +264,8 @@ module Spec =
                      match tup_2 with
                      | (c_1, (a_3, b_3)) ->
                          if c_1 = true
-                         then (a_3, b_3) :: h_4__012_.contents
-                         else h_4__012_.contents
+                         then (a_3, b_3) :: h_4__013_.contents
+                         else h_4__013_.contents
                    with
                    | e ->
                        raise
@@ -273,17 +288,17 @@ module Spec =
                                   }
                               })))
               } in
-          Model.push (Model.drop_n state__003_ 1) h_4__013_
+          Model.push (Model.drop_n state__004_ 1) h_4__014_
       | Size_tup ->
-          let t_1__014_ = Model.get state__003_ 0 in
-          let t_1__015_ = t_1__014_ in
-          Model.push (Model.drop_n state__003_ 1) t_1__015_
+          let t_1__015_ = Model.get state__004_ 0 in
+          let t_1__016_ = t_1__015_ in
+          Model.push (Model.drop_n state__004_ 1) t_1__016_
       | Size_tup' ->
-          let t_2__016_ = Model.get state__003_ 0 in
-          let t_2__017_ = t_2__016_ in
-          Model.push (Model.drop_n state__003_ 1) t_2__017_
-    let precond cmd__038_ state__039_ =
-      match cmd__038_ with
+          let t_2__017_ = Model.get state__004_ 0 in
+          let t_2__018_ = t_2__017_ in
+          Model.push (Model.drop_n state__004_ 1) t_2__018_
+    let precond cmd__039_ state__040_ =
+      match cmd__039_ with
       | Create () -> true
       | Clear -> true
       | Add tup -> true
@@ -292,102 +307,102 @@ module Spec =
       | Size_tup -> true
       | Size_tup' -> true
     let postcond _ _ _ = true
-    let run cmd__040_ sut__041_ =
-      match cmd__040_ with
+    let run cmd__041_ sut__042_ =
+      match cmd__041_ with
       | Create () ->
           Res
             (sut,
-              (let res__042_ = create () in
-               (SUT.push sut__041_ res__042_; res__042_)))
+              (let res__043_ = create () in
+               (SUT.push sut__042_ res__043_; res__043_)))
       | Clear ->
           Res
             (unit,
-              (let h_1__043_ = SUT.pop sut__041_ in
-               let res__044_ = clear h_1__043_ in
-               (SUT.push sut__041_ h_1__043_; res__044_)))
+              (let h_1__044_ = SUT.pop sut__042_ in
+               let res__045_ = clear h_1__044_ in
+               (SUT.push sut__042_ h_1__044_; res__045_)))
       | Add tup ->
           Res
             (unit,
-              (let h_2__045_ = SUT.pop sut__041_ in
-               let res__046_ = add h_2__045_ tup in
-               (SUT.push sut__041_ h_2__045_; res__046_)))
+              (let h_2__046_ = SUT.pop sut__042_ in
+               let res__047_ = add h_2__046_ tup in
+               (SUT.push sut__042_ h_2__046_; res__047_)))
       | Add' tup_1 ->
           Res
             (unit,
-              (let h_3__047_ = SUT.pop sut__041_ in
-               let res__048_ = add' h_3__047_ tup_1 in
-               (SUT.push sut__041_ h_3__047_; res__048_)))
+              (let h_3__048_ = SUT.pop sut__042_ in
+               let res__049_ = add' h_3__048_ tup_1 in
+               (SUT.push sut__042_ h_3__048_; res__049_)))
       | Add'' tup_2 ->
           Res
             (unit,
-              (let h_4__049_ = SUT.pop sut__041_ in
-               let res__050_ = add'' h_4__049_ tup_2 in
-               (SUT.push sut__041_ h_4__049_; res__050_)))
+              (let h_4__050_ = SUT.pop sut__042_ in
+               let res__051_ = add'' h_4__050_ tup_2 in
+               (SUT.push sut__042_ h_4__050_; res__051_)))
       | Size_tup ->
           Res
             ((tup2 int int),
-              (let t_1__051_ = SUT.pop sut__041_ in
-               let res__052_ = size_tup t_1__051_ in
-               (SUT.push sut__041_ t_1__051_; res__052_)))
+              (let t_1__052_ = SUT.pop sut__042_ in
+               let res__053_ = size_tup t_1__052_ in
+               (SUT.push sut__042_ t_1__052_; res__053_)))
       | Size_tup' ->
           Res
             ((tup3 int int int),
-              (let t_2__053_ = SUT.pop sut__041_ in
-               let res__054_ = size_tup' t_2__053_ in
-               (SUT.push sut__041_ t_2__053_; res__054_)))
+              (let t_2__054_ = SUT.pop sut__042_ in
+               let res__055_ = size_tup' t_2__054_ in
+               (SUT.push sut__042_ t_2__054_; res__055_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__056_ state__057_ last__059_ res__058_ =
+let ortac_show_cmd cmd__057_ state__058_ last__060_ res__059_ =
   let open Spec in
     let open STM in
-      match (cmd__056_, res__058_) with
+      match (cmd__057_, res__059_) with
       | (Create (), Res ((SUT, _), h)) ->
-          let lhs = if last__059_ then "r" else SUT.get_name state__057_ 0
+          let lhs = if last__060_ then "r" else SUT.get_name state__058_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "create"
             (Util.Pp.pp_unit true) ()
       | (Clear, Res ((Unit, _), _)) ->
-          let lhs = if last__059_ then "r" else "_"
+          let lhs = if last__060_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "clear"
-            (SUT.get_name state__057_ (0 + shift))
+            (SUT.get_name state__058_ (0 + shift))
       | (Add tup, Res ((Unit, _), _)) ->
-          let lhs = if last__059_ then "r" else "_"
+          let lhs = if last__060_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "add"
-            (SUT.get_name state__057_ (0 + shift))
+            (SUT.get_name state__058_ (0 + shift))
             (Util.Pp.pp_tuple2 Util.Pp.pp_char Util.Pp.pp_int true) tup
       | (Add' tup_1, Res ((Unit, _), _)) ->
-          let lhs = if last__059_ then "r" else "_"
+          let lhs = if last__060_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "add'"
-            (SUT.get_name state__057_ (0 + shift))
+            (SUT.get_name state__058_ (0 + shift))
             (Util.Pp.pp_tuple3 Util.Pp.pp_bool Util.Pp.pp_char Util.Pp.pp_int
                true) tup_1
       | (Add'' tup_2, Res ((Unit, _), _)) ->
-          let lhs = if last__059_ then "r" else "_"
+          let lhs = if last__060_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "add''"
-            (SUT.get_name state__057_ (0 + shift))
+            (SUT.get_name state__058_ (0 + shift))
             (Util.Pp.pp_tuple2 Util.Pp.pp_bool
                (Util.Pp.pp_tuple2 Util.Pp.pp_char Util.Pp.pp_int) true) tup_2
       | (Size_tup, Res ((Tup2 (Int, Int), _), _)) ->
-          let lhs = if last__059_ then "r" else "_"
+          let lhs = if last__060_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "size_tup"
-            (SUT.get_name state__057_ (0 + shift))
+            (SUT.get_name state__058_ (0 + shift))
       | (Size_tup', Res ((Tup3 (Int, Int, Int), _), _)) ->
-          let lhs = if last__059_ then "r" else "_"
+          let lhs = if last__060_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "size_tup'"
-            (SUT.get_name state__057_ (0 + shift))
+            (SUT.get_name state__058_ (0 + shift))
       | _ -> assert false
-let ortac_postcond cmd__018_ state__019_ res__020_ =
+let ortac_postcond cmd__019_ state__020_ res__021_ =
   let open Spec in
     let open STM in
-      let new_state__021_ = lazy (next_state cmd__018_ state__019_) in
-      match (cmd__018_, res__020_) with
+      let new_state__022_ = lazy (next_state cmd__019_ state__020_) in
+      match (cmd__019_, res__021_) with
       | (Create (), Res ((SUT, _), h)) -> None
       | (Clear, Res ((Unit, _), _)) -> None
       | (Add tup, Res ((Unit, _), _)) -> None
@@ -396,13 +411,13 @@ let ortac_postcond cmd__018_ state__019_ res__020_ =
       | (Size_tup, Res ((Tup2 (Int, Int), _), (x, y))) ->
           Ortac_runtime.append
             (if
-               let t_old__026_ = Model.get state__019_ 0
-               and t_new__027_ =
-                 lazy (Model.get (Lazy.force new_state__021_) 0) in
+               let t_old__027_ = Model.get state__020_ 0
+               and t_new__028_ =
+                 lazy (Model.get (Lazy.force new_state__022_) 0) in
                try
                  (Ortac_runtime.Gospelstdlib.integer_of_int x) =
                    (Ortac_runtime.Gospelstdlib.List.length
-                      (Lazy.force t_new__027_).contents)
+                      (Lazy.force t_new__028_).contents)
                with
                | e ->
                    raise
@@ -448,13 +463,13 @@ let ortac_postcond cmd__018_ state__019_ res__020_ =
                            }
                        })]))
             (if
-               let t_old__028_ = Model.get state__019_ 0
-               and t_new__029_ =
-                 lazy (Model.get (Lazy.force new_state__021_) 0) in
+               let t_old__029_ = Model.get state__020_ 0
+               and t_new__030_ =
+                 lazy (Model.get (Lazy.force new_state__022_) 0) in
                try
                  (Ortac_runtime.Gospelstdlib.integer_of_int y) =
                    (Ortac_runtime.Gospelstdlib.List.length
-                      (Lazy.force t_new__029_).contents)
+                      (Lazy.force t_new__030_).contents)
                with
                | e ->
                    raise
@@ -502,13 +517,13 @@ let ortac_postcond cmd__018_ state__019_ res__020_ =
       | (Size_tup', Res ((Tup3 (Int, Int, Int), _), (x_1, y_1, z))) ->
           Ortac_runtime.append
             (if
-               let t_old__031_ = Model.get state__019_ 0
-               and t_new__032_ =
-                 lazy (Model.get (Lazy.force new_state__021_) 0) in
+               let t_old__032_ = Model.get state__020_ 0
+               and t_new__033_ =
+                 lazy (Model.get (Lazy.force new_state__022_) 0) in
                try
                  (Ortac_runtime.Gospelstdlib.integer_of_int x_1) =
                    (Ortac_runtime.Gospelstdlib.List.length
-                      (Lazy.force t_new__032_).contents)
+                      (Lazy.force t_new__033_).contents)
                with
                | e ->
                    raise
@@ -555,13 +570,13 @@ let ortac_postcond cmd__018_ state__019_ res__020_ =
                        })]))
             (Ortac_runtime.append
                (if
-                  let t_old__033_ = Model.get state__019_ 0
-                  and t_new__034_ =
-                    lazy (Model.get (Lazy.force new_state__021_) 0) in
+                  let t_old__034_ = Model.get state__020_ 0
+                  and t_new__035_ =
+                    lazy (Model.get (Lazy.force new_state__022_) 0) in
                   try
                     (Ortac_runtime.Gospelstdlib.integer_of_int y_1) =
                       (Ortac_runtime.Gospelstdlib.List.length
-                         (Lazy.force t_new__034_).contents)
+                         (Lazy.force t_new__035_).contents)
                   with
                   | e ->
                       raise
@@ -607,13 +622,13 @@ let ortac_postcond cmd__018_ state__019_ res__020_ =
                               }
                           })]))
                (if
-                  let t_old__035_ = Model.get state__019_ 0
-                  and t_new__036_ =
-                    lazy (Model.get (Lazy.force new_state__021_) 0) in
+                  let t_old__036_ = Model.get state__020_ 0
+                  and t_new__037_ =
+                    lazy (Model.get (Lazy.force new_state__022_) 0) in
                   try
                     (Ortac_runtime.Gospelstdlib.integer_of_int z) =
                       (Ortac_runtime.Gospelstdlib.List.length
-                         (Lazy.force t_new__036_).contents)
+                         (Lazy.force t_new__037_).contents)
                   with
                   | e ->
                       raise


### PR DESCRIPTION
This PR adds support for creating a function to automatically shrink the arguments of tested functions when creating counter-examples. 

This fixes #269.