### PR TITLE
Fix generation of the `QCheck.Fn.apply` identifier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix generation of the `QCheck.Fn.apply` identifier
+  [\#288](https://github.com/ocaml-gospel/ortac/pull/288)
 - Improve failure message in case of out of domain failure
   [\#287](https://github.com/ocaml-gospel/ortac/pull/287)
 

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -16,6 +16,7 @@ let exp_default = evar exp_default_name
 let res_default = Ident.create ~loc:Location.none "res"
 let list_append = list_fold_expr (qualify [ "Ortac_runtime" ] "append") "None"
 let res = lident "Res"
+let fn_apply_name = Ident.create ~loc:Location.none "QCheck.Fn.apply"
 
 let eexpected_value case e =
   let x =
@@ -140,7 +141,6 @@ let subst_term state ?(out_of_scope = []) ~gos_t ?(old_lz = false) ~fun_vars
           raise (ImpossibleSubst (term, `NotModel))
     | Tvar { vs_name; _ } when List.mem vs_name fun_vars ->
         let open Gospel in
-        let fn_apply_name = Ident.create ~loc:Location.none "QCheck.Fn.apply" in
         let fn_apply_ty = Ttypes.fresh_ty_var "a" in
         let fn_apply_term =
           Tterm_helper.mk_term

--- a/plugins/qcheck-stm/test/array.mli
+++ b/plugins/qcheck-stm/test/array.mli
@@ -60,3 +60,7 @@ val of_list : 'a list -> 'a t
 val mem : 'a -> 'a t -> bool
 (*@ b = mem a t
     ensures b = Sequence.mem t.contents a *)
+
+val for_all : ('a -> bool) -> 'a t -> bool
+(*@ b = for_all p t
+    ensures b = Sequence.fold_left (fun acc a -> p a && acc) true t.contents *)

--- a/plugins/qcheck-stm/test/array_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/array_stm_tests.expected.ml
@@ -1604,8 +1604,7 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                  (Ortac_runtime.Gospelstdlib.Sequence.fold_left
                     (fun acc ->
                        fun a_6 ->
-                         if
-                           ((QCheck.Fn.apply_1 p a_6) = true) && (acc = true)
+                         if ((QCheck.Fn.apply p a_6) = true) && (acc = true)
                          then true
                          else false) true (Lazy.force t_new__085_).contents)
              with | e -> false)

--- a/plugins/qcheck-stm/test/array_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/array_stm_tests.expected.ml
@@ -100,6 +100,7 @@ module Spec =
       | To_list 
       | Of_list of char list 
       | Mem of char 
+      | For_all of (char -> bool) QCheck.fun_ 
     let show_cmd cmd__001_ =
       match cmd__001_ with
       | Length -> Format.asprintf "%s <sut>" "length"
@@ -127,6 +128,8 @@ module Spec =
             (Util.Pp.pp_list Util.Pp.pp_char true) l
       | Mem a_3 ->
           Format.asprintf "%s %a <sut>" "mem" (Util.Pp.pp_char true) a_3
+      | For_all p ->
+          Format.asprintf "%s %a <sut>" "for_all" (Util.Pp.pp_fun_ true) p
     let cleanup _ = ()
     let arb_cmd _ =
       let open QCheck in
@@ -149,7 +152,9 @@ module Spec =
                  <*> char;
                pure To_list;
                (pure (fun l -> Of_list l)) <*> (list char);
-               (pure (fun a_3 -> Mem a_3)) <*> char])
+               (pure (fun a_3 -> Mem a_3)) <*> char;
+               (pure (fun p -> For_all p)) <*>
+                 (fun1 Observable.char QCheck.bool).gen])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Length ->
@@ -634,8 +639,12 @@ module Spec =
           let t_11__042_ = Model.get state__003_ 0 in
           let t_11__043_ = t_11__042_ in
           Model.push (Model.drop_n state__003_ 1) t_11__043_
-    let precond cmd__080_ state__081_ =
-      match cmd__080_ with
+      | For_all p ->
+          let t_12__044_ = Model.get state__003_ 0 in
+          let t_12__045_ = t_12__044_ in
+          Model.push (Model.drop_n state__003_ 1) t_12__045_
+    let precond cmd__087_ state__088_ =
+      match cmd__087_ with
       | Length -> true
       | Get i -> true
       | Set (i_1, a_1) -> true
@@ -647,179 +656,191 @@ module Spec =
       | To_list -> true
       | Of_list l -> true
       | Mem a_3 -> true
+      | For_all p -> true
     let postcond _ _ _ = true
-    let run cmd__082_ sut__083_ =
-      match cmd__082_ with
+    let run cmd__089_ sut__090_ =
+      match cmd__089_ with
       | Length ->
           Res
             (int,
-              (let t_1__084_ = SUT.pop sut__083_ in
-               let res__085_ = length t_1__084_ in
-               (SUT.push sut__083_ t_1__084_; res__085_)))
+              (let t_1__091_ = SUT.pop sut__090_ in
+               let res__092_ = length t_1__091_ in
+               (SUT.push sut__090_ t_1__091_; res__092_)))
       | Get i ->
           Res
             ((result char exn),
-              (let t_2__086_ = SUT.pop sut__083_ in
-               let res__087_ = protect (fun () -> get t_2__086_ i) () in
-               (SUT.push sut__083_ t_2__086_; res__087_)))
+              (let t_2__093_ = SUT.pop sut__090_ in
+               let res__094_ = protect (fun () -> get t_2__093_ i) () in
+               (SUT.push sut__090_ t_2__093_; res__094_)))
       | Set (i_1, a_1) ->
           Res
             ((result unit exn),
-              (let t_3__088_ = SUT.pop sut__083_ in
-               let res__089_ = protect (fun () -> set t_3__088_ i_1 a_1) () in
-               (SUT.push sut__083_ t_3__088_; res__089_)))
+              (let t_3__095_ = SUT.pop sut__090_ in
+               let res__096_ = protect (fun () -> set t_3__095_ i_1 a_1) () in
+               (SUT.push sut__090_ t_3__095_; res__096_)))
       | Make (i_2, a_2) ->
           Res
             ((result sut exn),
-              (let res__090_ = protect (fun () -> make i_2 a_2) () in
-               ((match res__090_ with
-                 | Ok res -> SUT.push sut__083_ res
+              (let res__097_ = protect (fun () -> make i_2 a_2) () in
+               ((match res__097_ with
+                 | Ok res -> SUT.push sut__090_ res
                  | Error _ -> ());
-                res__090_)))
+                res__097_)))
       | Append ->
           Res
             (sut,
-              (let a_4__091_ = SUT.pop sut__083_ in
-               let b__092_ = SUT.pop sut__083_ in
-               let res__093_ = append a_4__091_ b__092_ in
-               (SUT.push sut__083_ b__092_;
-                SUT.push sut__083_ a_4__091_;
-                SUT.push sut__083_ res__093_;
-                res__093_)))
+              (let a_4__098_ = SUT.pop sut__090_ in
+               let b__099_ = SUT.pop sut__090_ in
+               let res__100_ = append a_4__098_ b__099_ in
+               (SUT.push sut__090_ b__099_;
+                SUT.push sut__090_ a_4__098_;
+                SUT.push sut__090_ res__100_;
+                res__100_)))
       | Sub (i_3, n) ->
           Res
             ((result sut exn),
-              (let t_6__094_ = SUT.pop sut__083_ in
-               let res__095_ = protect (fun () -> sub t_6__094_ i_3 n) () in
-               (SUT.push sut__083_ t_6__094_;
-                (match res__095_ with
-                 | Ok res -> SUT.push sut__083_ res
+              (let t_6__101_ = SUT.pop sut__090_ in
+               let res__102_ = protect (fun () -> sub t_6__101_ i_3 n) () in
+               (SUT.push sut__090_ t_6__101_;
+                (match res__102_ with
+                 | Ok res -> SUT.push sut__090_ res
                  | Error _ -> ());
-                res__095_)))
+                res__102_)))
       | Copy ->
           Res
             (sut,
-              (let t_7__096_ = SUT.pop sut__083_ in
-               let res__097_ = copy t_7__096_ in
-               (SUT.push sut__083_ t_7__096_;
-                SUT.push sut__083_ res__097_;
-                res__097_)))
+              (let t_7__103_ = SUT.pop sut__090_ in
+               let res__104_ = copy t_7__103_ in
+               (SUT.push sut__090_ t_7__103_;
+                SUT.push sut__090_ res__104_;
+                res__104_)))
       | Fill (pos, len, x) ->
           Res
             ((result unit exn),
-              (let t_8__098_ = SUT.pop sut__083_ in
-               let res__099_ =
-                 protect (fun () -> fill t_8__098_ pos len x) () in
-               (SUT.push sut__083_ t_8__098_; res__099_)))
+              (let t_8__105_ = SUT.pop sut__090_ in
+               let res__106_ =
+                 protect (fun () -> fill t_8__105_ pos len x) () in
+               (SUT.push sut__090_ t_8__105_; res__106_)))
       | To_list ->
           Res
             ((list char),
-              (let t_9__100_ = SUT.pop sut__083_ in
-               let res__101_ = to_list t_9__100_ in
-               (SUT.push sut__083_ t_9__100_; res__101_)))
+              (let t_9__107_ = SUT.pop sut__090_ in
+               let res__108_ = to_list t_9__107_ in
+               (SUT.push sut__090_ t_9__107_; res__108_)))
       | Of_list l ->
           Res
             (sut,
-              (let res__102_ = of_list l in
-               (SUT.push sut__083_ res__102_; res__102_)))
+              (let res__109_ = of_list l in
+               (SUT.push sut__090_ res__109_; res__109_)))
       | Mem a_3 ->
           Res
             (bool,
-              (let t_11__103_ = SUT.pop sut__083_ in
-               let res__104_ = mem a_3 t_11__103_ in
-               (SUT.push sut__083_ t_11__103_; res__104_)))
+              (let t_11__110_ = SUT.pop sut__090_ in
+               let res__111_ = mem a_3 t_11__110_ in
+               (SUT.push sut__090_ t_11__110_; res__111_)))
+      | For_all p ->
+          Res
+            (bool,
+              (let t_12__112_ = SUT.pop sut__090_ in
+               let res__113_ = for_all (QCheck.Fn.apply p) t_12__112_ in
+               (SUT.push sut__090_ t_12__112_; res__113_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__106_ state__107_ last__109_ res__108_ =
+let ortac_show_cmd cmd__115_ state__116_ last__118_ res__117_ =
   let open Spec in
     let open STM in
-      match (cmd__106_, res__108_) with
+      match (cmd__115_, res__117_) with
       | (Length, Res ((Int, _), _)) ->
-          let lhs = if last__109_ then "r" else "_"
+          let lhs = if last__118_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "length"
-            (SUT.get_name state__107_ (0 + shift))
+            (SUT.get_name state__116_ (0 + shift))
       | (Get i, Res ((Result (Char, Exn), _), _)) ->
-          let lhs = if last__109_ then "r" else "_"
+          let lhs = if last__118_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a)" lhs "get"
-            (SUT.get_name state__107_ (0 + shift)) (Util.Pp.pp_int true) i
+            (SUT.get_name state__116_ (0 + shift)) (Util.Pp.pp_int true) i
       | (Set (i_1, a_1), Res ((Result (Unit, Exn), _), _)) ->
-          let lhs = if last__109_ then "r" else "_"
+          let lhs = if last__118_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "set" (SUT.get_name state__107_ (0 + shift))
+            "set" (SUT.get_name state__116_ (0 + shift))
             (Util.Pp.pp_int true) i_1 (Util.Pp.pp_char true) a_1
       | (Make (i_2, a_2), Res ((Result (SUT, Exn), _), t_4)) ->
           let lhs =
-            if last__109_
+            if last__118_
             then "r"
             else
               (match t_4 with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__107_ 0)
+               | Ok _ -> "Ok " ^ (SUT.get_name state__116_ 0)
                | Error _ -> "_")
           and shift = match t_4 with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %a %a)" lhs "make"
             (Util.Pp.pp_int true) i_2 (Util.Pp.pp_char true) a_2
       | (Append, Res ((SUT, _), t_5)) ->
-          let lhs = if last__109_ then "r" else SUT.get_name state__107_ 0
+          let lhs = if last__118_ then "r" else SUT.get_name state__116_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s %s" lhs "append"
-            (SUT.get_name state__107_ (0 + shift))
-            (SUT.get_name state__107_ (1 + shift))
+            (SUT.get_name state__116_ (0 + shift))
+            (SUT.get_name state__116_ (1 + shift))
       | (Sub (i_3, n), Res ((Result (SUT, Exn), _), r)) ->
           let lhs =
-            if last__109_
+            if last__118_
             then "r"
             else
               (match r with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__107_ 0)
+               | Ok _ -> "Ok " ^ (SUT.get_name state__116_ 0)
                | Error _ -> "_")
           and shift = match r with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "sub" (SUT.get_name state__107_ (0 + shift))
+            "sub" (SUT.get_name state__116_ (0 + shift))
             (Util.Pp.pp_int true) i_3 (Util.Pp.pp_int true) n
       | (Copy, Res ((SUT, _), r_1)) ->
-          let lhs = if last__109_ then "r" else SUT.get_name state__107_ 0
+          let lhs = if last__118_ then "r" else SUT.get_name state__116_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s" lhs "copy"
-            (SUT.get_name state__107_ (0 + shift))
+            (SUT.get_name state__116_ (0 + shift))
       | (Fill (pos, len, x), Res ((Result (Unit, Exn), _), _)) ->
-          let lhs = if last__109_ then "r" else "_"
+          let lhs = if last__118_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a %a)" lhs
-            "fill" (SUT.get_name state__107_ (0 + shift))
+            "fill" (SUT.get_name state__116_ (0 + shift))
             (Util.Pp.pp_int true) pos (Util.Pp.pp_int true) len
             (Util.Pp.pp_char true) x
       | (To_list, Res ((List (Char), _), _)) ->
-          let lhs = if last__109_ then "r" else "_"
+          let lhs = if last__118_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "to_list"
-            (SUT.get_name state__107_ (0 + shift))
+            (SUT.get_name state__116_ (0 + shift))
       | (Of_list l, Res ((SUT, _), t_10)) ->
-          let lhs = if last__109_ then "r" else SUT.get_name state__107_ 0
+          let lhs = if last__118_ then "r" else SUT.get_name state__116_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "of_list"
             (Util.Pp.pp_list Util.Pp.pp_char true) l
       | (Mem a_3, Res ((Bool, _), _)) ->
-          let lhs = if last__109_ then "r" else "_"
+          let lhs = if last__118_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "mem"
-            (Util.Pp.pp_char true) a_3 (SUT.get_name state__107_ (0 + shift))
+            (Util.Pp.pp_char true) a_3 (SUT.get_name state__116_ (0 + shift))
+      | (For_all p, Res ((Bool, _), _)) ->
+          let lhs = if last__118_ then "r" else "_"
+          and shift = 0 in
+          Format.asprintf "let %s = %s %a %s" lhs "for_all"
+            (Util.Pp.pp_fun_ true) p (SUT.get_name state__116_ (0 + shift))
       | _ -> assert false
-let ortac_postcond cmd__044_ state__045_ res__046_ =
+let ortac_postcond cmd__046_ state__047_ res__048_ =
   let open Spec in
     let open STM in
-      let new_state__047_ = lazy (next_state cmd__044_ state__045_) in
-      match (cmd__044_, res__046_) with
+      let new_state__049_ = lazy (next_state cmd__046_ state__047_) in
+      match (cmd__046_, res__048_) with
       | (Length, Res ((Int, _), i_5)) ->
           if
-            let t_old__050_ = Model.get state__045_ 0
-            and t_new__051_ = lazy (Model.get (Lazy.force new_state__047_) 0) in
+            let t_old__052_ = Model.get state__047_ 0
+            and t_new__053_ = lazy (Model.get (Lazy.force new_state__049_) 0) in
             (try
                (Ortac_runtime.Gospelstdlib.integer_of_int i_5) =
-                 (Lazy.force t_new__051_).size
+                 (Lazy.force t_new__053_).size
              with | e -> false)
           then None
           else
@@ -829,10 +850,10 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                     Ortac_runtime.Value
                       (Res
                          (integer,
-                           (let t_old__048_ = Model.get state__045_ 0
-                            and t_new__049_ =
-                              lazy (Model.get (Lazy.force new_state__047_) 0) in
-                            (Lazy.force t_new__049_).size)))
+                           (let t_old__050_ = Model.get state__047_ 0
+                            and t_new__051_ =
+                              lazy (Model.get (Lazy.force new_state__049_) 0) in
+                            (Lazy.force t_new__051_).size)))
                   with | e -> Ortac_runtime.Out_of_domain) "length"
                  [("i = t.size",
                     {
@@ -853,17 +874,17 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                     })])
       | (Get i, Res ((Result (Char, Exn), _), a_5)) ->
           (match if
-                   let tmp__057_ = Model.get state__045_ 0 in
+                   let tmp__059_ = Model.get state__047_ 0 in
                    try
-                     let __t1__058_ =
+                     let __t1__060_ =
                        Ortac_runtime.Gospelstdlib.(<=)
                          (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                          (Ortac_runtime.Gospelstdlib.integer_of_int i) in
-                     let __t2__059_ =
+                     let __t2__061_ =
                        Ortac_runtime.Gospelstdlib.(<)
                          (Ortac_runtime.Gospelstdlib.integer_of_int i)
-                         tmp__057_.size in
-                     __t1__058_ && __t2__059_
+                         tmp__059_.size in
+                     __t1__060_ && __t2__061_
                    with | e -> false
                  then None
                  else
@@ -893,13 +914,13 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                (match a_5 with
                 | Ok a_5 ->
                     if
-                      let t_old__055_ = Model.get state__045_ 0
-                      and t_new__056_ =
-                        lazy (Model.get (Lazy.force new_state__047_) 0) in
+                      let t_old__057_ = Model.get state__047_ 0
+                      and t_new__058_ =
+                        lazy (Model.get (Lazy.force new_state__049_) 0) in
                       (try
                          a_5 =
                            (Ortac_runtime.Gospelstdlib.__mix_Bub
-                              (Lazy.force t_new__056_).contents
+                              (Lazy.force t_new__058_).contents
                               (Ortac_runtime.Gospelstdlib.integer_of_int i))
                        with | e -> false)
                     then None
@@ -910,14 +931,14 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                               Ortac_runtime.Protected_value
                                 (Res
                                    (char,
-                                     (let t_old__053_ =
-                                        Model.get state__045_ 0
-                                      and t_new__054_ =
+                                     (let t_old__055_ =
+                                        Model.get state__047_ 0
+                                      and t_new__056_ =
                                         lazy
                                           (Model.get
-                                             (Lazy.force new_state__047_) 0) in
+                                             (Lazy.force new_state__049_) 0) in
                                       Ortac_runtime.Gospelstdlib.__mix_Bub
-                                        (Lazy.force t_new__054_).contents
+                                        (Lazy.force t_new__056_).contents
                                         (Ortac_runtime.Gospelstdlib.integer_of_int
                                            i))))
                             with | e -> Ortac_runtime.Out_of_domain) "get"
@@ -944,17 +965,17 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                 | Error (Invalid_argument _) -> None
                 | _ ->
                     if
-                      let tmp__057_ = Model.get state__045_ 0 in
+                      let tmp__059_ = Model.get state__047_ 0 in
                       (try
-                         let __t1__058_ =
+                         let __t1__060_ =
                            Ortac_runtime.Gospelstdlib.(<=)
                              (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                              (Ortac_runtime.Gospelstdlib.integer_of_int i) in
-                         let __t2__059_ =
+                         let __t2__061_ =
                            Ortac_runtime.Gospelstdlib.(<)
                              (Ortac_runtime.Gospelstdlib.integer_of_int i)
-                             tmp__057_.size in
-                         __t1__058_ && __t2__059_
+                             tmp__059_.size in
+                         __t1__060_ && __t2__061_
                        with | e -> false)
                     then None
                     else
@@ -981,17 +1002,17 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                               })])))
       | (Set (i_1, a_1), Res ((Result (Unit, Exn), _), res)) ->
           (match if
-                   let tmp__060_ = Model.get state__045_ 0 in
+                   let tmp__062_ = Model.get state__047_ 0 in
                    try
-                     let __t1__061_ =
+                     let __t1__063_ =
                        Ortac_runtime.Gospelstdlib.(<=)
                          (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                          (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
-                     let __t2__062_ =
+                     let __t2__064_ =
                        Ortac_runtime.Gospelstdlib.(<)
                          (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
-                         tmp__060_.size in
-                     __t1__061_ && __t2__062_
+                         tmp__062_.size in
+                     __t1__063_ && __t2__064_
                    with | e -> false
                  then None
                  else
@@ -1023,17 +1044,17 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                 | Error (Invalid_argument _) -> None
                 | _ ->
                     if
-                      let tmp__060_ = Model.get state__045_ 0 in
+                      let tmp__062_ = Model.get state__047_ 0 in
                       (try
-                         let __t1__061_ =
+                         let __t1__063_ =
                            Ortac_runtime.Gospelstdlib.(<=)
                              (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                              (Ortac_runtime.Gospelstdlib.integer_of_int i_1) in
-                         let __t2__062_ =
+                         let __t2__064_ =
                            Ortac_runtime.Gospelstdlib.(<)
                              (Ortac_runtime.Gospelstdlib.integer_of_int i_1)
-                             tmp__060_.size in
-                         __t1__061_ && __t2__062_
+                             tmp__062_.size in
+                         __t1__063_ && __t2__064_
                        with | e -> false)
                     then None
                     else
@@ -1127,18 +1148,18 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
       | (Sub (i_3, n), Res ((Result (SUT, Exn), _), r)) ->
           (match Ortac_runtime.append
                    (if
-                      let tmp__065_ = Model.get state__045_ 0 in
+                      let tmp__067_ = Model.get state__047_ 0 in
                       try
-                        let __t1__066_ =
+                        let __t1__068_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                             (Ortac_runtime.Gospelstdlib.integer_of_int i_3) in
-                        let __t2__067_ =
+                        let __t2__069_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                             (Ortac_runtime.Gospelstdlib.Sequence.length
-                               tmp__065_.contents) in
-                        __t1__066_ && __t2__067_
+                               tmp__067_.contents) in
+                        __t1__068_ && __t2__069_
                       with | e -> false
                     then None
                     else
@@ -1164,22 +1185,22 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                                   }
                               })]))
                    (if
-                      let tmp__065_ = Model.get state__045_ 0 in
+                      let tmp__067_ = Model.get state__047_ 0 in
                       try
-                        let __t1__068_ =
+                        let __t1__070_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                             (Ortac_runtime.Gospelstdlib.(+)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                                (Ortac_runtime.Gospelstdlib.integer_of_int n)) in
-                        let __t2__069_ =
+                        let __t2__071_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.(+)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                                (Ortac_runtime.Gospelstdlib.integer_of_int n))
                             (Ortac_runtime.Gospelstdlib.Sequence.length
-                               tmp__065_.contents) in
-                        __t1__068_ && __t2__069_
+                               tmp__067_.contents) in
+                        __t1__070_ && __t2__071_
                       with | e -> false
                     then None
                     else
@@ -1212,18 +1233,18 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                 | _ ->
                     Ortac_runtime.append
                       (if
-                         let tmp__065_ = Model.get state__045_ 0 in
+                         let tmp__067_ = Model.get state__047_ 0 in
                          try
-                           let __t1__066_ =
+                           let __t1__068_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_3) in
-                           let __t2__067_ =
+                           let __t2__069_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                                (Ortac_runtime.Gospelstdlib.Sequence.length
-                                  tmp__065_.contents) in
-                           __t1__066_ && __t2__067_
+                                  tmp__067_.contents) in
+                           __t1__068_ && __t2__069_
                          with | e -> false
                        then None
                        else
@@ -1249,9 +1270,9 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                                      }
                                  })]))
                       (if
-                         let tmp__065_ = Model.get state__045_ 0 in
+                         let tmp__067_ = Model.get state__047_ 0 in
                          try
-                           let __t1__068_ =
+                           let __t1__070_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                                (Ortac_runtime.Gospelstdlib.(+)
@@ -1259,7 +1280,7 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                                      i_3)
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
                                      n)) in
-                           let __t2__069_ =
+                           let __t2__071_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.(+)
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
@@ -1267,8 +1288,8 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
                                      n))
                                (Ortac_runtime.Gospelstdlib.Sequence.length
-                                  tmp__065_.contents) in
-                           __t1__068_ && __t2__069_
+                                  tmp__067_.contents) in
+                           __t1__070_ && __t2__071_
                          with | e -> false
                        then None
                        else
@@ -1297,7 +1318,7 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
       | (Fill (pos, len, x), Res ((Result (Unit, Exn), _), res)) ->
           (match Ortac_runtime.append
                    (if
-                      let tmp__071_ = Model.get state__045_ 0 in
+                      let tmp__073_ = Model.get state__047_ 0 in
                       try
                         Ortac_runtime.Gospelstdlib.(<=)
                           (Ortac_runtime.Gospelstdlib.integer_of_int 0)
@@ -1328,7 +1349,7 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                               })]))
                    (Ortac_runtime.append
                       (if
-                         let tmp__071_ = Model.get state__045_ 0 in
+                         let tmp__073_ = Model.get state__047_ 0 in
                          try
                            Ortac_runtime.Gospelstdlib.(<=)
                              (Ortac_runtime.Gospelstdlib.integer_of_int 0)
@@ -1359,14 +1380,14 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                                      }
                                  })]))
                       (if
-                         let tmp__071_ = Model.get state__045_ 0 in
+                         let tmp__073_ = Model.get state__047_ 0 in
                          try
                            Ortac_runtime.Gospelstdlib.(<=)
                              (Ortac_runtime.Gospelstdlib.(+)
                                 (Ortac_runtime.Gospelstdlib.integer_of_int
                                    pos)
                                 (Ortac_runtime.Gospelstdlib.integer_of_int
-                                   len)) tmp__071_.size
+                                   len)) tmp__073_.size
                          with | e -> false
                        then None
                        else
@@ -1400,7 +1421,7 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                 | _ ->
                     Ortac_runtime.append
                       (if
-                         let tmp__071_ = Model.get state__045_ 0 in
+                         let tmp__073_ = Model.get state__047_ 0 in
                          try
                            Ortac_runtime.Gospelstdlib.(<=)
                              (Ortac_runtime.Gospelstdlib.integer_of_int 0)
@@ -1432,7 +1453,7 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                                  })]))
                       (Ortac_runtime.append
                          (if
-                            let tmp__071_ = Model.get state__045_ 0 in
+                            let tmp__073_ = Model.get state__047_ 0 in
                             try
                               Ortac_runtime.Gospelstdlib.(<=)
                                 (Ortac_runtime.Gospelstdlib.integer_of_int 0)
@@ -1466,14 +1487,14 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                                         }
                                     })]))
                          (if
-                            let tmp__071_ = Model.get state__045_ 0 in
+                            let tmp__073_ = Model.get state__047_ 0 in
                             try
                               Ortac_runtime.Gospelstdlib.(<=)
                                 (Ortac_runtime.Gospelstdlib.(+)
                                    (Ortac_runtime.Gospelstdlib.integer_of_int
                                       pos)
                                    (Ortac_runtime.Gospelstdlib.integer_of_int
-                                      len)) tmp__071_.size
+                                      len)) tmp__073_.size
                             with | e -> false
                           then None
                           else
@@ -1503,12 +1524,12 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                                     })])))))
       | (To_list, Res ((List (Char), _), l_1)) ->
           if
-            let t_old__074_ = Model.get state__045_ 0
-            and t_new__075_ = lazy (Model.get (Lazy.force new_state__047_) 0) in
+            let t_old__076_ = Model.get state__047_ 0
+            and t_new__077_ = lazy (Model.get (Lazy.force new_state__049_) 0) in
             (try
                l_1 =
                  (Ortac_runtime.Gospelstdlib.List.of_seq
-                    (Lazy.force t_new__075_).contents)
+                    (Lazy.force t_new__077_).contents)
              with | e -> false)
           then None
           else
@@ -1518,11 +1539,11 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                     Ortac_runtime.Value
                       (Res
                          ((list char),
-                           (let t_old__072_ = Model.get state__045_ 0
-                            and t_new__073_ =
-                              lazy (Model.get (Lazy.force new_state__047_) 0) in
+                           (let t_old__074_ = Model.get state__047_ 0
+                            and t_new__075_ =
+                              lazy (Model.get (Lazy.force new_state__049_) 0) in
                             Ortac_runtime.Gospelstdlib.List.of_seq
-                              (Lazy.force t_new__073_).contents)))
+                              (Lazy.force t_new__075_).contents)))
                   with | e -> Ortac_runtime.Out_of_domain) "to_list"
                  [("l = List.of_seq t.contents",
                     {
@@ -1544,12 +1565,12 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
       | (Of_list l, Res ((SUT, _), t_10)) -> None
       | (Mem a_3, Res ((Bool, _), b_1)) ->
           if
-            let t_old__077_ = Model.get state__045_ 0
-            and t_new__078_ = lazy (Model.get (Lazy.force new_state__047_) 0) in
+            let t_old__079_ = Model.get state__047_ 0
+            and t_new__080_ = lazy (Model.get (Lazy.force new_state__049_) 0) in
             (try
                (b_1 = true) =
                  (Ortac_runtime.Gospelstdlib.Sequence.mem
-                    (Lazy.force t_new__078_).contents a_3)
+                    (Lazy.force t_new__080_).contents a_3)
              with | e -> false)
           then None
           else
@@ -1572,6 +1593,58 @@ let ortac_postcond cmd__044_ state__045_ res__046_ =
                           pos_lnum = 62;
                           pos_bol = 2791;
                           pos_cnum = 2832
+                        }
+                    })])
+      | (For_all p, Res ((Bool, _), b_2)) ->
+          if
+            let t_old__084_ = Model.get state__047_ 0
+            and t_new__085_ = lazy (Model.get (Lazy.force new_state__049_) 0) in
+            (try
+               b_2 =
+                 (Ortac_runtime.Gospelstdlib.Sequence.fold_left
+                    (fun acc ->
+                       fun a_6 ->
+                         if
+                           ((QCheck.Fn.apply_1 p a_6) = true) && (acc = true)
+                         then true
+                         else false) true (Lazy.force t_new__085_).contents)
+             with | e -> false)
+          then None
+          else
+            Some
+              (Ortac_runtime.report "Array" "make 16 'a'"
+                 (try
+                    Ortac_runtime.Value
+                      (Res
+                         (bool,
+                           (let t_old__082_ = Model.get state__047_ 0
+                            and t_new__083_ =
+                              lazy (Model.get (Lazy.force new_state__049_) 0) in
+                            Ortac_runtime.Gospelstdlib.Sequence.fold_left
+                              (fun acc ->
+                                 fun a_6 ->
+                                   if
+                                     ((QCheck.Fn.apply p a_6) = true) &&
+                                       (acc = true)
+                                   then true
+                                   else false) true
+                              (Lazy.force t_new__083_).contents)))
+                  with | e -> Ortac_runtime.Out_of_domain) "for_all"
+                 [("b = Sequence.fold_left (fun acc a -> p a && acc) true t.contents",
+                    {
+                      Ortac_runtime.start =
+                        {
+                          pos_fname = "array.mli";
+                          pos_lnum = 66;
+                          pos_bol = 2989;
+                          pos_cnum = 3001
+                        };
+                      Ortac_runtime.stop =
+                        {
+                          pos_fname = "array.mli";
+                          pos_lnum = 66;
+                          pos_bol = 2989;
+                          pos_cnum = 3065
                         }
                     })])
       | _ -> None


### PR DESCRIPTION

Due to how `Gospel.Identifier.Ident.create` guarantee identifier uniqueness, some setup was generating `QCheck.Fn.apply_1` call in the generated code.

This PR fixes this behaviour by extracting the generation of this identifier so that it is done at most once per run.