### PR TITLE
Make search for returned value description more flexible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Make search for returned value description more flexible
+  [\#291](https://github.com/ocaml-gospel/ortac/pull/291)
 - Fix generation of the `QCheck.Fn.apply` identifier
   [\#288](https://github.com/ocaml-gospel/ortac/pull/288)
 - Improve failure message in case of out of domain failure

--- a/examples/lwt_dllist_spec_tests.ml
+++ b/examples/lwt_dllist_spec_tests.ml
@@ -357,8 +357,8 @@ module Spec =
                               })))
               } in
           Model.push (Model.drop_n state__003_ 1) s_8__022_
-    let precond cmd__057_ state__058_ =
-      match cmd__057_ with
+    let precond cmd__059_ state__060_ =
+      match cmd__059_ with
       | Create () -> true
       | Is_empty -> true
       | Length -> true
@@ -369,113 +369,113 @@ module Spec =
       | Take_opt_l -> true
       | Take_opt_r -> true
     let postcond _ _ _ = true
-    let run cmd__059_ sut__060_ =
-      match cmd__059_ with
+    let run cmd__061_ sut__062_ =
+      match cmd__061_ with
       | Create () ->
           Res
             (sut,
-              (let res__061_ = create () in
-               (SUT.push sut__060_ res__061_; res__061_)))
+              (let res__063_ = create () in
+               (SUT.push sut__062_ res__063_; res__063_)))
       | Is_empty ->
           Res
             (bool,
-              (let s_1__062_ = SUT.pop sut__060_ in
-               let res__063_ = is_empty s_1__062_ in
-               (SUT.push sut__060_ s_1__062_; res__063_)))
+              (let s_1__064_ = SUT.pop sut__062_ in
+               let res__065_ = is_empty s_1__064_ in
+               (SUT.push sut__062_ s_1__064_; res__065_)))
       | Length ->
           Res
             (int,
-              (let s_2__064_ = SUT.pop sut__060_ in
-               let res__065_ = length s_2__064_ in
-               (SUT.push sut__060_ s_2__064_; res__065_)))
+              (let s_2__066_ = SUT.pop sut__062_ in
+               let res__067_ = length s_2__066_ in
+               (SUT.push sut__062_ s_2__066_; res__067_)))
       | Add_l a_1 ->
           Res
             ((node int),
-              (let s_3__066_ = SUT.pop sut__060_ in
-               let res__067_ = add_l a_1 s_3__066_ in
-               (SUT.push sut__060_ s_3__066_; res__067_)))
+              (let s_3__068_ = SUT.pop sut__062_ in
+               let res__069_ = add_l a_1 s_3__068_ in
+               (SUT.push sut__062_ s_3__068_; res__069_)))
       | Add_r a_2 ->
           Res
             ((node int),
-              (let s_4__068_ = SUT.pop sut__060_ in
-               let res__069_ = add_r a_2 s_4__068_ in
-               (SUT.push sut__060_ s_4__068_; res__069_)))
+              (let s_4__070_ = SUT.pop sut__062_ in
+               let res__071_ = add_r a_2 s_4__070_ in
+               (SUT.push sut__062_ s_4__070_; res__071_)))
       | Take_l ->
           Res
             ((result int exn),
-              (let s_5__070_ = SUT.pop sut__060_ in
-               let res__071_ = protect (fun () -> take_l s_5__070_) () in
-               (SUT.push sut__060_ s_5__070_; res__071_)))
+              (let s_5__072_ = SUT.pop sut__062_ in
+               let res__073_ = protect (fun () -> take_l s_5__072_) () in
+               (SUT.push sut__062_ s_5__072_; res__073_)))
       | Take_r ->
           Res
             ((result int exn),
-              (let s_6__072_ = SUT.pop sut__060_ in
-               let res__073_ = protect (fun () -> take_r s_6__072_) () in
-               (SUT.push sut__060_ s_6__072_; res__073_)))
+              (let s_6__074_ = SUT.pop sut__062_ in
+               let res__075_ = protect (fun () -> take_r s_6__074_) () in
+               (SUT.push sut__062_ s_6__074_; res__075_)))
       | Take_opt_l ->
           Res
             ((option int),
-              (let s_7__074_ = SUT.pop sut__060_ in
-               let res__075_ = take_opt_l s_7__074_ in
-               (SUT.push sut__060_ s_7__074_; res__075_)))
+              (let s_7__076_ = SUT.pop sut__062_ in
+               let res__077_ = take_opt_l s_7__076_ in
+               (SUT.push sut__062_ s_7__076_; res__077_)))
       | Take_opt_r ->
           Res
             ((option int),
-              (let s_8__076_ = SUT.pop sut__060_ in
-               let res__077_ = take_opt_r s_8__076_ in
-               (SUT.push sut__060_ s_8__076_; res__077_)))
+              (let s_8__078_ = SUT.pop sut__062_ in
+               let res__079_ = take_opt_r s_8__078_ in
+               (SUT.push sut__062_ s_8__078_; res__079_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__079_ state__080_ last__082_ res__081_ =
+let ortac_show_cmd cmd__081_ state__082_ last__084_ res__083_ =
   let open Spec in
     let open STM in
-      match (cmd__079_, res__081_) with
+      match (cmd__081_, res__083_) with
       | (Create (), Res ((SUT, _), s)) ->
-          let lhs = if last__082_ then "r" else SUT.get_name state__080_ 0
+          let lhs = if last__084_ then "r" else SUT.get_name state__082_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "create"
             (Util.Pp.pp_unit true) ()
       | (Is_empty, Res ((Bool, _), _)) ->
-          let lhs = if last__082_ then "r" else "_"
+          let lhs = if last__084_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "is_empty"
-            (SUT.get_name state__080_ (0 + shift))
+            (SUT.get_name state__082_ (0 + shift))
       | (Length, Res ((Int, _), _)) ->
-          let lhs = if last__082_ then "r" else "_"
+          let lhs = if last__084_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "length"
-            (SUT.get_name state__080_ (0 + shift))
+            (SUT.get_name state__082_ (0 + shift))
       | (Add_l a_1, Res ((Node (Int), _), _)) ->
-          let lhs = if last__082_ then "r" else "_"
+          let lhs = if last__084_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "add_l"
-            (Util.Pp.pp_int true) a_1 (SUT.get_name state__080_ (0 + shift))
+            (Util.Pp.pp_int true) a_1 (SUT.get_name state__082_ (0 + shift))
       | (Add_r a_2, Res ((Node (Int), _), _)) ->
-          let lhs = if last__082_ then "r" else "_"
+          let lhs = if last__084_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "add_r"
-            (Util.Pp.pp_int true) a_2 (SUT.get_name state__080_ (0 + shift))
+            (Util.Pp.pp_int true) a_2 (SUT.get_name state__082_ (0 + shift))
       | (Take_l, Res ((Result (Int, Exn), _), _)) ->
-          let lhs = if last__082_ then "r" else "_"
+          let lhs = if last__084_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "take_l"
-            (SUT.get_name state__080_ (0 + shift))
+            (SUT.get_name state__082_ (0 + shift))
       | (Take_r, Res ((Result (Int, Exn), _), _)) ->
-          let lhs = if last__082_ then "r" else "_"
+          let lhs = if last__084_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "take_r"
-            (SUT.get_name state__080_ (0 + shift))
+            (SUT.get_name state__082_ (0 + shift))
       | (Take_opt_l, Res ((Option (Int), _), _)) ->
-          let lhs = if last__082_ then "r" else "_"
+          let lhs = if last__084_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "take_opt_l"
-            (SUT.get_name state__080_ (0 + shift))
+            (SUT.get_name state__082_ (0 + shift))
       | (Take_opt_r, Res ((Option (Int), _), _)) ->
-          let lhs = if last__082_ then "r" else "_"
+          let lhs = if last__084_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "take_opt_r"
-            (SUT.get_name state__080_ (0 + shift))
+            (SUT.get_name state__082_ (0 + shift))
       | _ -> assert false
 let ortac_postcond cmd__023_ state__024_ res__025_ =
   let open Spec in
@@ -485,18 +485,26 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
       | (Create (), Res ((SUT, _), s)) -> None
       | (Is_empty, Res ((Bool, _), b)) ->
           if
-            let s_old__027_ = Model.get state__024_ 0
-            and s_new__028_ = lazy (Model.get (Lazy.force new_state__026_) 0) in
+            let s_old__029_ = Model.get state__024_ 0
+            and s_new__030_ = lazy (Model.get (Lazy.force new_state__026_) 0) in
             (try
                (b = true) =
-                 ((Lazy.force s_new__028_).contents =
+                 ((Lazy.force s_new__030_).contents =
                     Ortac_runtime.Gospelstdlib.Sequence.empty)
              with | e -> false)
           then None
           else
             Some
               (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                 (try Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))
+                 (try
+                    Ortac_runtime.Value
+                      (Res
+                         (bool,
+                           (let s_old__027_ = Model.get state__024_ 0
+                            and s_new__028_ =
+                              lazy (Model.get (Lazy.force new_state__026_) 0) in
+                            (Lazy.force s_new__028_).contents =
+                              Ortac_runtime.Gospelstdlib.Sequence.empty)))
                   with | e -> Ortac_runtime.Out_of_domain) "is_empty"
                  [("b <-> s.contents = Sequence.empty",
                     {
@@ -517,12 +525,12 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                     })])
       | (Length, Res ((Int, _), l_1)) ->
           if
-            let s_old__032_ = Model.get state__024_ 0
-            and s_new__033_ = lazy (Model.get (Lazy.force new_state__026_) 0) in
+            let s_old__034_ = Model.get state__024_ 0
+            and s_new__035_ = lazy (Model.get (Lazy.force new_state__026_) 0) in
             (try
                (Ortac_runtime.Gospelstdlib.integer_of_int l_1) =
                  (Ortac_runtime.Gospelstdlib.Sequence.length
-                    (Lazy.force s_new__033_).contents)
+                    (Lazy.force s_new__035_).contents)
              with | e -> false)
           then None
           else
@@ -532,11 +540,11 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                     Ortac_runtime.Value
                       (Res
                          (integer,
-                           (let s_old__030_ = Model.get state__024_ 0
-                            and s_new__031_ =
+                           (let s_old__032_ = Model.get state__024_ 0
+                            and s_new__033_ =
                               lazy (Model.get (Lazy.force new_state__026_) 0) in
                             Ortac_runtime.Gospelstdlib.Sequence.length
-                              (Lazy.force s_new__031_).contents)))
+                              (Lazy.force s_new__033_).contents)))
                   with | e -> Ortac_runtime.Out_of_domain) "length"
                  [("l = Sequence.length s.contents",
                     {
@@ -561,18 +569,18 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
           (match a_3 with
            | Ok a_3 ->
                if
-                 let s_old__037_ = Model.get state__024_ 0
-                 and s_new__038_ =
+                 let s_old__039_ = Model.get state__024_ 0
+                 and s_new__040_ =
                    lazy (Model.get (Lazy.force new_state__026_) 0) in
                  (try
                     if
-                      s_old__037_.contents =
+                      s_old__039_.contents =
                         Ortac_runtime.Gospelstdlib.Sequence.empty
                     then false
                     else
                       a_3 =
                         (Ortac_runtime.Gospelstdlib.Sequence.hd
-                           s_old__037_.contents)
+                           s_old__039_.contents)
                   with | e -> false)
                then None
                else
@@ -601,17 +609,17 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                          })])
            | Error (Empty) ->
                if
-                 let s_old__039_ = Model.get state__024_ 0
-                 and s_new__040_ =
+                 let s_old__041_ = Model.get state__024_ 0
+                 and s_new__042_ =
                    lazy (Model.get (Lazy.force new_state__026_) 0) in
                  (try
-                    let __t1__041_ =
-                      s_old__039_.contents =
+                    let __t1__043_ =
+                      s_old__041_.contents =
                         Ortac_runtime.Gospelstdlib.Sequence.empty in
-                    let __t2__042_ =
+                    let __t2__044_ =
                       Ortac_runtime.Gospelstdlib.Sequence.empty =
-                        (Lazy.force s_new__040_).contents in
-                    __t1__041_ && __t2__042_
+                        (Lazy.force s_new__042_).contents in
+                    __t1__043_ && __t2__044_
                   with | e -> false)
                then None
                else
@@ -641,21 +649,21 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
           (match a_4 with
            | Ok a_4 ->
                if
-                 let s_old__044_ = Model.get state__024_ 0
-                 and s_new__045_ =
+                 let s_old__046_ = Model.get state__024_ 0
+                 and s_new__047_ =
                    lazy (Model.get (Lazy.force new_state__026_) 0) in
                  (try
                     if
-                      s_old__044_.contents =
+                      s_old__046_.contents =
                         Ortac_runtime.Gospelstdlib.Sequence.empty
                     then false
                     else
                       a_4 =
                         (Ortac_runtime.Gospelstdlib.__mix_Bub
-                           s_old__044_.contents
+                           s_old__046_.contents
                            (Ortac_runtime.Gospelstdlib.(-)
                               (Ortac_runtime.Gospelstdlib.Sequence.length
-                                 s_old__044_.contents)
+                                 s_old__046_.contents)
                               (Ortac_runtime.Gospelstdlib.integer_of_int 1)))
                   with | e -> false)
                then None
@@ -685,17 +693,17 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                          })])
            | Error (Empty) ->
                if
-                 let s_old__046_ = Model.get state__024_ 0
-                 and s_new__047_ =
+                 let s_old__048_ = Model.get state__024_ 0
+                 and s_new__049_ =
                    lazy (Model.get (Lazy.force new_state__026_) 0) in
                  (try
-                    let __t1__048_ =
-                      s_old__046_.contents =
+                    let __t1__050_ =
+                      s_old__048_.contents =
                         Ortac_runtime.Gospelstdlib.Sequence.empty in
-                    let __t2__049_ =
+                    let __t2__051_ =
                       Ortac_runtime.Gospelstdlib.Sequence.empty =
-                        (Lazy.force s_new__047_).contents in
-                    __t1__048_ && __t2__049_
+                        (Lazy.force s_new__049_).contents in
+                    __t1__050_ && __t2__051_
                   with | e -> false)
                then None
                else
@@ -723,15 +731,15 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
            | _ -> None)
       | (Take_opt_l, Res ((Option (Int), _), o)) ->
           if
-            let s_old__051_ = Model.get state__024_ 0
-            and s_new__052_ = lazy (Model.get (Lazy.force new_state__026_) 0) in
+            let s_old__053_ = Model.get state__024_ 0
+            and s_new__054_ = lazy (Model.get (Lazy.force new_state__026_) 0) in
             (try
-               s_old__051_.contents =
+               s_old__053_.contents =
                  (match o with
                   | None -> Ortac_runtime.Gospelstdlib.Sequence.empty
                   | Some a_5 ->
                       Ortac_runtime.Gospelstdlib.Sequence.cons a_5
-                        (Lazy.force s_new__052_).contents)
+                        (Lazy.force s_new__054_).contents)
              with | e -> false)
           then None
           else
@@ -758,15 +766,15 @@ let ortac_postcond cmd__023_ state__024_ res__025_ =
                     })])
       | (Take_opt_r, Res ((Option (Int), _), o_1)) ->
           if
-            let s_old__054_ = Model.get state__024_ 0
-            and s_new__055_ = lazy (Model.get (Lazy.force new_state__026_) 0) in
+            let s_old__056_ = Model.get state__024_ 0
+            and s_new__057_ = lazy (Model.get (Lazy.force new_state__026_) 0) in
             (try
-               s_old__054_.contents =
+               s_old__056_.contents =
                  (match o_1 with
                   | None -> Ortac_runtime.Gospelstdlib.Sequence.empty
                   | Some a_6 ->
                       Ortac_runtime.Gospelstdlib.Sequence.snoc
-                        (Lazy.force s_new__055_).contents a_6)
+                        (Lazy.force s_new__057_).contents a_6)
              with | e -> false)
           then None
           else

--- a/examples/varray_circular_spec_tests.ml
+++ b/examples/varray_circular_spec_tests.ml
@@ -1028,8 +1028,8 @@ module Spec =
             Model.push (Model.push (Model.drop_n state__005_ 2) dst__064_)
               src__065_
           else state__005_
-    let precond cmd__138_ state__139_ =
-      match cmd__138_ with
+    let precond cmd__140_ state__141_ =
+      match cmd__140_ with
       | Push_back x -> true
       | Pop_back -> true
       | Push_front x_1 -> true
@@ -1049,257 +1049,257 @@ module Spec =
       | Fill (pos, len, x_4) -> true
       | Blit (src_pos, dst_pos, len_1) -> true
     let postcond _ _ _ = true
-    let run cmd__140_ sut__141_ =
-      match cmd__140_ with
+    let run cmd__142_ sut__143_ =
+      match cmd__142_ with
       | Push_back x ->
           Res
             (unit,
-              (let t_1__142_ = SUT.pop sut__141_ in
-               let res__143_ = push_back t_1__142_ x in
-               (SUT.push sut__141_ t_1__142_; res__143_)))
+              (let t_1__144_ = SUT.pop sut__143_ in
+               let res__145_ = push_back t_1__144_ x in
+               (SUT.push sut__143_ t_1__144_; res__145_)))
       | Pop_back ->
           Res
             ((result (elt char) exn),
-              (let t_2__144_ = SUT.pop sut__141_ in
-               let res__145_ = protect (fun () -> pop_back t_2__144_) () in
-               (SUT.push sut__141_ t_2__144_; res__145_)))
+              (let t_2__146_ = SUT.pop sut__143_ in
+               let res__147_ = protect (fun () -> pop_back t_2__146_) () in
+               (SUT.push sut__143_ t_2__146_; res__147_)))
       | Push_front x_1 ->
           Res
             (unit,
-              (let t_3__146_ = SUT.pop sut__141_ in
-               let res__147_ = push_front t_3__146_ x_1 in
-               (SUT.push sut__141_ t_3__146_; res__147_)))
+              (let t_3__148_ = SUT.pop sut__143_ in
+               let res__149_ = push_front t_3__148_ x_1 in
+               (SUT.push sut__143_ t_3__148_; res__149_)))
       | Pop_front ->
           Res
             ((result (elt char) exn),
-              (let t_4__148_ = SUT.pop sut__141_ in
-               let res__149_ = protect (fun () -> pop_front t_4__148_) () in
-               (SUT.push sut__141_ t_4__148_; res__149_)))
+              (let t_4__150_ = SUT.pop sut__143_ in
+               let res__151_ = protect (fun () -> pop_front t_4__150_) () in
+               (SUT.push sut__143_ t_4__150_; res__151_)))
       | Insert_at (i_1, x_2) ->
           Res
             ((result unit exn),
-              (let t_5__150_ = SUT.pop sut__141_ in
-               let res__151_ =
-                 protect (fun () -> insert_at t_5__150_ i_1 x_2) () in
-               (SUT.push sut__141_ t_5__150_; res__151_)))
+              (let t_5__152_ = SUT.pop sut__143_ in
+               let res__153_ =
+                 protect (fun () -> insert_at t_5__152_ i_1 x_2) () in
+               (SUT.push sut__143_ t_5__152_; res__153_)))
       | Pop_at i_2 ->
           Res
             ((result (elt char) exn),
-              (let t_6__152_ = SUT.pop sut__141_ in
-               let res__153_ = protect (fun () -> pop_at t_6__152_ i_2) () in
-               (SUT.push sut__141_ t_6__152_; res__153_)))
+              (let t_6__154_ = SUT.pop sut__143_ in
+               let res__155_ = protect (fun () -> pop_at t_6__154_ i_2) () in
+               (SUT.push sut__143_ t_6__154_; res__155_)))
       | Delete_at i_3 ->
           Res
             ((result unit exn),
-              (let t_7__154_ = SUT.pop sut__141_ in
-               let res__155_ = protect (fun () -> delete_at t_7__154_ i_3) () in
-               (SUT.push sut__141_ t_7__154_; res__155_)))
+              (let t_7__156_ = SUT.pop sut__143_ in
+               let res__157_ = protect (fun () -> delete_at t_7__156_ i_3) () in
+               (SUT.push sut__143_ t_7__156_; res__157_)))
       | Get i_4 ->
           Res
             ((result (elt char) exn),
-              (let t_8__156_ = SUT.pop sut__141_ in
-               let res__157_ = protect (fun () -> get t_8__156_ i_4) () in
-               (SUT.push sut__141_ t_8__156_; res__157_)))
+              (let t_8__158_ = SUT.pop sut__143_ in
+               let res__159_ = protect (fun () -> get t_8__158_ i_4) () in
+               (SUT.push sut__143_ t_8__158_; res__159_)))
       | Set (i_5, v) ->
           Res
             ((result unit exn),
-              (let t_9__158_ = SUT.pop sut__141_ in
-               let res__159_ = protect (fun () -> set t_9__158_ i_5 v) () in
-               (SUT.push sut__141_ t_9__158_; res__159_)))
+              (let t_9__160_ = SUT.pop sut__143_ in
+               let res__161_ = protect (fun () -> set t_9__160_ i_5 v) () in
+               (SUT.push sut__143_ t_9__160_; res__161_)))
       | Length ->
           Res
             (int,
-              (let t_10__160_ = SUT.pop sut__141_ in
-               let res__161_ = length t_10__160_ in
-               (SUT.push sut__141_ t_10__160_; res__161_)))
+              (let t_10__162_ = SUT.pop sut__143_ in
+               let res__163_ = length t_10__162_ in
+               (SUT.push sut__143_ t_10__162_; res__163_)))
       | Make (n, x_3) ->
           Res
             ((result sut exn),
-              (let res__162_ = protect (fun () -> make n x_3) () in
-               ((match res__162_ with
-                 | Ok res -> SUT.push sut__141_ res
+              (let res__164_ = protect (fun () -> make n x_3) () in
+               ((match res__164_ with
+                 | Ok res -> SUT.push sut__143_ res
                  | Error _ -> ());
-                res__162_)))
+                res__164_)))
       | Empty () ->
           Res
             (sut,
-              (let res__163_ = empty () in
-               (SUT.push sut__141_ res__163_; res__163_)))
+              (let res__165_ = empty () in
+               (SUT.push sut__143_ res__165_; res__165_)))
       | Is_empty ->
           Res
             (bool,
-              (let t_13__164_ = SUT.pop sut__141_ in
-               let res__165_ = is_empty t_13__164_ in
-               (SUT.push sut__141_ t_13__164_; res__165_)))
+              (let t_13__166_ = SUT.pop sut__143_ in
+               let res__167_ = is_empty t_13__166_ in
+               (SUT.push sut__143_ t_13__166_; res__167_)))
       | Append ->
           Res
             (sut,
-              (let a_1__166_ = SUT.pop sut__141_ in
-               let b__167_ = SUT.pop sut__141_ in
-               let res__168_ = append a_1__166_ b__167_ in
-               (SUT.push sut__141_ b__167_;
-                SUT.push sut__141_ a_1__166_;
-                SUT.push sut__141_ res__168_;
-                res__168_)))
+              (let a_1__168_ = SUT.pop sut__143_ in
+               let b__169_ = SUT.pop sut__143_ in
+               let res__170_ = append a_1__168_ b__169_ in
+               (SUT.push sut__143_ b__169_;
+                SUT.push sut__143_ a_1__168_;
+                SUT.push sut__143_ res__170_;
+                res__170_)))
       | Sub (i_6, n_1) ->
           Res
             ((result sut exn),
-              (let t_15__169_ = SUT.pop sut__141_ in
-               let res__170_ = protect (fun () -> sub t_15__169_ i_6 n_1) () in
-               (SUT.push sut__141_ t_15__169_;
-                (match res__170_ with
-                 | Ok res -> SUT.push sut__141_ res
+              (let t_15__171_ = SUT.pop sut__143_ in
+               let res__172_ = protect (fun () -> sub t_15__171_ i_6 n_1) () in
+               (SUT.push sut__143_ t_15__171_;
+                (match res__172_ with
+                 | Ok res -> SUT.push sut__143_ res
                  | Error _ -> ());
-                res__170_)))
+                res__172_)))
       | Copy ->
           Res
             (sut,
-              (let t_16__171_ = SUT.pop sut__141_ in
-               let res__172_ = copy t_16__171_ in
-               (SUT.push sut__141_ t_16__171_;
-                SUT.push sut__141_ res__172_;
-                res__172_)))
+              (let t_16__173_ = SUT.pop sut__143_ in
+               let res__174_ = copy t_16__173_ in
+               (SUT.push sut__143_ t_16__173_;
+                SUT.push sut__143_ res__174_;
+                res__174_)))
       | Fill (pos, len, x_4) ->
           Res
             ((result unit exn),
-              (let t_17__173_ = SUT.pop sut__141_ in
-               let res__174_ =
-                 protect (fun () -> fill t_17__173_ pos len x_4) () in
-               (SUT.push sut__141_ t_17__173_; res__174_)))
+              (let t_17__175_ = SUT.pop sut__143_ in
+               let res__176_ =
+                 protect (fun () -> fill t_17__175_ pos len x_4) () in
+               (SUT.push sut__143_ t_17__175_; res__176_)))
       | Blit (src_pos, dst_pos, len_1) ->
           Res
             ((result unit exn),
-              (let src__175_ = SUT.pop sut__141_ in
-               let dst__176_ = SUT.pop sut__141_ in
-               let res__177_ =
+              (let src__177_ = SUT.pop sut__143_ in
+               let dst__178_ = SUT.pop sut__143_ in
+               let res__179_ =
                  protect
-                   (fun () -> blit src__175_ src_pos dst__176_ dst_pos len_1)
+                   (fun () -> blit src__177_ src_pos dst__178_ dst_pos len_1)
                    () in
-               (SUT.push sut__141_ dst__176_;
-                SUT.push sut__141_ src__175_;
-                res__177_)))
+               (SUT.push sut__143_ dst__178_;
+                SUT.push sut__143_ src__177_;
+                res__179_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__179_ state__180_ last__182_ res__181_ =
+let ortac_show_cmd cmd__181_ state__182_ last__184_ res__183_ =
   let open Spec in
     let open STM in
-      match (cmd__179_, res__181_) with
+      match (cmd__181_, res__183_) with
       | (Push_back x, Res ((Unit, _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "push_back"
-            (SUT.get_name state__180_ (0 + shift))
+            (SUT.get_name state__182_ (0 + shift))
             (Util.Pp.pp_elt Util.Pp.pp_char true) x
       | (Pop_back, Res ((Result (Elt (Char), Exn), _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "pop_back"
-            (SUT.get_name state__180_ (0 + shift))
+            (SUT.get_name state__182_ (0 + shift))
       | (Push_front x_1, Res ((Unit, _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "push_front"
-            (SUT.get_name state__180_ (0 + shift))
+            (SUT.get_name state__182_ (0 + shift))
             (Util.Pp.pp_elt Util.Pp.pp_char true) x_1
       | (Pop_front, Res ((Result (Elt (Char), Exn), _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs
-            "pop_front" (SUT.get_name state__180_ (0 + shift))
+            "pop_front" (SUT.get_name state__182_ (0 + shift))
       | (Insert_at (i_1, x_2), Res ((Result (Unit, Exn), _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "insert_at" (SUT.get_name state__180_ (0 + shift))
+            "insert_at" (SUT.get_name state__182_ (0 + shift))
             (Util.Pp.pp_int true) i_1 (Util.Pp.pp_elt Util.Pp.pp_char true)
             x_2
       | (Pop_at i_2, Res ((Result (Elt (Char), Exn), _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a)" lhs
-            "pop_at" (SUT.get_name state__180_ (0 + shift))
+            "pop_at" (SUT.get_name state__182_ (0 + shift))
             (Util.Pp.pp_int true) i_2
       | (Delete_at i_3, Res ((Result (Unit, Exn), _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a)" lhs
-            "delete_at" (SUT.get_name state__180_ (0 + shift))
+            "delete_at" (SUT.get_name state__182_ (0 + shift))
             (Util.Pp.pp_int true) i_3
       | (Get i_4, Res ((Result (Elt (Char), Exn), _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a)" lhs "get"
-            (SUT.get_name state__180_ (0 + shift)) (Util.Pp.pp_int true) i_4
+            (SUT.get_name state__182_ (0 + shift)) (Util.Pp.pp_int true) i_4
       | (Set (i_5, v), Res ((Result (Unit, Exn), _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "set" (SUT.get_name state__180_ (0 + shift))
+            "set" (SUT.get_name state__182_ (0 + shift))
             (Util.Pp.pp_int true) i_5 (Util.Pp.pp_elt Util.Pp.pp_char true) v
       | (Length, Res ((Int, _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "length"
-            (SUT.get_name state__180_ (0 + shift))
+            (SUT.get_name state__182_ (0 + shift))
       | (Make (n, x_3), Res ((Result (SUT, Exn), _), t_11)) ->
           let lhs =
-            if last__182_
+            if last__184_
             then "r"
             else
               (match t_11 with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__180_ 0)
+               | Ok _ -> "Ok " ^ (SUT.get_name state__182_ 0)
                | Error _ -> "_")
           and shift = match t_11 with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %a %a)" lhs "make"
             (Util.Pp.pp_int true) n (Util.Pp.pp_elt Util.Pp.pp_char true) x_3
       | (Empty (), Res ((SUT, _), t_12)) ->
-          let lhs = if last__182_ then "r" else SUT.get_name state__180_ 0
+          let lhs = if last__184_ then "r" else SUT.get_name state__182_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "empty" (Util.Pp.pp_unit true)
             ()
       | (Is_empty, Res ((Bool, _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "is_empty"
-            (SUT.get_name state__180_ (0 + shift))
+            (SUT.get_name state__182_ (0 + shift))
       | (Append, Res ((SUT, _), t_14)) ->
-          let lhs = if last__182_ then "r" else SUT.get_name state__180_ 0
+          let lhs = if last__184_ then "r" else SUT.get_name state__182_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s %s" lhs "append"
-            (SUT.get_name state__180_ (0 + shift))
-            (SUT.get_name state__180_ (1 + shift))
+            (SUT.get_name state__182_ (0 + shift))
+            (SUT.get_name state__182_ (1 + shift))
       | (Sub (i_6, n_1), Res ((Result (SUT, Exn), _), r)) ->
           let lhs =
-            if last__182_
+            if last__184_
             then "r"
             else
               (match r with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__180_ 0)
+               | Ok _ -> "Ok " ^ (SUT.get_name state__182_ 0)
                | Error _ -> "_")
           and shift = match r with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "sub" (SUT.get_name state__180_ (0 + shift))
+            "sub" (SUT.get_name state__182_ (0 + shift))
             (Util.Pp.pp_int true) i_6 (Util.Pp.pp_int true) n_1
       | (Copy, Res ((SUT, _), r_1)) ->
-          let lhs = if last__182_ then "r" else SUT.get_name state__180_ 0
+          let lhs = if last__184_ then "r" else SUT.get_name state__182_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s" lhs "copy"
-            (SUT.get_name state__180_ (0 + shift))
+            (SUT.get_name state__182_ (0 + shift))
       | (Fill (pos, len, x_4), Res ((Result (Unit, Exn), _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a %a)" lhs
-            "fill" (SUT.get_name state__180_ (0 + shift))
+            "fill" (SUT.get_name state__182_ (0 + shift))
             (Util.Pp.pp_int true) pos (Util.Pp.pp_int true) len
             (Util.Pp.pp_elt Util.Pp.pp_char true) x_4
       | (Blit (src_pos, dst_pos, len_1), Res ((Result (Unit, Exn), _), _)) ->
-          let lhs = if last__182_ then "r" else "_"
+          let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %s %a %a)"
-            lhs "blit" (SUT.get_name state__180_ (0 + shift))
+            lhs "blit" (SUT.get_name state__182_ (0 + shift))
             (Util.Pp.pp_int true) src_pos
-            (SUT.get_name state__180_ (1 + shift)) (Util.Pp.pp_int true)
+            (SUT.get_name state__182_ (1 + shift)) (Util.Pp.pp_int true)
             dst_pos (Util.Pp.pp_int true) len_1
       | _ -> assert false
 let ortac_postcond cmd__074_ state__075_ res__076_ =
@@ -2068,18 +2068,26 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
       | (Empty (), Res ((SUT, _), t_12)) -> None
       | (Is_empty, Res ((Bool, _), b_1)) ->
           if
-            let t_old__112_ = Model.get state__075_ 0
-            and t_new__113_ = lazy (Model.get (Lazy.force new_state__077_) 0) in
+            let t_old__114_ = Model.get state__075_ 0
+            and t_new__115_ = lazy (Model.get (Lazy.force new_state__077_) 0) in
             (try
                (b_1 = true) =
-                 ((Lazy.force t_new__113_).contents =
+                 ((Lazy.force t_new__115_).contents =
                     Ortac_runtime.Gospelstdlib.Sequence.empty)
              with | e -> false)
           then None
           else
             Some
               (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
-                 (try Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))
+                 (try
+                    Ortac_runtime.Value
+                      (Res
+                         (bool,
+                           (let t_old__112_ = Model.get state__075_ 0
+                            and t_new__113_ =
+                              lazy (Model.get (Lazy.force new_state__077_) 0) in
+                            (Lazy.force t_new__113_).contents =
+                              Ortac_runtime.Gospelstdlib.Sequence.empty)))
                   with | e -> Ortac_runtime.Out_of_domain) "is_empty"
                  [("b <-> t.contents = Sequence.empty",
                     {
@@ -2102,18 +2110,18 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
       | (Sub (i_6, n_1), Res ((Result (SUT, Exn), _), r)) ->
           (match Ortac_runtime.append
                    (if
-                      let tmp__117_ = Model.get state__075_ 0 in
+                      let tmp__119_ = Model.get state__075_ 0 in
                       try
-                        let __t1__118_ =
+                        let __t1__120_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                             (Ortac_runtime.Gospelstdlib.integer_of_int i_6) in
-                        let __t2__119_ =
+                        let __t2__121_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.integer_of_int i_6)
                             (Ortac_runtime.Gospelstdlib.Sequence.length
-                               tmp__117_.contents) in
-                        __t1__118_ && __t2__119_
+                               tmp__119_.contents) in
+                        __t1__120_ && __t2__121_
                       with | e -> false
                     then None
                     else
@@ -2140,22 +2148,22 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                   }
                               })]))
                    (if
-                      let tmp__117_ = Model.get state__075_ 0 in
+                      let tmp__119_ = Model.get state__075_ 0 in
                       try
-                        let __t1__120_ =
+                        let __t1__122_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.integer_of_int i_6)
                             (Ortac_runtime.Gospelstdlib.(+)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_6)
                                (Ortac_runtime.Gospelstdlib.integer_of_int n_1)) in
-                        let __t2__121_ =
+                        let __t2__123_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.(+)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_6)
                                (Ortac_runtime.Gospelstdlib.integer_of_int n_1))
                             (Ortac_runtime.Gospelstdlib.Sequence.length
-                               tmp__117_.contents) in
-                        __t1__120_ && __t2__121_
+                               tmp__119_.contents) in
+                        __t1__122_ && __t2__123_
                       with | e -> false
                     then None
                     else
@@ -2189,18 +2197,18 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                 | _ ->
                     Ortac_runtime.append
                       (if
-                         let tmp__117_ = Model.get state__075_ 0 in
+                         let tmp__119_ = Model.get state__075_ 0 in
                          try
-                           let __t1__118_ =
+                           let __t1__120_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_6) in
-                           let __t2__119_ =
+                           let __t2__121_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_6)
                                (Ortac_runtime.Gospelstdlib.Sequence.length
-                                  tmp__117_.contents) in
-                           __t1__118_ && __t2__119_
+                                  tmp__119_.contents) in
+                           __t1__120_ && __t2__121_
                          with | e -> false
                        then None
                        else
@@ -2227,9 +2235,9 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                      }
                                  })]))
                       (if
-                         let tmp__117_ = Model.get state__075_ 0 in
+                         let tmp__119_ = Model.get state__075_ 0 in
                          try
-                           let __t1__120_ =
+                           let __t1__122_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int i_6)
                                (Ortac_runtime.Gospelstdlib.(+)
@@ -2237,7 +2245,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                      i_6)
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
                                      n_1)) in
-                           let __t2__121_ =
+                           let __t2__123_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.(+)
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
@@ -2245,8 +2253,8 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
                                      n_1))
                                (Ortac_runtime.Gospelstdlib.Sequence.length
-                                  tmp__117_.contents) in
-                           __t1__120_ && __t2__121_
+                                  tmp__119_.contents) in
+                           __t1__122_ && __t2__123_
                          with | e -> false
                        then None
                        else
@@ -2275,26 +2283,26 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
       | (Copy, Res ((SUT, _), r_1)) -> None
       | (Fill (pos, len, x_4), Res ((Result (Unit, Exn), _), res)) ->
           (match if
-                   let tmp__123_ = Model.get state__075_ 0 in
+                   let tmp__125_ = Model.get state__075_ 0 in
                    try
-                     let __t1__124_ =
+                     let __t1__126_ =
                        Ortac_runtime.Gospelstdlib.(<=)
                          (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                          (Ortac_runtime.Gospelstdlib.integer_of_int pos) in
-                     let __t2__125_ =
-                       let __t1__126_ =
+                     let __t2__127_ =
+                       let __t1__128_ =
                          Ortac_runtime.Gospelstdlib.(<=)
                            (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                            (Ortac_runtime.Gospelstdlib.integer_of_int len) in
-                       let __t2__127_ =
+                       let __t2__129_ =
                          Ortac_runtime.Gospelstdlib.(<)
                            (Ortac_runtime.Gospelstdlib.(+)
                               (Ortac_runtime.Gospelstdlib.integer_of_int pos)
                               (Ortac_runtime.Gospelstdlib.integer_of_int len))
                            (Ortac_runtime.Gospelstdlib.Sequence.length
-                              tmp__123_.contents) in
-                       __t1__126_ && __t2__127_ in
-                     __t1__124_ && __t2__125_
+                              tmp__125_.contents) in
+                       __t1__128_ && __t2__129_ in
+                     __t1__126_ && __t2__127_
                    with | e -> false
                  then None
                  else
@@ -2327,18 +2335,18 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                 | Error (Invalid_argument _) -> None
                 | _ ->
                     if
-                      let tmp__123_ = Model.get state__075_ 0 in
+                      let tmp__125_ = Model.get state__075_ 0 in
                       (try
-                         let __t1__124_ =
+                         let __t1__126_ =
                            Ortac_runtime.Gospelstdlib.(<=)
                              (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                              (Ortac_runtime.Gospelstdlib.integer_of_int pos) in
-                         let __t2__125_ =
-                           let __t1__126_ =
+                         let __t2__127_ =
+                           let __t1__128_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                                (Ortac_runtime.Gospelstdlib.integer_of_int len) in
-                           let __t2__127_ =
+                           let __t2__129_ =
                              Ortac_runtime.Gospelstdlib.(<)
                                (Ortac_runtime.Gospelstdlib.(+)
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
@@ -2346,9 +2354,9 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                   (Ortac_runtime.Gospelstdlib.integer_of_int
                                      len))
                                (Ortac_runtime.Gospelstdlib.Sequence.length
-                                  tmp__123_.contents) in
-                           __t1__126_ && __t2__127_ in
-                         __t1__124_ && __t2__125_
+                                  tmp__125_.contents) in
+                           __t1__128_ && __t2__129_ in
+                         __t1__126_ && __t2__127_
                        with | e -> false)
                     then None
                     else
@@ -2378,16 +2386,16 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
           ->
           (match Ortac_runtime.append
                    (if
-                      let tmp__128_ = Model.get state__075_ 0
-                      and tmp__129_ = Model.get state__075_ 1 in
+                      let tmp__130_ = Model.get state__075_ 0
+                      and tmp__131_ = Model.get state__075_ 1 in
                       try
-                        let __t1__130_ =
+                        let __t1__132_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                             (Ortac_runtime.Gospelstdlib.integer_of_int
                                src_pos) in
-                        let __t2__131_ =
-                          let __t1__132_ =
+                        let __t2__133_ =
+                          let __t1__134_ =
                             Ortac_runtime.Gospelstdlib.(<=)
                               (Ortac_runtime.Gospelstdlib.integer_of_int
                                  src_pos)
@@ -2396,7 +2404,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                     src_pos)
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
                                     len_1)) in
-                          let __t2__133_ =
+                          let __t2__135_ =
                             Ortac_runtime.Gospelstdlib.(<=)
                               (Ortac_runtime.Gospelstdlib.(+)
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
@@ -2404,9 +2412,9 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
                                     len_1))
                               (Ortac_runtime.Gospelstdlib.Sequence.length
-                                 tmp__128_.contents) in
-                          __t1__132_ && __t2__133_ in
-                        __t1__130_ && __t2__131_
+                                 tmp__130_.contents) in
+                          __t1__134_ && __t2__135_ in
+                        __t1__132_ && __t2__133_
                       with | e -> false
                     then None
                     else
@@ -2433,16 +2441,16 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                   }
                               })]))
                    (if
-                      let tmp__128_ = Model.get state__075_ 0
-                      and tmp__129_ = Model.get state__075_ 1 in
+                      let tmp__130_ = Model.get state__075_ 0
+                      and tmp__131_ = Model.get state__075_ 1 in
                       try
-                        let __t1__134_ =
+                        let __t1__136_ =
                           Ortac_runtime.Gospelstdlib.(<=)
                             (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                             (Ortac_runtime.Gospelstdlib.integer_of_int
                                dst_pos) in
-                        let __t2__135_ =
-                          let __t1__136_ =
+                        let __t2__137_ =
+                          let __t1__138_ =
                             Ortac_runtime.Gospelstdlib.(<=)
                               (Ortac_runtime.Gospelstdlib.integer_of_int
                                  dst_pos)
@@ -2451,7 +2459,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                     dst_pos)
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
                                     len_1)) in
-                          let __t2__137_ =
+                          let __t2__139_ =
                             Ortac_runtime.Gospelstdlib.(<=)
                               (Ortac_runtime.Gospelstdlib.(+)
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
@@ -2459,9 +2467,9 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
                                     len_1))
                               (Ortac_runtime.Gospelstdlib.Sequence.length
-                                 tmp__129_.contents) in
-                          __t1__136_ && __t2__137_ in
-                        __t1__134_ && __t2__135_
+                                 tmp__131_.contents) in
+                          __t1__138_ && __t2__139_ in
+                        __t1__136_ && __t2__137_
                       with | e -> false
                     then None
                     else
@@ -2495,16 +2503,16 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                 | _ ->
                     Ortac_runtime.append
                       (if
-                         let tmp__128_ = Model.get state__075_ 0
-                         and tmp__129_ = Model.get state__075_ 1 in
+                         let tmp__130_ = Model.get state__075_ 0
+                         and tmp__131_ = Model.get state__075_ 1 in
                          try
-                           let __t1__130_ =
+                           let __t1__132_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                                (Ortac_runtime.Gospelstdlib.integer_of_int
                                   src_pos) in
-                           let __t2__131_ =
-                             let __t1__132_ =
+                           let __t2__133_ =
+                             let __t1__134_ =
                                Ortac_runtime.Gospelstdlib.(<=)
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
                                     src_pos)
@@ -2513,7 +2521,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                        src_pos)
                                     (Ortac_runtime.Gospelstdlib.integer_of_int
                                        len_1)) in
-                             let __t2__133_ =
+                             let __t2__135_ =
                                Ortac_runtime.Gospelstdlib.(<=)
                                  (Ortac_runtime.Gospelstdlib.(+)
                                     (Ortac_runtime.Gospelstdlib.integer_of_int
@@ -2521,9 +2529,9 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                     (Ortac_runtime.Gospelstdlib.integer_of_int
                                        len_1))
                                  (Ortac_runtime.Gospelstdlib.Sequence.length
-                                    tmp__128_.contents) in
-                             __t1__132_ && __t2__133_ in
-                           __t1__130_ && __t2__131_
+                                    tmp__130_.contents) in
+                             __t1__134_ && __t2__135_ in
+                           __t1__132_ && __t2__133_
                          with | e -> false
                        then None
                        else
@@ -2551,16 +2559,16 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                      }
                                  })]))
                       (if
-                         let tmp__128_ = Model.get state__075_ 0
-                         and tmp__129_ = Model.get state__075_ 1 in
+                         let tmp__130_ = Model.get state__075_ 0
+                         and tmp__131_ = Model.get state__075_ 1 in
                          try
-                           let __t1__134_ =
+                           let __t1__136_ =
                              Ortac_runtime.Gospelstdlib.(<=)
                                (Ortac_runtime.Gospelstdlib.integer_of_int 0)
                                (Ortac_runtime.Gospelstdlib.integer_of_int
                                   dst_pos) in
-                           let __t2__135_ =
-                             let __t1__136_ =
+                           let __t2__137_ =
+                             let __t1__138_ =
                                Ortac_runtime.Gospelstdlib.(<=)
                                  (Ortac_runtime.Gospelstdlib.integer_of_int
                                     dst_pos)
@@ -2569,7 +2577,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                        dst_pos)
                                     (Ortac_runtime.Gospelstdlib.integer_of_int
                                        len_1)) in
-                             let __t2__137_ =
+                             let __t2__139_ =
                                Ortac_runtime.Gospelstdlib.(<=)
                                  (Ortac_runtime.Gospelstdlib.(+)
                                     (Ortac_runtime.Gospelstdlib.integer_of_int
@@ -2577,9 +2585,9 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                                     (Ortac_runtime.Gospelstdlib.integer_of_int
                                        len_1))
                                  (Ortac_runtime.Gospelstdlib.Sequence.length
-                                    tmp__129_.contents) in
-                             __t1__136_ && __t2__137_ in
-                           __t1__134_ && __t2__135_
+                                    tmp__131_.contents) in
+                             __t1__138_ && __t2__139_ in
+                           __t1__136_ && __t2__137_
                          with | e -> false
                        then None
                        else

--- a/plugins/qcheck-stm/src/ir_of_gospel.ml
+++ b/plugins/qcheck-stm/src/ir_of_gospel.ml
@@ -277,6 +277,23 @@ let returned_value_description spec ret =
            && Symbols.(ls_equal ps_equ ls)
            && is_ret vs ->
         [ Ir.term_val spec right ]
+    (* Gospel turns equality between prop (bool being coerced to prop) into
+       double implication of a specific form. This case is obviously fragile
+       and depends a lot on the implementation of Gospel type-checker *)
+    | Tbinop
+        ( Tiff,
+          {
+            t_node =
+              Tapp
+                ( ls1,
+                  [ { t_node = Tvar vs; _ }; { t_node = Tapp (ls2, []); _ } ] );
+            _;
+          },
+          right )
+      when is_ret vs
+           && Symbols.(ls_equal ps_equ ls1)
+           && Symbols.(ls_equal fs_bool_true ls2) ->
+        [ Ir.term_val spec right ]
     | Tbinop ((Tand | Tand_asym), l, r) -> pred l @ pred r
     | _ -> []
   in

--- a/plugins/qcheck-stm/test/array_errors.expected
+++ b/plugins/qcheck-stm/test/array_errors.expected
@@ -1,5 +1,0 @@
-File "array.mli", line 60, characters 0-89:
-60 | val mem : 'a -> 'a t -> bool
-61 | (*@ b = mem a t
-62 |     ensures b = Sequence.mem t.contents a *)
-Warning: Incomplete computation of the returned value in the specification of mem. Failure message won't be able to display the expected returned value.

--- a/plugins/qcheck-stm/test/array_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/array_stm_tests.expected.ml
@@ -643,8 +643,8 @@ module Spec =
           let t_12__044_ = Model.get state__003_ 0 in
           let t_12__045_ = t_12__044_ in
           Model.push (Model.drop_n state__003_ 1) t_12__045_
-    let precond cmd__087_ state__088_ =
-      match cmd__087_ with
+    let precond cmd__089_ state__090_ =
+      match cmd__089_ with
       | Length -> true
       | Get i -> true
       | Set (i_1, a_1) -> true
@@ -658,176 +658,176 @@ module Spec =
       | Mem a_3 -> true
       | For_all p -> true
     let postcond _ _ _ = true
-    let run cmd__089_ sut__090_ =
-      match cmd__089_ with
+    let run cmd__091_ sut__092_ =
+      match cmd__091_ with
       | Length ->
           Res
             (int,
-              (let t_1__091_ = SUT.pop sut__090_ in
-               let res__092_ = length t_1__091_ in
-               (SUT.push sut__090_ t_1__091_; res__092_)))
+              (let t_1__093_ = SUT.pop sut__092_ in
+               let res__094_ = length t_1__093_ in
+               (SUT.push sut__092_ t_1__093_; res__094_)))
       | Get i ->
           Res
             ((result char exn),
-              (let t_2__093_ = SUT.pop sut__090_ in
-               let res__094_ = protect (fun () -> get t_2__093_ i) () in
-               (SUT.push sut__090_ t_2__093_; res__094_)))
+              (let t_2__095_ = SUT.pop sut__092_ in
+               let res__096_ = protect (fun () -> get t_2__095_ i) () in
+               (SUT.push sut__092_ t_2__095_; res__096_)))
       | Set (i_1, a_1) ->
           Res
             ((result unit exn),
-              (let t_3__095_ = SUT.pop sut__090_ in
-               let res__096_ = protect (fun () -> set t_3__095_ i_1 a_1) () in
-               (SUT.push sut__090_ t_3__095_; res__096_)))
+              (let t_3__097_ = SUT.pop sut__092_ in
+               let res__098_ = protect (fun () -> set t_3__097_ i_1 a_1) () in
+               (SUT.push sut__092_ t_3__097_; res__098_)))
       | Make (i_2, a_2) ->
           Res
             ((result sut exn),
-              (let res__097_ = protect (fun () -> make i_2 a_2) () in
-               ((match res__097_ with
-                 | Ok res -> SUT.push sut__090_ res
+              (let res__099_ = protect (fun () -> make i_2 a_2) () in
+               ((match res__099_ with
+                 | Ok res -> SUT.push sut__092_ res
                  | Error _ -> ());
-                res__097_)))
+                res__099_)))
       | Append ->
           Res
             (sut,
-              (let a_4__098_ = SUT.pop sut__090_ in
-               let b__099_ = SUT.pop sut__090_ in
-               let res__100_ = append a_4__098_ b__099_ in
-               (SUT.push sut__090_ b__099_;
-                SUT.push sut__090_ a_4__098_;
-                SUT.push sut__090_ res__100_;
-                res__100_)))
+              (let a_4__100_ = SUT.pop sut__092_ in
+               let b__101_ = SUT.pop sut__092_ in
+               let res__102_ = append a_4__100_ b__101_ in
+               (SUT.push sut__092_ b__101_;
+                SUT.push sut__092_ a_4__100_;
+                SUT.push sut__092_ res__102_;
+                res__102_)))
       | Sub (i_3, n) ->
           Res
             ((result sut exn),
-              (let t_6__101_ = SUT.pop sut__090_ in
-               let res__102_ = protect (fun () -> sub t_6__101_ i_3 n) () in
-               (SUT.push sut__090_ t_6__101_;
-                (match res__102_ with
-                 | Ok res -> SUT.push sut__090_ res
+              (let t_6__103_ = SUT.pop sut__092_ in
+               let res__104_ = protect (fun () -> sub t_6__103_ i_3 n) () in
+               (SUT.push sut__092_ t_6__103_;
+                (match res__104_ with
+                 | Ok res -> SUT.push sut__092_ res
                  | Error _ -> ());
-                res__102_)))
+                res__104_)))
       | Copy ->
           Res
             (sut,
-              (let t_7__103_ = SUT.pop sut__090_ in
-               let res__104_ = copy t_7__103_ in
-               (SUT.push sut__090_ t_7__103_;
-                SUT.push sut__090_ res__104_;
-                res__104_)))
+              (let t_7__105_ = SUT.pop sut__092_ in
+               let res__106_ = copy t_7__105_ in
+               (SUT.push sut__092_ t_7__105_;
+                SUT.push sut__092_ res__106_;
+                res__106_)))
       | Fill (pos, len, x) ->
           Res
             ((result unit exn),
-              (let t_8__105_ = SUT.pop sut__090_ in
-               let res__106_ =
-                 protect (fun () -> fill t_8__105_ pos len x) () in
-               (SUT.push sut__090_ t_8__105_; res__106_)))
+              (let t_8__107_ = SUT.pop sut__092_ in
+               let res__108_ =
+                 protect (fun () -> fill t_8__107_ pos len x) () in
+               (SUT.push sut__092_ t_8__107_; res__108_)))
       | To_list ->
           Res
             ((list char),
-              (let t_9__107_ = SUT.pop sut__090_ in
-               let res__108_ = to_list t_9__107_ in
-               (SUT.push sut__090_ t_9__107_; res__108_)))
+              (let t_9__109_ = SUT.pop sut__092_ in
+               let res__110_ = to_list t_9__109_ in
+               (SUT.push sut__092_ t_9__109_; res__110_)))
       | Of_list l ->
           Res
             (sut,
-              (let res__109_ = of_list l in
-               (SUT.push sut__090_ res__109_; res__109_)))
+              (let res__111_ = of_list l in
+               (SUT.push sut__092_ res__111_; res__111_)))
       | Mem a_3 ->
           Res
             (bool,
-              (let t_11__110_ = SUT.pop sut__090_ in
-               let res__111_ = mem a_3 t_11__110_ in
-               (SUT.push sut__090_ t_11__110_; res__111_)))
+              (let t_11__112_ = SUT.pop sut__092_ in
+               let res__113_ = mem a_3 t_11__112_ in
+               (SUT.push sut__092_ t_11__112_; res__113_)))
       | For_all p ->
           Res
             (bool,
-              (let t_12__112_ = SUT.pop sut__090_ in
-               let res__113_ = for_all (QCheck.Fn.apply p) t_12__112_ in
-               (SUT.push sut__090_ t_12__112_; res__113_)))
+              (let t_12__114_ = SUT.pop sut__092_ in
+               let res__115_ = for_all (QCheck.Fn.apply p) t_12__114_ in
+               (SUT.push sut__092_ t_12__114_; res__115_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__115_ state__116_ last__118_ res__117_ =
+let ortac_show_cmd cmd__117_ state__118_ last__120_ res__119_ =
   let open Spec in
     let open STM in
-      match (cmd__115_, res__117_) with
+      match (cmd__117_, res__119_) with
       | (Length, Res ((Int, _), _)) ->
-          let lhs = if last__118_ then "r" else "_"
+          let lhs = if last__120_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "length"
-            (SUT.get_name state__116_ (0 + shift))
+            (SUT.get_name state__118_ (0 + shift))
       | (Get i, Res ((Result (Char, Exn), _), _)) ->
-          let lhs = if last__118_ then "r" else "_"
+          let lhs = if last__120_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a)" lhs "get"
-            (SUT.get_name state__116_ (0 + shift)) (Util.Pp.pp_int true) i
+            (SUT.get_name state__118_ (0 + shift)) (Util.Pp.pp_int true) i
       | (Set (i_1, a_1), Res ((Result (Unit, Exn), _), _)) ->
-          let lhs = if last__118_ then "r" else "_"
+          let lhs = if last__120_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "set" (SUT.get_name state__116_ (0 + shift))
+            "set" (SUT.get_name state__118_ (0 + shift))
             (Util.Pp.pp_int true) i_1 (Util.Pp.pp_char true) a_1
       | (Make (i_2, a_2), Res ((Result (SUT, Exn), _), t_4)) ->
           let lhs =
-            if last__118_
+            if last__120_
             then "r"
             else
               (match t_4 with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__116_ 0)
+               | Ok _ -> "Ok " ^ (SUT.get_name state__118_ 0)
                | Error _ -> "_")
           and shift = match t_4 with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %a %a)" lhs "make"
             (Util.Pp.pp_int true) i_2 (Util.Pp.pp_char true) a_2
       | (Append, Res ((SUT, _), t_5)) ->
-          let lhs = if last__118_ then "r" else SUT.get_name state__116_ 0
+          let lhs = if last__120_ then "r" else SUT.get_name state__118_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s %s" lhs "append"
-            (SUT.get_name state__116_ (0 + shift))
-            (SUT.get_name state__116_ (1 + shift))
+            (SUT.get_name state__118_ (0 + shift))
+            (SUT.get_name state__118_ (1 + shift))
       | (Sub (i_3, n), Res ((Result (SUT, Exn), _), r)) ->
           let lhs =
-            if last__118_
+            if last__120_
             then "r"
             else
               (match r with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__116_ 0)
+               | Ok _ -> "Ok " ^ (SUT.get_name state__118_ 0)
                | Error _ -> "_")
           and shift = match r with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "sub" (SUT.get_name state__116_ (0 + shift))
+            "sub" (SUT.get_name state__118_ (0 + shift))
             (Util.Pp.pp_int true) i_3 (Util.Pp.pp_int true) n
       | (Copy, Res ((SUT, _), r_1)) ->
-          let lhs = if last__118_ then "r" else SUT.get_name state__116_ 0
+          let lhs = if last__120_ then "r" else SUT.get_name state__118_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s" lhs "copy"
-            (SUT.get_name state__116_ (0 + shift))
+            (SUT.get_name state__118_ (0 + shift))
       | (Fill (pos, len, x), Res ((Result (Unit, Exn), _), _)) ->
-          let lhs = if last__118_ then "r" else "_"
+          let lhs = if last__120_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a %a)" lhs
-            "fill" (SUT.get_name state__116_ (0 + shift))
+            "fill" (SUT.get_name state__118_ (0 + shift))
             (Util.Pp.pp_int true) pos (Util.Pp.pp_int true) len
             (Util.Pp.pp_char true) x
       | (To_list, Res ((List (Char), _), _)) ->
-          let lhs = if last__118_ then "r" else "_"
+          let lhs = if last__120_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "to_list"
-            (SUT.get_name state__116_ (0 + shift))
+            (SUT.get_name state__118_ (0 + shift))
       | (Of_list l, Res ((SUT, _), t_10)) ->
-          let lhs = if last__118_ then "r" else SUT.get_name state__116_ 0
+          let lhs = if last__120_ then "r" else SUT.get_name state__118_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "of_list"
             (Util.Pp.pp_list Util.Pp.pp_char true) l
       | (Mem a_3, Res ((Bool, _), _)) ->
-          let lhs = if last__118_ then "r" else "_"
+          let lhs = if last__120_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "mem"
-            (Util.Pp.pp_char true) a_3 (SUT.get_name state__116_ (0 + shift))
+            (Util.Pp.pp_char true) a_3 (SUT.get_name state__118_ (0 + shift))
       | (For_all p, Res ((Bool, _), _)) ->
-          let lhs = if last__118_ then "r" else "_"
+          let lhs = if last__120_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "for_all"
-            (Util.Pp.pp_fun_ true) p (SUT.get_name state__116_ (0 + shift))
+            (Util.Pp.pp_fun_ true) p (SUT.get_name state__118_ (0 + shift))
       | _ -> assert false
 let ortac_postcond cmd__046_ state__047_ res__048_ =
   let open Spec in
@@ -1565,18 +1565,26 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
       | (Of_list l, Res ((SUT, _), t_10)) -> None
       | (Mem a_3, Res ((Bool, _), b_1)) ->
           if
-            let t_old__079_ = Model.get state__047_ 0
-            and t_new__080_ = lazy (Model.get (Lazy.force new_state__049_) 0) in
+            let t_old__081_ = Model.get state__047_ 0
+            and t_new__082_ = lazy (Model.get (Lazy.force new_state__049_) 0) in
             (try
                (b_1 = true) =
                  (Ortac_runtime.Gospelstdlib.Sequence.mem
-                    (Lazy.force t_new__080_).contents a_3)
+                    (Lazy.force t_new__082_).contents a_3)
              with | e -> false)
           then None
           else
             Some
               (Ortac_runtime.report "Array" "make 16 'a'"
-                 (try Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))
+                 (try
+                    Ortac_runtime.Value
+                      (Res
+                         (bool,
+                           (let t_old__079_ = Model.get state__047_ 0
+                            and t_new__080_ =
+                              lazy (Model.get (Lazy.force new_state__049_) 0) in
+                            Ortac_runtime.Gospelstdlib.Sequence.mem
+                              (Lazy.force t_new__080_).contents a_3)))
                   with | e -> Ortac_runtime.Out_of_domain) "mem"
                  [("b = Sequence.mem t.contents a",
                     {
@@ -1597,8 +1605,8 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                     })])
       | (For_all p, Res ((Bool, _), b_2)) ->
           if
-            let t_old__084_ = Model.get state__047_ 0
-            and t_new__085_ = lazy (Model.get (Lazy.force new_state__049_) 0) in
+            let t_old__086_ = Model.get state__047_ 0
+            and t_new__087_ = lazy (Model.get (Lazy.force new_state__049_) 0) in
             (try
                b_2 =
                  (Ortac_runtime.Gospelstdlib.Sequence.fold_left
@@ -1606,7 +1614,7 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                        fun a_6 ->
                          if ((QCheck.Fn.apply p a_6) = true) && (acc = true)
                          then true
-                         else false) true (Lazy.force t_new__085_).contents)
+                         else false) true (Lazy.force t_new__087_).contents)
              with | e -> false)
           then None
           else
@@ -1616,8 +1624,8 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                     Ortac_runtime.Value
                       (Res
                          (bool,
-                           (let t_old__082_ = Model.get state__047_ 0
-                            and t_new__083_ =
+                           (let t_old__084_ = Model.get state__047_ 0
+                            and t_new__085_ =
                               lazy (Model.get (Lazy.force new_state__049_) 0) in
                             Ortac_runtime.Gospelstdlib.Sequence.fold_left
                               (fun acc ->
@@ -1627,7 +1635,7 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                                        (acc = true)
                                    then true
                                    else false) true
-                              (Lazy.force t_new__083_).contents)))
+                              (Lazy.force t_new__085_).contents)))
                   with | e -> Ortac_runtime.Out_of_domain) "for_all"
                  [("b = Sequence.fold_left (fun acc a -> p a && acc) true t.contents",
                     {

--- a/plugins/qcheck-stm/test/hashtbl_errors.expected
+++ b/plugins/qcheck-stm/test/hashtbl_errors.expected
@@ -93,8 +93,3 @@ File "hashtbl.mli", line 40, characters 0-162:
 41 | (*@ bs = find_all h a
 42 |     ensures bs = Sequence.filter_map (fun (x, y) -> if x = a then Some y else None) h.contents *)
 Warning: Incomplete computation of the returned value in the specification of find_all. Failure message won't be able to display the expected returned value.
-File "hashtbl.mli", line 44, characters 0-114:
-44 | val mem : ('a, 'b) t -> 'a -> bool
-45 | (*@ b = mem h a
-46 |     ensures b = Sequence.mem (Sequence.map fst h.contents) a *)
-Warning: Incomplete computation of the returned value in the specification of mem. Failure message won't be able to display the expected returned value.

--- a/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
@@ -431,8 +431,8 @@ module Spec =
           let h_11__030_ = Model.get state__003_ 0 in
           let h_11__031_ = h_11__030_ in
           Model.push (Model.drop_n state__003_ 1) h_11__031_
-    let precond cmd__064_ state__065_ =
-      match cmd__064_ with
+    let precond cmd__066_ state__067_ =
+      match cmd__066_ with
       | Create (random, size) -> true
       | Clear -> true
       | Reset -> true
@@ -447,162 +447,162 @@ module Spec =
       | Filter_map_inplace f -> true
       | Length -> true
     let postcond _ _ _ = true
-    let run cmd__066_ sut__067_ =
-      match cmd__066_ with
+    let run cmd__068_ sut__069_ =
+      match cmd__068_ with
       | Create (random, size) ->
           Res
             (sut,
-              (let res__068_ = create ~random size in
-               (SUT.push sut__067_ res__068_; res__068_)))
+              (let res__070_ = create ~random size in
+               (SUT.push sut__069_ res__070_; res__070_)))
       | Clear ->
           Res
             (unit,
-              (let h_1__069_ = SUT.pop sut__067_ in
-               let res__070_ = clear h_1__069_ in
-               (SUT.push sut__067_ h_1__069_; res__070_)))
+              (let h_1__071_ = SUT.pop sut__069_ in
+               let res__072_ = clear h_1__071_ in
+               (SUT.push sut__069_ h_1__071_; res__072_)))
       | Reset ->
           Res
             (unit,
-              (let h_2__071_ = SUT.pop sut__067_ in
-               let res__072_ = reset h_2__071_ in
-               (SUT.push sut__067_ h_2__071_; res__072_)))
+              (let h_2__073_ = SUT.pop sut__069_ in
+               let res__074_ = reset h_2__073_ in
+               (SUT.push sut__069_ h_2__073_; res__074_)))
       | Copy ->
           Res
             (sut,
-              (let h1__073_ = SUT.pop sut__067_ in
-               let res__074_ = copy h1__073_ in
-               (SUT.push sut__067_ h1__073_;
-                SUT.push sut__067_ res__074_;
-                res__074_)))
+              (let h1__075_ = SUT.pop sut__069_ in
+               let res__076_ = copy h1__075_ in
+               (SUT.push sut__069_ h1__075_;
+                SUT.push sut__069_ res__076_;
+                res__076_)))
       | Add (a_1, b_1) ->
           Res
             (unit,
-              (let h_3__075_ = SUT.pop sut__067_ in
-               let res__076_ = add h_3__075_ a_1 b_1 in
-               (SUT.push sut__067_ h_3__075_; res__076_)))
+              (let h_3__077_ = SUT.pop sut__069_ in
+               let res__078_ = add h_3__077_ a_1 b_1 in
+               (SUT.push sut__069_ h_3__077_; res__078_)))
       | Find a_2 ->
           Res
             ((result int exn),
-              (let h_4__077_ = SUT.pop sut__067_ in
-               let res__078_ = protect (fun () -> find h_4__077_ a_2) () in
-               (SUT.push sut__067_ h_4__077_; res__078_)))
+              (let h_4__079_ = SUT.pop sut__069_ in
+               let res__080_ = protect (fun () -> find h_4__079_ a_2) () in
+               (SUT.push sut__069_ h_4__079_; res__080_)))
       | Find_opt a_3 ->
           Res
             ((option int),
-              (let h_5__079_ = SUT.pop sut__067_ in
-               let res__080_ = find_opt h_5__079_ a_3 in
-               (SUT.push sut__067_ h_5__079_; res__080_)))
+              (let h_5__081_ = SUT.pop sut__069_ in
+               let res__082_ = find_opt h_5__081_ a_3 in
+               (SUT.push sut__069_ h_5__081_; res__082_)))
       | Find_all a_4 ->
           Res
             ((list int),
-              (let h_6__081_ = SUT.pop sut__067_ in
-               let res__082_ = find_all h_6__081_ a_4 in
-               (SUT.push sut__067_ h_6__081_; res__082_)))
+              (let h_6__083_ = SUT.pop sut__069_ in
+               let res__084_ = find_all h_6__083_ a_4 in
+               (SUT.push sut__069_ h_6__083_; res__084_)))
       | Mem a_5 ->
           Res
             (bool,
-              (let h_7__083_ = SUT.pop sut__067_ in
-               let res__084_ = mem h_7__083_ a_5 in
-               (SUT.push sut__067_ h_7__083_; res__084_)))
+              (let h_7__085_ = SUT.pop sut__069_ in
+               let res__086_ = mem h_7__085_ a_5 in
+               (SUT.push sut__069_ h_7__085_; res__086_)))
       | Remove a_6 ->
           Res
             (unit,
-              (let h_8__085_ = SUT.pop sut__067_ in
-               let res__086_ = remove h_8__085_ a_6 in
-               (SUT.push sut__067_ h_8__085_; res__086_)))
+              (let h_8__087_ = SUT.pop sut__069_ in
+               let res__088_ = remove h_8__087_ a_6 in
+               (SUT.push sut__069_ h_8__087_; res__088_)))
       | Replace (a_7, b_2) ->
           Res
             (unit,
-              (let h_9__087_ = SUT.pop sut__067_ in
-               let res__088_ = replace h_9__087_ a_7 b_2 in
-               (SUT.push sut__067_ h_9__087_; res__088_)))
+              (let h_9__089_ = SUT.pop sut__069_ in
+               let res__090_ = replace h_9__089_ a_7 b_2 in
+               (SUT.push sut__069_ h_9__089_; res__090_)))
       | Filter_map_inplace f ->
           Res
             (unit,
-              (let h_10__089_ = SUT.pop sut__067_ in
-               let res__090_ =
-                 filter_map_inplace (QCheck.Fn.apply f) h_10__089_ in
-               (SUT.push sut__067_ h_10__089_; res__090_)))
+              (let h_10__091_ = SUT.pop sut__069_ in
+               let res__092_ =
+                 filter_map_inplace (QCheck.Fn.apply f) h_10__091_ in
+               (SUT.push sut__069_ h_10__091_; res__092_)))
       | Length ->
           Res
             (int,
-              (let h_11__091_ = SUT.pop sut__067_ in
-               let res__092_ = length h_11__091_ in
-               (SUT.push sut__067_ h_11__091_; res__092_)))
+              (let h_11__093_ = SUT.pop sut__069_ in
+               let res__094_ = length h_11__093_ in
+               (SUT.push sut__069_ h_11__093_; res__094_)))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__094_ state__095_ last__097_ res__096_ =
+let ortac_show_cmd cmd__096_ state__097_ last__099_ res__098_ =
   let open Spec in
     let open STM in
-      match (cmd__094_, res__096_) with
+      match (cmd__096_, res__098_) with
       | (Create (random, size), Res ((SUT, _), h)) ->
-          let lhs = if last__097_ then "r" else SUT.get_name state__095_ 0
+          let lhs = if last__099_ then "r" else SUT.get_name state__097_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a %a" lhs "create"
             (Util.Pp.pp_bool true) random (Util.Pp.pp_int true) size
       | (Clear, Res ((Unit, _), _)) ->
-          let lhs = if last__097_ then "r" else "_"
+          let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "clear"
-            (SUT.get_name state__095_ (0 + shift))
+            (SUT.get_name state__097_ (0 + shift))
       | (Reset, Res ((Unit, _), _)) ->
-          let lhs = if last__097_ then "r" else "_"
+          let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "reset"
-            (SUT.get_name state__095_ (0 + shift))
+            (SUT.get_name state__097_ (0 + shift))
       | (Copy, Res ((SUT, _), h2)) ->
-          let lhs = if last__097_ then "r" else SUT.get_name state__095_ 0
+          let lhs = if last__099_ then "r" else SUT.get_name state__097_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s" lhs "copy"
-            (SUT.get_name state__095_ (0 + shift))
+            (SUT.get_name state__097_ (0 + shift))
       | (Add (a_1, b_1), Res ((Unit, _), _)) ->
-          let lhs = if last__097_ then "r" else "_"
+          let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a %a" lhs "add"
-            (SUT.get_name state__095_ (0 + shift)) (Util.Pp.pp_char true) a_1
+            (SUT.get_name state__097_ (0 + shift)) (Util.Pp.pp_char true) a_1
             (Util.Pp.pp_int true) b_1
       | (Find a_2, Res ((Result (Int, Exn), _), _)) ->
-          let lhs = if last__097_ then "r" else "_"
+          let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a)" lhs "find"
-            (SUT.get_name state__095_ (0 + shift)) (Util.Pp.pp_char true) a_2
+            (SUT.get_name state__097_ (0 + shift)) (Util.Pp.pp_char true) a_2
       | (Find_opt a_3, Res ((Option (Int), _), _)) ->
-          let lhs = if last__097_ then "r" else "_"
+          let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "find_opt"
-            (SUT.get_name state__095_ (0 + shift)) (Util.Pp.pp_char true) a_3
+            (SUT.get_name state__097_ (0 + shift)) (Util.Pp.pp_char true) a_3
       | (Find_all a_4, Res ((List (Int), _), _)) ->
-          let lhs = if last__097_ then "r" else "_"
+          let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "find_all"
-            (SUT.get_name state__095_ (0 + shift)) (Util.Pp.pp_char true) a_4
+            (SUT.get_name state__097_ (0 + shift)) (Util.Pp.pp_char true) a_4
       | (Mem a_5, Res ((Bool, _), _)) ->
-          let lhs = if last__097_ then "r" else "_"
+          let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "mem"
-            (SUT.get_name state__095_ (0 + shift)) (Util.Pp.pp_char true) a_5
+            (SUT.get_name state__097_ (0 + shift)) (Util.Pp.pp_char true) a_5
       | (Remove a_6, Res ((Unit, _), _)) ->
-          let lhs = if last__097_ then "r" else "_"
+          let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "remove"
-            (SUT.get_name state__095_ (0 + shift)) (Util.Pp.pp_char true) a_6
+            (SUT.get_name state__097_ (0 + shift)) (Util.Pp.pp_char true) a_6
       | (Replace (a_7, b_2), Res ((Unit, _), _)) ->
-          let lhs = if last__097_ then "r" else "_"
+          let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a %a" lhs "replace"
-            (SUT.get_name state__095_ (0 + shift)) (Util.Pp.pp_char true) a_7
+            (SUT.get_name state__097_ (0 + shift)) (Util.Pp.pp_char true) a_7
             (Util.Pp.pp_int true) b_2
       | (Filter_map_inplace f, Res ((Unit, _), _)) ->
-          let lhs = if last__097_ then "r" else "_"
+          let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "filter_map_inplace"
-            (Util.Pp.pp_fun_ true) f (SUT.get_name state__095_ (0 + shift))
+            (Util.Pp.pp_fun_ true) f (SUT.get_name state__097_ (0 + shift))
       | (Length, Res ((Int, _), _)) ->
-          let lhs = if last__097_ then "r" else "_"
+          let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "length"
-            (SUT.get_name state__095_ (0 + shift))
+            (SUT.get_name state__097_ (0 + shift))
       | _ -> assert false
 let ortac_postcond cmd__032_ state__033_ res__034_ =
   let open Spec in
@@ -767,20 +767,30 @@ let ortac_postcond cmd__032_ state__033_ res__034_ =
                     })])
       | (Mem a_5, Res ((Bool, _), b_5)) ->
           if
-            let h_old__053_ = Model.get state__033_ 0
-            and h_new__054_ = lazy (Model.get (Lazy.force new_state__035_) 0) in
+            let h_old__055_ = Model.get state__033_ 0
+            and h_new__056_ = lazy (Model.get (Lazy.force new_state__035_) 0) in
             (try
                (b_5 = true) =
                  (Ortac_runtime.Gospelstdlib.Sequence.mem
                     (Ortac_runtime.Gospelstdlib.Sequence.map
                        Ortac_runtime.Gospelstdlib.fst
-                       (Lazy.force h_new__054_).contents) a_5)
+                       (Lazy.force h_new__056_).contents) a_5)
              with | e -> false)
           then None
           else
             Some
               (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
-                 (try Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))
+                 (try
+                    Ortac_runtime.Value
+                      (Res
+                         (bool,
+                           (let h_old__053_ = Model.get state__033_ 0
+                            and h_new__054_ =
+                              lazy (Model.get (Lazy.force new_state__035_) 0) in
+                            Ortac_runtime.Gospelstdlib.Sequence.mem
+                              (Ortac_runtime.Gospelstdlib.Sequence.map
+                                 Ortac_runtime.Gospelstdlib.fst
+                                 (Lazy.force h_new__054_).contents) a_5)))
                   with | e -> Ortac_runtime.Out_of_domain) "mem"
                  [("b = Sequence.mem (Sequence.map fst h.contents) a",
                     {
@@ -804,12 +814,12 @@ let ortac_postcond cmd__032_ state__033_ res__034_ =
       | (Filter_map_inplace f, Res ((Unit, _), _)) -> None
       | (Length, Res ((Int, _), i)) ->
           if
-            let h_old__061_ = Model.get state__033_ 0
-            and h_new__062_ = lazy (Model.get (Lazy.force new_state__035_) 0) in
+            let h_old__063_ = Model.get state__033_ 0
+            and h_new__064_ = lazy (Model.get (Lazy.force new_state__035_) 0) in
             (try
                (Ortac_runtime.Gospelstdlib.integer_of_int i) =
                  (Ortac_runtime.Gospelstdlib.Sequence.length
-                    (Lazy.force h_new__062_).contents)
+                    (Lazy.force h_new__064_).contents)
              with | e -> false)
           then None
           else
@@ -819,11 +829,11 @@ let ortac_postcond cmd__032_ state__033_ res__034_ =
                     Ortac_runtime.Value
                       (Res
                          (integer,
-                           (let h_old__059_ = Model.get state__033_ 0
-                            and h_new__060_ =
+                           (let h_old__061_ = Model.get state__033_ 0
+                            and h_new__062_ =
                               lazy (Model.get (Lazy.force new_state__035_) 0) in
                             Ortac_runtime.Gospelstdlib.Sequence.length
-                              (Lazy.force h_new__060_).contents)))
+                              (Lazy.force h_new__062_).contents)))
                   with | e -> Ortac_runtime.Out_of_domain) "length"
                  [("i = Sequence.length h.contents",
                     {


### PR DESCRIPTION

Dealing with coercions form boolean to prop, Gospel turns equalities between a boolean and a prop into a double implication.

For example, the postcondition in:

```ocaml
val mem : 'a -> 'a t -> bool
(*@ b = mem a t
    ensures b = Sequence.mem t.contents a *)
```

Will be translated as `b = true <-> Sequence.mem t.contents a`.

This caused some warnings about incomplete computation of the expected returned value (as noted in #269) where the user was sure to have follow what say the documentation (and they was right).

This PR fixes this by exploring `Iff` cases (following the pattern above) in the search for candidates for the returned value description.

It also makes this search more flexible/complete by exploring the symmetric, both for equality and double implication.