### PR TITLE
Fix incorrect error type for violated preconditions and postconditions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- Fix incorrect error type for violated preconditions and postconditions
+  [\#295](https://github.com/ocaml-gospel/ortac/pull/295)
+
 # 0.6.0
 
 - Make search for returned value description more flexible

--- a/plugins/monolith/test/generated/wrapper.expected.ml
+++ b/plugins/monolith/test/generated/wrapper.expected.ml
@@ -108,8 +108,8 @@ module R =
                   |> (Ortac_runtime.Errors.register __error__012_);
                 true))
       then
-        (Ortac_runtime.Violated_invariant
-           { term = "0 <= n <= 32"; position = Pre })
+        (Ortac_runtime.Violated_condition
+           { term = "0 <= n <= 32"; term_kind = Pre })
           |> (Ortac_runtime.Errors.register __error__012_);
       Ortac_runtime.Errors.report __error__012_;
       (let bv_1 =
@@ -142,10 +142,10 @@ module R =
                    |> (Ortac_runtime.Errors.register __error__012_);
                  true))
        then
-         (Ortac_runtime.Violated_invariant
+         (Ortac_runtime.Violated_condition
             {
               term = "forall i. 0 <= i < n -> not (mem i bv)";
-              position = Post
+              term_kind = Post
             })
            |> (Ortac_runtime.Errors.register __error__012_);
        if
@@ -158,8 +158,8 @@ module R =
                    |> (Ortac_runtime.Errors.register __error__012_);
                  true))
        then
-         (Ortac_runtime.Violated_invariant
-            { term = "bv.size = n"; position = Post })
+         (Ortac_runtime.Violated_condition
+            { term = "bv.size = n"; term_kind = Post })
            |> (Ortac_runtime.Errors.register __error__012_);
        __invariant___006_ __error__012_ Post bv_1;
        __invariant___001_ __error__012_ Post bv_1;
@@ -203,8 +203,8 @@ module R =
                   |> (Ortac_runtime.Errors.register __error__015_);
                 true))
       then
-        (Ortac_runtime.Violated_invariant
-           { term = "0 <= i < bv.size"; position = Pre })
+        (Ortac_runtime.Violated_condition
+           { term = "0 <= i < bv.size"; term_kind = Pre })
           |> (Ortac_runtime.Errors.register __error__015_);
       __invariant___006_ __error__015_ Pre bv_2;
       __invariant___001_ __error__015_ Pre bv_2;
@@ -267,8 +267,8 @@ module R =
                   |> (Ortac_runtime.Errors.register __error__020_);
                 true))
       then
-        (Ortac_runtime.Violated_invariant
-           { term = "0 <= i < bv.size"; position = Pre })
+        (Ortac_runtime.Violated_condition
+           { term = "0 <= i < bv.size"; term_kind = Pre })
           |> (Ortac_runtime.Errors.register __error__020_);
       __invariant___006_ __error__020_ Pre bv_3;
       __invariant___001_ __error__020_ Pre bv_3;
@@ -302,8 +302,8 @@ module R =
                    |> (Ortac_runtime.Errors.register __error__020_);
                  true))
        then
-         (Ortac_runtime.Violated_invariant
-            { term = "b <-> mem i bv"; position = Post })
+         (Ortac_runtime.Violated_condition
+            { term = "b <-> mem i bv"; term_kind = Post })
            |> (Ortac_runtime.Errors.register __error__020_);
        __invariant___006_ __error__020_ Post bv_3;
        __invariant___001_ __error__020_ Post bv_3;

--- a/plugins/wrapper/src/failure.ml
+++ b/plugins/wrapper/src/failure.ml
@@ -16,13 +16,18 @@ let term_kind kind =
 let register ~register_name e =
   [%expr [%e e] |> Ortac_runtime.Errors.register [%e register_name]]
 
+let violated_condition kind ~term ~register_name =
+  let kind = term_kind kind in
+  [%expr
+    Ortac_runtime.Violated_condition
+      { term = [%e eterm term]; term_kind = [%e kind] }]
+  |> register ~register_name
+
 let violated_invariant kind ~term ~register_name =
   [%expr
     Ortac_runtime.Violated_invariant
       { term = [%e eterm term]; position = [%e kind] }]
   |> register ~register_name
-
-let violated kind = violated_invariant (term_kind kind)
 
 let violated_axiom ~register_name =
   register ~register_name [%expr Ortac_runtime.Violated_axiom]

--- a/plugins/wrapper/src/failure.mli
+++ b/plugins/wrapper/src/failure.mli
@@ -3,7 +3,7 @@ open Ppxlib
 val violated_invariant :
   expression -> term:string -> register_name:expression -> expression
 
-val violated :
+val violated_condition :
   [ `Check | `Post | `Pre | `XPost | `Invariant ] ->
   term:string ->
   register_name:expression ->

--- a/plugins/wrapper/src/ir_of_gospel.ml
+++ b/plugins/wrapper/src/ir_of_gospel.ml
@@ -176,7 +176,7 @@ let with_modified modifies (value : value) =
 
 let with_pres ~context ~term_printer pres (value : value) =
   let register_name = evar value.register_name in
-  let violated term = F.violated `Pre ~term ~register_name in
+  let violated term = F.violated_condition `Pre ~term ~register_name in
   let nonexec term exn = F.spec_failure `Pre ~term ~exn ~register_name in
   let preconditions = conditions ~context ~term_printer violated nonexec pres in
   { value with preconditions }
@@ -207,7 +207,7 @@ let with_checks ~context ~term_printer checks (value : value) =
 
 let with_posts ~context ~term_printer posts (value : value) =
   let register_name = evar value.register_name in
-  let violated term = F.violated `Post ~term ~register_name in
+  let violated term = F.violated_condition `Post ~term ~register_name in
   let nonexec term exn = F.spec_failure `Post ~term ~exn ~register_name in
   let postconditions =
     conditions ~context ~term_printer violated nonexec posts
@@ -217,7 +217,7 @@ let with_posts ~context ~term_printer posts (value : value) =
 let with_constant_checks ~context ~term_printer checks (constant : Ir.constant)
     =
   let register_name = evar constant.register_name in
-  let violated term = F.violated `Pre ~term ~register_name in
+  let violated term = F.violated_condition `Pre ~term ~register_name in
   let nonexec term exn = F.spec_failure `Pre ~term ~exn ~register_name in
   let checks = conditions ~context ~term_printer violated nonexec checks in
   { constant with checks }
@@ -254,7 +254,7 @@ let with_xposts ~context ~term_printer xposts (value : value) =
                    ~rhs:
                      [%expr
                        if not [%e t] then
-                         [%e F.violated `XPost ~term:s ~register_name]]))
+                         [%e F.violated_condition `XPost ~term:s ~register_name]]))
         (* XXX ptlist must be rev because the cases are given in the
            reverse order by gospel *)
         (List.rev ptlist)

--- a/plugins/wrapper/test/generated/wrapper.expected.ml
+++ b/plugins/wrapper/test/generated/wrapper.expected.ml
@@ -101,8 +101,8 @@ let create n =
               |> (Ortac_runtime.Errors.register __error__012_);
             true))
   then
-    (Ortac_runtime.Violated_invariant
-       { term = "0 <= n <= 32"; position = Pre })
+    (Ortac_runtime.Violated_condition
+       { term = "0 <= n <= 32"; term_kind = Pre })
       |> (Ortac_runtime.Errors.register __error__012_);
   Ortac_runtime.Errors.report __error__012_;
   (let bv_1 =
@@ -134,8 +134,8 @@ let create n =
                |> (Ortac_runtime.Errors.register __error__012_);
              true))
    then
-     (Ortac_runtime.Violated_invariant
-        { term = "forall i. 0 <= i < n -> not (mem i bv)"; position = Post })
+     (Ortac_runtime.Violated_condition
+        { term = "forall i. 0 <= i < n -> not (mem i bv)"; term_kind = Post })
        |> (Ortac_runtime.Errors.register __error__012_);
    if
      not
@@ -147,8 +147,8 @@ let create n =
                |> (Ortac_runtime.Errors.register __error__012_);
              true))
    then
-     (Ortac_runtime.Violated_invariant
-        { term = "bv.size = n"; position = Post })
+     (Ortac_runtime.Violated_condition
+        { term = "bv.size = n"; term_kind = Post })
        |> (Ortac_runtime.Errors.register __error__012_);
    __invariant___006_ __error__012_ Post bv_1;
    __invariant___001_ __error__012_ Post bv_1;
@@ -192,8 +192,8 @@ let add i_2 bv_2 =
               |> (Ortac_runtime.Errors.register __error__015_);
             true))
   then
-    (Ortac_runtime.Violated_invariant
-       { term = "0 <= i < bv.size"; position = Pre })
+    (Ortac_runtime.Violated_condition
+       { term = "0 <= i < bv.size"; term_kind = Pre })
       |> (Ortac_runtime.Errors.register __error__015_);
   __invariant___006_ __error__015_ Pre bv_2;
   __invariant___001_ __error__015_ Pre bv_2;
@@ -255,8 +255,8 @@ let mem i_3 bv_3 =
               |> (Ortac_runtime.Errors.register __error__020_);
             true))
   then
-    (Ortac_runtime.Violated_invariant
-       { term = "0 <= i < bv.size"; position = Pre })
+    (Ortac_runtime.Violated_condition
+       { term = "0 <= i < bv.size"; term_kind = Pre })
       |> (Ortac_runtime.Errors.register __error__020_);
   __invariant___006_ __error__020_ Pre bv_3;
   __invariant___001_ __error__020_ Pre bv_3;
@@ -289,8 +289,8 @@ let mem i_3 bv_3 =
                |> (Ortac_runtime.Errors.register __error__020_);
              true))
    then
-     (Ortac_runtime.Violated_invariant
-        { term = "b <-> mem i bv"; position = Post })
+     (Ortac_runtime.Violated_condition
+        { term = "b <-> mem i bv"; term_kind = Post })
        |> (Ortac_runtime.Errors.register __error__020_);
    __invariant___006_ __error__020_ Post bv_3;
    __invariant___001_ __error__020_ Post bv_3;


### PR DESCRIPTION
When a precondition or postcondition is violated, Ortac generates a raise to `Violated_invariant` from the `Ortac_runtime`, which is incorrect (as explained in [#294]). The expected behaviour is to raise `Violated_condition` instead, as preconditions and postconditions are contract conditions, not invariants.

This PR fixes this by matching `kind` with the expected error type when `kind` is violated.
```ocaml
let violated kind = match kind with
  | `Pre | `Post -> violated_condition (term_kind kind)
  | _ -> violated_invariant (term_kind kind)
```