### PR TITLE
[QCheck-STM] Fix labelled arguments in runnable scenario

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [QCheck-STM] Fix labelled arguments in runnable scenario
+  [\#300](https://github.com/ocaml-gospel/ortac/pull/300)
 - Extend Wrapper plugin tests
   [\#299](https://github.com/ocaml-gospel/ortac/pull/299)
 - Fix incorrect error type for violated preconditions and postconditions

--- a/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
@@ -528,7 +528,7 @@ let ortac_show_cmd cmd__096_ state__097_ last__099_ res__098_ =
       | (Create (random, size), Res ((SUT, _), h)) ->
           let lhs = if last__099_ then "r" else SUT.get_name state__097_ 0
           and shift = 1 in
-          Format.asprintf "let %s = %s %a %a" lhs "create"
+          Format.asprintf "let %s = %s ~random:%a %a" lhs "create"
             (Util.Pp.pp_bool true) random (Util.Pp.pp_int true) size
       | (Clear, Res ((Unit, _), _)) ->
           let lhs = if last__099_ then "r" else "_"


### PR DESCRIPTION

This PR fixes #298

The fix is simpler that what I first thought, which is good news.