### PR TITLE
Add support for models in the wrapper plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [Wrapper] Add support for models in the wrapper plugin
+  [\#305](https://github.com/ocaml-gospel/ortac/pull/305)
 - [QCheck-STM] Disable warning 34 in generated code
   [\#307](https://github.com/ocaml-gospel/ortac/pull/307)
 - [Wrapper] Reorganise tests into separate files

--- a/plugins/wrapper/src/ir.ml
+++ b/plugins/wrapper/src/ir.ml
@@ -62,6 +62,7 @@ type value = {
   arguments : ocaml_var list;
   returns : ocaml_var list;
   register_name : string;
+  model : bool;
   ghost : Gospel.Tast.ghost;
   pure : bool;
   checks : check list;
@@ -71,13 +72,14 @@ type value = {
   xpostconditions : xpost list;
 }
 
-let value ~name ~loc ~arguments ~returns ~register_name ~ghost ~pure =
+let value ~name ~loc ~arguments ~returns ~register_name ~model ~ghost ~pure =
   {
     name;
     loc;
     arguments;
     returns;
     register_name;
+    model;
     ghost;
     pure;
     checks = [];

--- a/plugins/wrapper/src/ir_of_gospel.ml
+++ b/plugins/wrapper/src/ir_of_gospel.ml
@@ -586,6 +586,13 @@ let type_ ~pack ~ghost (td : Tast.type_declaration) =
 
 let types ~pack ~ghost = List.fold_left (fun pack -> type_ ~pack ~ghost) pack
 
+let is_projection (vd : Tast.val_description) =
+  let aux = function
+    | { attr_name = { txt = "model"; _ }; _ } -> true
+    | _ -> false
+  in
+  List.exists aux vd.vd_attrs
+
 let value ~pack ~ghost (vd : Tast.val_description) =
   let ir, context = P.unpack pack in
   let name = vd.vd_name.id_str in
@@ -593,9 +600,10 @@ let value ~pack ~ghost (vd : Tast.val_description) =
   let register_name = register_name () in
   let arguments = List.map (var_of_arg ~ir) vd.vd_args in
   let returns = List.map (var_of_arg ~ir) vd.vd_ret in
+  let model = is_projection vd in
   let pure = false in
   let value =
-    Ir.value ~name ~loc ~register_name ~arguments ~returns ~pure ~ghost
+    Ir.value ~name ~loc ~register_name ~arguments ~returns ~pure ~ghost ~model
   in
   let process ~value (spec : Tast.val_spec) =
     let term_printer = term_printer spec.sp_text spec.sp_loc in

--- a/plugins/wrapper/src/report.ml
+++ b/plugins/wrapper/src/report.ml
@@ -3,13 +3,12 @@ module W = Ortac_core.Warnings
 type W.kind +=
   | Ghost_value of string
   | Ghost_type of string
-  | Unsupported_model of string * string
   | Function_without_definition of string
   | Predicate_without_definition of string
 
 let level = function
-  | Ghost_value _ | Ghost_type _ | Unsupported_model _
-  | Function_without_definition _ | Predicate_without_definition _ ->
+  | Ghost_value _ | Ghost_type _ | Function_without_definition _
+  | Predicate_without_definition _ ->
       W.Warning
   | kind -> W.level kind
 
@@ -19,9 +18,6 @@ let pp_kind ppf = function
   | Ghost_value name ->
       pf ppf "%s is a ghost value. It was not translated." name
   | Ghost_type name -> pf ppf "%s is a ghost type. It was not translated." name
-  | Unsupported_model (type_, name) ->
-      pf ppf "Model %s of type %s is not supported. It was not translated." name
-        type_
   | Function_without_definition name ->
       pf ppf "The function %s has no definition. It was not translated." name
   | Predicate_without_definition name ->
@@ -55,11 +51,6 @@ let type_ ppf (t : type_) =
   match t.ghost with
   | Gospel.Tast.Ghost -> pp ppf (Ghost_type t.name, t.loc)
   | Nonghost ->
-      List.iter
-        (fun (m, _) ->
-          let t = (Unsupported_model (t.name, m), t.loc) in
-          pp ppf t)
-        t.models;
       (* Result.iter_error (W.pp ppf) t.equality; *)
       (* Result.iter_error (W.pp ppf) t.comparison; *)
       (* Result.iter_error (W.pp ppf) t.copy; *)

--- a/plugins/wrapper/test/generated/dune
+++ b/plugins/wrapper/test/generated/dune
@@ -54,3 +54,28 @@
   (progn
    (diff errors_behaviour.expected errors_behaviour)
    (diff wrapper_behaviour.expected.ml wrapper_behaviour.ml))))
+
+(rule
+ (copy lib_model.mli wrapper_model.mli))
+
+(rule
+ (target wrapper_model.ml)
+ (package ortac-wrapper)
+ (deps
+  (package ortac-core)
+  (package ortac-wrapper))
+ (action
+  (setenv
+   ORTAC_ONLY_PLUGIN
+   wrapper
+   (with-stderr-to
+    errors_model
+    (run ortac wrapper -o %{target} %{dep:lib_model.mli})))))
+
+(rule
+ (alias runtest)
+ (package ortac-wrapper)
+ (action
+  (progn
+   (diff errors_model.expected errors_model)
+   (diff wrapper_model.expected.ml wrapper_model.ml))))

--- a/plugins/wrapper/test/generated/lib_model.ml
+++ b/plugins/wrapper/test/generated/lib_model.ml
@@ -1,0 +1,10 @@
+type 'a t = { cap : int; mutable elements : 'a list }
+
+let capacity t = t.cap
+let view t = t.elements
+let length t = List.length t.elements
+let create n = { cap = n; elements = [] }
+let is_empty t = t.elements = []
+let mem t x = List.mem x t.elements
+let clear t = t.elements <- []
+let add t x = if length t + 1 <= t.cap then t.elements <- x :: t.elements

--- a/plugins/wrapper/test/generated/lib_model.mli
+++ b/plugins/wrapper/test/generated/lib_model.mli
@@ -1,0 +1,34 @@
+type 'a t
+(*@ model capacity: int
+    mutable model view: 'a list
+    with t
+    invariant t.capacity > 0
+    invariant List.length t.view <= t.capacity *)
+
+val capacity : 'a t -> int [@@model]
+val view : 'a t -> 'a list [@@model]
+val create : int -> 'a t
+(*@ t = create c
+    requires c > 0
+    ensures t.capacity = c
+    ensures t.view = [] *)
+
+val is_empty : 'a t -> bool
+(*@ b = is_empty t
+    pure
+    ensures b <-> t.view = [] *)
+
+val mem : 'a t -> 'a -> bool
+(*@ b = mem t x
+    pure
+    ensures b <-> List.mem x t.view *)
+
+val clear : 'a t -> unit
+(*@ clear t
+    modifies t.view
+    ensures is_empty t *)
+
+val add : 'a t -> 'a -> unit
+(*@ add t x
+    modifies t.view
+    ensures t.view = x :: (old t.view) *)

--- a/plugins/wrapper/test/generated/test.ml
+++ b/plugins/wrapper/test/generated/test.ml
@@ -1,5 +1,6 @@
 module To_test = Wrapper
 module To_test2 = Wrapper_behaviour
+module To_test3 = Wrapper_model
 
 let test_create () =
   let s = To_test.create 5 in
@@ -94,6 +95,12 @@ Runtime error in function `bad2_increment_int'
     Alcotest.fail "n should be incremented"
   with Ortac_runtime.Error _ -> ()
 
+let add_model () =
+  let s = To_test3.create 4 in
+  To_test3.add s 1;
+  To_test3.add s 2;
+  To_test3.add s 3
+
 let () =
   let open Alcotest in
   run "Wrapped lib"
@@ -115,4 +122,5 @@ let () =
           test_case "checks no hold, Invalid_argument hit" `Quick inv_arg;
           test_case "postcondition hit" `Quick post_cond;
         ] );
+      ("model tests", [ test_case "add model" `Quick add_model ]);
     ]

--- a/plugins/wrapper/test/generated/wrapper_model.expected.ml
+++ b/plugins/wrapper/test/generated/wrapper_model.expected.ml
@@ -1,0 +1,426 @@
+include Lib_model
+module Ortac_runtime = Ortac_runtime
+let __invariant___001_ __error___002_ __position___003_ t_1 =
+  if
+    not
+      (try
+         Ortac_runtime.Gospelstdlib.(>)
+           (Ortac_runtime.Gospelstdlib.integer_of_int (capacity t_1))
+           (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+       with
+       | e ->
+           ((Ortac_runtime.Specification_failure
+               {
+                 term = "t.capacity > 0";
+                 term_kind = __position___003_;
+                 exn = e
+               })
+              |> (Ortac_runtime.Errors.register __error___002_);
+            true))
+  then
+    (Ortac_runtime.Violated_invariant
+       { term = "t.capacity > 0"; position = __position___003_ })
+      |> (Ortac_runtime.Errors.register __error___002_)
+let __invariant___004_ __error___005_ __position___006_ t_1 =
+  if
+    not
+      (try
+         Ortac_runtime.Gospelstdlib.(<=)
+           (Ortac_runtime.Gospelstdlib.List.length (view t_1))
+           (Ortac_runtime.Gospelstdlib.integer_of_int (capacity t_1))
+       with
+       | e ->
+           ((Ortac_runtime.Specification_failure
+               {
+                 term = "List.length t.view <= t.capacity";
+                 term_kind = __position___006_;
+                 exn = e
+               })
+              |> (Ortac_runtime.Errors.register __error___005_);
+            true))
+  then
+    (Ortac_runtime.Violated_invariant
+       {
+         term = "List.length t.view <= t.capacity";
+         position = __position___006_
+       })
+      |> (Ortac_runtime.Errors.register __error___005_)
+let capacity __arg0 =
+  let __error__007_ =
+    Ortac_runtime.Errors.create
+      {
+        Ortac_runtime.start =
+          {
+            pos_fname = "lib_model.mli";
+            pos_lnum = 8;
+            pos_bol = 277;
+            pos_cnum = 277
+          };
+        Ortac_runtime.stop =
+          {
+            pos_fname = "lib_model.mli";
+            pos_lnum = 8;
+            pos_bol = 277;
+            pos_cnum = 313
+          }
+      } "capacity" in
+  __invariant___004_ __error__007_ Pre __arg0;
+  __invariant___001_ __error__007_ Pre __arg0;
+  Ortac_runtime.Errors.report __error__007_;
+  (let result =
+     try capacity __arg0
+     with
+     | Stack_overflow | Out_of_memory as e ->
+         ((__invariant___004_ __error__007_ XPost __arg0;
+           __invariant___001_ __error__007_ XPost __arg0;
+           Ortac_runtime.Errors.report __error__007_);
+          raise e)
+     | e ->
+         ((Ortac_runtime.Unexpected_exception { allowed_exn = []; exn = e })
+            |> (Ortac_runtime.Errors.register __error__007_);
+          (__invariant___004_ __error__007_ XPost __arg0;
+           __invariant___001_ __error__007_ XPost __arg0;
+           Ortac_runtime.Errors.report __error__007_);
+          raise e) in
+   __invariant___004_ __error__007_ Post __arg0;
+   __invariant___001_ __error__007_ Post __arg0;
+   Ortac_runtime.Errors.report __error__007_;
+   result)
+let view __arg0_1 =
+  let __error__008_ =
+    Ortac_runtime.Errors.create
+      {
+        Ortac_runtime.start =
+          {
+            pos_fname = "lib_model.mli";
+            pos_lnum = 9;
+            pos_bol = 314;
+            pos_cnum = 314
+          };
+        Ortac_runtime.stop =
+          {
+            pos_fname = "lib_model.mli";
+            pos_lnum = 9;
+            pos_bol = 314;
+            pos_cnum = 350
+          }
+      } "view" in
+  __invariant___004_ __error__008_ Pre __arg0_1;
+  __invariant___001_ __error__008_ Pre __arg0_1;
+  Ortac_runtime.Errors.report __error__008_;
+  (let result_1 =
+     try view __arg0_1
+     with
+     | Stack_overflow | Out_of_memory as e ->
+         ((__invariant___004_ __error__008_ XPost __arg0_1;
+           __invariant___001_ __error__008_ XPost __arg0_1;
+           Ortac_runtime.Errors.report __error__008_);
+          raise e)
+     | e ->
+         ((Ortac_runtime.Unexpected_exception { allowed_exn = []; exn = e })
+            |> (Ortac_runtime.Errors.register __error__008_);
+          (__invariant___004_ __error__008_ XPost __arg0_1;
+           __invariant___001_ __error__008_ XPost __arg0_1;
+           Ortac_runtime.Errors.report __error__008_);
+          raise e) in
+   __invariant___004_ __error__008_ Post __arg0_1;
+   __invariant___001_ __error__008_ Post __arg0_1;
+   Ortac_runtime.Errors.report __error__008_;
+   result_1)
+let create c =
+  let __error__009_ =
+    Ortac_runtime.Errors.create
+      {
+        Ortac_runtime.start =
+          {
+            pos_fname = "lib_model.mli";
+            pos_lnum = 10;
+            pos_bol = 351;
+            pos_cnum = 351
+          };
+        Ortac_runtime.stop =
+          {
+            pos_fname = "lib_model.mli";
+            pos_lnum = 14;
+            pos_bol = 518;
+            pos_cnum = 544
+          }
+      } "create" in
+  if
+    not
+      (try
+         Ortac_runtime.Gospelstdlib.(>)
+           (Ortac_runtime.Gospelstdlib.integer_of_int c)
+           (Ortac_runtime.Gospelstdlib.integer_of_int 0)
+       with
+       | e ->
+           ((Ortac_runtime.Specification_failure
+               { term = "c > 0"; term_kind = Pre; exn = e })
+              |> (Ortac_runtime.Errors.register __error__009_);
+            true))
+  then
+    (Ortac_runtime.Violated_condition { term = "c > 0"; term_kind = Pre }) |>
+      (Ortac_runtime.Errors.register __error__009_);
+  Ortac_runtime.Errors.report __error__009_;
+  (let t_2 =
+     try create c
+     with
+     | Stack_overflow | Out_of_memory as e ->
+         (Ortac_runtime.Errors.report __error__009_; raise e)
+     | e ->
+         ((Ortac_runtime.Unexpected_exception { allowed_exn = []; exn = e })
+            |> (Ortac_runtime.Errors.register __error__009_);
+          Ortac_runtime.Errors.report __error__009_;
+          raise e) in
+   if
+     not
+       (try (view t_2) = []
+        with
+        | e ->
+            ((Ortac_runtime.Specification_failure
+                { term = "t.view = []"; term_kind = Post; exn = e })
+               |> (Ortac_runtime.Errors.register __error__009_);
+             true))
+   then
+     (Ortac_runtime.Violated_condition
+        { term = "t.view = []"; term_kind = Post })
+       |> (Ortac_runtime.Errors.register __error__009_);
+   if
+     not
+       (try (capacity t_2) = c
+        with
+        | e ->
+            ((Ortac_runtime.Specification_failure
+                { term = "t.capacity = c"; term_kind = Post; exn = e })
+               |> (Ortac_runtime.Errors.register __error__009_);
+             true))
+   then
+     (Ortac_runtime.Violated_condition
+        { term = "t.capacity = c"; term_kind = Post })
+       |> (Ortac_runtime.Errors.register __error__009_);
+   __invariant___004_ __error__009_ Post t_2;
+   __invariant___001_ __error__009_ Post t_2;
+   Ortac_runtime.Errors.report __error__009_;
+   t_2)
+let is_empty t_3 =
+  let __error__010_ =
+    Ortac_runtime.Errors.create
+      {
+        Ortac_runtime.start =
+          {
+            pos_fname = "lib_model.mli";
+            pos_lnum = 16;
+            pos_bol = 546;
+            pos_cnum = 546
+          };
+        Ortac_runtime.stop =
+          {
+            pos_fname = "lib_model.mli";
+            pos_lnum = 19;
+            pos_bol = 687;
+            pos_cnum = 719
+          }
+      } "is_empty" in
+  __invariant___004_ __error__010_ Pre t_3;
+  __invariant___001_ __error__010_ Pre t_3;
+  Ortac_runtime.Errors.report __error__010_;
+  (let b =
+     try is_empty t_3
+     with
+     | Stack_overflow | Out_of_memory as e ->
+         ((__invariant___004_ __error__010_ XPost t_3;
+           __invariant___001_ __error__010_ XPost t_3;
+           Ortac_runtime.Errors.report __error__010_);
+          raise e)
+     | e ->
+         ((Ortac_runtime.Unexpected_exception { allowed_exn = []; exn = e })
+            |> (Ortac_runtime.Errors.register __error__010_);
+          (__invariant___004_ __error__010_ XPost t_3;
+           __invariant___001_ __error__010_ XPost t_3;
+           Ortac_runtime.Errors.report __error__010_);
+          raise e) in
+   if
+     not
+       (try (b = true) = ((view t_3) = [])
+        with
+        | e ->
+            ((Ortac_runtime.Specification_failure
+                { term = "b <-> t.view = []"; term_kind = Post; exn = e })
+               |> (Ortac_runtime.Errors.register __error__010_);
+             true))
+   then
+     (Ortac_runtime.Violated_condition
+        { term = "b <-> t.view = []"; term_kind = Post })
+       |> (Ortac_runtime.Errors.register __error__010_);
+   __invariant___004_ __error__010_ Post t_3;
+   __invariant___001_ __error__010_ Post t_3;
+   Ortac_runtime.Errors.report __error__010_;
+   b)
+let mem t_4 x =
+  let __error__011_ =
+    Ortac_runtime.Errors.create
+      {
+        Ortac_runtime.start =
+          {
+            pos_fname = "lib_model.mli";
+            pos_lnum = 21;
+            pos_bol = 721;
+            pos_cnum = 721
+          };
+        Ortac_runtime.stop =
+          {
+            pos_fname = "lib_model.mli";
+            pos_lnum = 24;
+            pos_bol = 866;
+            pos_cnum = 904
+          }
+      } "mem" in
+  __invariant___004_ __error__011_ Pre t_4;
+  __invariant___001_ __error__011_ Pre t_4;
+  Ortac_runtime.Errors.report __error__011_;
+  (let b_1 =
+     try mem t_4 x
+     with
+     | Stack_overflow | Out_of_memory as e ->
+         ((__invariant___004_ __error__011_ XPost t_4;
+           __invariant___001_ __error__011_ XPost t_4;
+           Ortac_runtime.Errors.report __error__011_);
+          raise e)
+     | e ->
+         ((Ortac_runtime.Unexpected_exception { allowed_exn = []; exn = e })
+            |> (Ortac_runtime.Errors.register __error__011_);
+          (__invariant___004_ __error__011_ XPost t_4;
+           __invariant___001_ __error__011_ XPost t_4;
+           Ortac_runtime.Errors.report __error__011_);
+          raise e) in
+   if
+     not
+       (try (b_1 = true) = (Ortac_runtime.Gospelstdlib.List.mem x (view t_4))
+        with
+        | e ->
+            ((Ortac_runtime.Specification_failure
+                { term = "b <-> List.mem x t.view"; term_kind = Post; exn = e
+                })
+               |> (Ortac_runtime.Errors.register __error__011_);
+             true))
+   then
+     (Ortac_runtime.Violated_condition
+        { term = "b <-> List.mem x t.view"; term_kind = Post })
+       |> (Ortac_runtime.Errors.register __error__011_);
+   __invariant___004_ __error__011_ Post t_4;
+   __invariant___001_ __error__011_ Post t_4;
+   Ortac_runtime.Errors.report __error__011_;
+   b_1)
+let clear t_5 =
+  let __error__012_ =
+    Ortac_runtime.Errors.create
+      {
+        Ortac_runtime.start =
+          {
+            pos_fname = "lib_model.mli";
+            pos_lnum = 26;
+            pos_bol = 906;
+            pos_cnum = 906
+          };
+        Ortac_runtime.stop =
+          {
+            pos_fname = "lib_model.mli";
+            pos_lnum = 29;
+            pos_bol = 1041;
+            pos_cnum = 1066
+          }
+      } "clear" in
+  __invariant___004_ __error__012_ Pre t_5;
+  __invariant___001_ __error__012_ Pre t_5;
+  Ortac_runtime.Errors.report __error__012_;
+  (let () =
+     try clear t_5
+     with
+     | Stack_overflow | Out_of_memory as e ->
+         ((__invariant___004_ __error__012_ XPost t_5;
+           __invariant___001_ __error__012_ XPost t_5;
+           Ortac_runtime.Errors.report __error__012_);
+          raise e)
+     | e ->
+         ((Ortac_runtime.Unexpected_exception { allowed_exn = []; exn = e })
+            |> (Ortac_runtime.Errors.register __error__012_);
+          (__invariant___004_ __error__012_ XPost t_5;
+           __invariant___001_ __error__012_ XPost t_5;
+           Ortac_runtime.Errors.report __error__012_);
+          raise e) in
+   if
+     not
+       (try (is_empty t_5) = true
+        with
+        | e ->
+            ((Ortac_runtime.Specification_failure
+                { term = "is_empty t"; term_kind = Post; exn = e })
+               |> (Ortac_runtime.Errors.register __error__012_);
+             true))
+   then
+     (Ortac_runtime.Violated_condition
+        { term = "is_empty t"; term_kind = Post })
+       |> (Ortac_runtime.Errors.register __error__012_);
+   __invariant___004_ __error__012_ Post t_5;
+   __invariant___001_ __error__012_ Post t_5;
+   Ortac_runtime.Errors.report __error__012_;
+   ())
+let add t_6 x_1 =
+  let __error__013_ =
+    Ortac_runtime.Errors.create
+      {
+        Ortac_runtime.start =
+          {
+            pos_fname = "lib_model.mli";
+            pos_lnum = 31;
+            pos_bol = 1068;
+            pos_cnum = 1068
+          };
+        Ortac_runtime.stop =
+          {
+            pos_fname = "lib_model.mli";
+            pos_lnum = 34;
+            pos_bol = 1223;
+            pos_cnum = 1264
+          }
+      } "add" in
+  let ___ortac_copy_1 = Ortac_runtime.copy t_6 in
+  __invariant___004_ __error__013_ Pre t_6;
+  __invariant___001_ __error__013_ Pre t_6;
+  Ortac_runtime.Errors.report __error__013_;
+  (let () =
+     try add t_6 x_1
+     with
+     | Stack_overflow | Out_of_memory as e ->
+         ((__invariant___004_ __error__013_ XPost t_6;
+           __invariant___001_ __error__013_ XPost t_6;
+           Ortac_runtime.Errors.report __error__013_);
+          raise e)
+     | e ->
+         ((Ortac_runtime.Unexpected_exception { allowed_exn = []; exn = e })
+            |> (Ortac_runtime.Errors.register __error__013_);
+          (__invariant___004_ __error__013_ XPost t_6;
+           __invariant___001_ __error__013_ XPost t_6;
+           Ortac_runtime.Errors.report __error__013_);
+          raise e) in
+   if
+     not
+       (try (view t_6) = (x_1 :: (view ___ortac_copy_1))
+        with
+        | e ->
+            ((Ortac_runtime.Specification_failure
+                {
+                  term = "t.view = x :: (old t.view)";
+                  term_kind = Post;
+                  exn = e
+                })
+               |> (Ortac_runtime.Errors.register __error__013_);
+             true))
+   then
+     (Ortac_runtime.Violated_condition
+        { term = "t.view = x :: (old t.view)"; term_kind = Post })
+       |> (Ortac_runtime.Errors.register __error__013_);
+   __invariant___004_ __error__013_ Post t_6;
+   __invariant___001_ __error__013_ Post t_6;
+   Ortac_runtime.Errors.report __error__013_;
+   ())


### PR DESCRIPTION
WIP:
This PR adds support for models in the Wrapper plugin, using ideas from #224.
To enable model support in Wrapper, a projection function should be implemented and exposed in the interface file. This function should be named the same as the gospel model it targets and annotated in the interface file with the attribute `[@@model]`.
When multiple models are defined, the same number of projection functions should be provided.

Internally, these projection functions are handled as regular `values` except that we register if it has the attribute `model` or not.

For example, the projection function `view`:
 ```ocaml
type 'a t
(*@ mutable model view : 'a sequence *)

val view : 'a t -> 'a list [@@model]
```
During translation, `collect_model` replaces all occurrences of the gospel model with calls to the corresponding projection function (both in the postconditions and invariants).