### PR TITLE
[QCheck-STM] Refactor runtime to allow for OCaml5-only sub-library

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- [QCheck-STM] Refactor runtime to allow for OCaml5-only sub-library
+  [\#316](https://github.com/ocaml-gospel/ortac/pull/316)
+
 # 0.7.2
 
 - [Dune] Fix cycle dependency in `Ortac/Dune-rules` for wrapper plugin

--- a/examples/dune.lwt_dllist.inc
+++ b/examples/dune.lwt_dllist.inc
@@ -29,7 +29,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm)
+  ortac-runtime-qcheck-stm.sequential)
  (package ortac-examples)
  (action
   (run

--- a/examples/dune.varray_circular.inc
+++ b/examples/dune.varray_circular.inc
@@ -29,7 +29,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm)
+  ortac-runtime-qcheck-stm.sequential)
  (package ortac-examples)
  (action
   (run

--- a/examples/lwt_dllist_spec_tests.ml
+++ b/examples/lwt_dllist_spec_tests.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Lwt_dllist_spec
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 module SUT =
   (Ortac_runtime.SUT.Make)(struct type sut = int t
                                   let init () = create () end)

--- a/examples/lwt_dllist_spec_tests.ml
+++ b/examples/lwt_dllist_spec_tests.ml
@@ -534,9 +534,9 @@ let ortac_postcond cmd__025_ state__026_ res__027_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
+              (Ortac_runtime.Report.report "Lwt_dllist_spec" "create ()"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          (bool,
                            (let s_old__030_ = Model.get state__026_ 0
@@ -544,7 +544,7 @@ let ortac_postcond cmd__025_ state__026_ res__027_ =
                               lazy (Model.get (Lazy.force new_state__028_) 0) in
                             (Lazy.force s_new__031_).contents =
                               Ortac_runtime.Gospelstdlib.Sequence.empty)))
-                  with | e -> Ortac_runtime.Out_of_domain) "is_empty"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "is_empty"
                  [("b <-> s.contents = Sequence.empty",
                     {
                       Ortac_runtime.start =
@@ -574,9 +574,9 @@ let ortac_postcond cmd__025_ state__026_ res__027_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
+              (Ortac_runtime.Report.report "Lwt_dllist_spec" "create ()"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          (integer,
                            (let s_old__035_ = Model.get state__026_ 0
@@ -584,7 +584,7 @@ let ortac_postcond cmd__025_ state__026_ res__027_ =
                               lazy (Model.get (Lazy.force new_state__028_) 0) in
                             Ortac_runtime.Gospelstdlib.Sequence.length
                               (Lazy.force s_new__036_).contents)))
-                  with | e -> Ortac_runtime.Out_of_domain) "length"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "length"
                  [("l = Sequence.length s.contents",
                     {
                       Ortac_runtime.start =
@@ -624,11 +624,12 @@ let ortac_postcond cmd__025_ state__026_ res__027_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
+                   (Ortac_runtime.Report.report "Lwt_dllist_spec" "create ()"
                       (try
-                         Ortac_runtime.Protected_value
-                           (Res (Ortac_runtime.dummy, ()))
-                       with | e -> Ortac_runtime.Out_of_domain) "take_l"
+                         Ortac_runtime.Report.Protected_value
+                           (Res (Ortac_runtime.Report.dummy, ()))
+                       with | e -> Ortac_runtime.Report.Out_of_domain)
+                      "take_l"
                       [("if old s.contents = Sequence.empty\n              then false\n              else a = Sequence.hd (old s.contents)",
                          {
                            Ortac_runtime.start =
@@ -663,9 +664,10 @@ let ortac_postcond cmd__025_ state__026_ res__027_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                      (try Ortac_runtime.Exception "Empty"
-                       with | e -> Ortac_runtime.Out_of_domain) "take_l"
+                   (Ortac_runtime.Report.report "Lwt_dllist_spec" "create ()"
+                      (try Ortac_runtime.Report.Exception "Empty"
+                       with | e -> Ortac_runtime.Report.Out_of_domain)
+                      "take_l"
                       [("old s.contents = Sequence.empty = s.contents",
                          {
                            Ortac_runtime.start =
@@ -708,11 +710,12 @@ let ortac_postcond cmd__025_ state__026_ res__027_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
+                   (Ortac_runtime.Report.report "Lwt_dllist_spec" "create ()"
                       (try
-                         Ortac_runtime.Protected_value
-                           (Res (Ortac_runtime.dummy, ()))
-                       with | e -> Ortac_runtime.Out_of_domain) "take_r"
+                         Ortac_runtime.Report.Protected_value
+                           (Res (Ortac_runtime.Report.dummy, ()))
+                       with | e -> Ortac_runtime.Report.Out_of_domain)
+                      "take_r"
                       [("if old s.contents = Sequence.empty\n              then false\n              else a = (old s.contents)[Sequence.length (old s.contents) - 1]",
                          {
                            Ortac_runtime.start =
@@ -747,9 +750,10 @@ let ortac_postcond cmd__025_ state__026_ res__027_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                      (try Ortac_runtime.Exception "Empty"
-                       with | e -> Ortac_runtime.Out_of_domain) "take_r"
+                   (Ortac_runtime.Report.report "Lwt_dllist_spec" "create ()"
+                      (try Ortac_runtime.Report.Exception "Empty"
+                       with | e -> Ortac_runtime.Report.Out_of_domain)
+                      "take_r"
                       [("old s.contents = Sequence.empty = s.contents",
                          {
                            Ortac_runtime.start =
@@ -783,9 +787,12 @@ let ortac_postcond cmd__025_ state__026_ res__027_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                 (try Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))
-                  with | e -> Ortac_runtime.Out_of_domain) "take_opt_l"
+              (Ortac_runtime.Report.report "Lwt_dllist_spec" "create ()"
+                 (try
+                    Ortac_runtime.Report.Value
+                      (Res (Ortac_runtime.Report.dummy, ()))
+                  with | e -> Ortac_runtime.Report.Out_of_domain)
+                 "take_opt_l"
                  [("old s.contents = match o with\n                                | None -> Sequence.empty\n                                | Some a -> Sequence.cons a s.contents",
                     {
                       Ortac_runtime.start =
@@ -818,9 +825,12 @@ let ortac_postcond cmd__025_ state__026_ res__027_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Lwt_dllist_spec" "create ()"
-                 (try Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))
-                  with | e -> Ortac_runtime.Out_of_domain) "take_opt_r"
+              (Ortac_runtime.Report.report "Lwt_dllist_spec" "create ()"
+                 (try
+                    Ortac_runtime.Report.Value
+                      (Res (Ortac_runtime.Report.dummy, ()))
+                  with | e -> Ortac_runtime.Report.Out_of_domain)
+                 "take_opt_r"
                  [("old s.contents = match o with\n                                | None -> Sequence.empty\n                                | Some a -> Sequence.snoc s.contents a",
                     {
                       Ortac_runtime.start =

--- a/examples/varray_circular_spec_tests.ml
+++ b/examples/varray_circular_spec_tests.ml
@@ -1320,11 +1320,13 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
+                   (Ortac_runtime.Report.report "Varray_circular_spec"
+                      "make 42 'a'"
                       (try
-                         Ortac_runtime.Protected_value
-                           (Res (Ortac_runtime.dummy, ()))
-                       with | e -> Ortac_runtime.Out_of_domain) "pop_back"
+                         Ortac_runtime.Report.Protected_value
+                           (Res (Ortac_runtime.Report.dummy, ()))
+                       with | e -> Ortac_runtime.Report.Out_of_domain)
+                      "pop_back"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = (old t.contents)[Sequence.length (old t.contents) - 1]",
                          {
                            Ortac_runtime.start =
@@ -1359,9 +1361,11 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
-                      (try Ortac_runtime.Exception "Not_found"
-                       with | e -> Ortac_runtime.Out_of_domain) "pop_back"
+                   (Ortac_runtime.Report.report "Varray_circular_spec"
+                      "make 42 'a'"
+                      (try Ortac_runtime.Report.Exception "Not_found"
+                       with | e -> Ortac_runtime.Report.Out_of_domain)
+                      "pop_back"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -1401,11 +1405,13 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
+                   (Ortac_runtime.Report.report "Varray_circular_spec"
+                      "make 42 'a'"
                       (try
-                         Ortac_runtime.Protected_value
-                           (Res (Ortac_runtime.dummy, ()))
-                       with | e -> Ortac_runtime.Out_of_domain) "pop_front"
+                         Ortac_runtime.Report.Protected_value
+                           (Res (Ortac_runtime.Report.dummy, ()))
+                       with | e -> Ortac_runtime.Report.Out_of_domain)
+                      "pop_front"
                       [("if old t.contents = Sequence.empty\n              then false\n              else proj x = Sequence.hd (old t.contents)",
                          {
                            Ortac_runtime.start =
@@ -1440,9 +1446,11 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
-                      (try Ortac_runtime.Exception "Not_found"
-                       with | e -> Ortac_runtime.Out_of_domain) "pop_front"
+                   (Ortac_runtime.Report.report "Varray_circular_spec"
+                      "make 42 'a'"
+                      (try Ortac_runtime.Report.Exception "Not_found"
+                       with | e -> Ortac_runtime.Report.Out_of_domain)
+                      "pop_front"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -1479,10 +1487,12 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec"
+                     (Ortac_runtime.Report.report "Varray_circular_spec"
                         "make 42 'a'"
-                        (try Ortac_runtime.Exception "Invalid_argument"
-                         with | e -> Ortac_runtime.Out_of_domain) "insert_at"
+                        (try
+                           Ortac_runtime.Report.Exception "Invalid_argument"
+                         with | e -> Ortac_runtime.Report.Out_of_domain)
+                        "insert_at"
                         [("0 <= i <= Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -1523,10 +1533,12 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec"
+                        (Ortac_runtime.Report.report "Varray_circular_spec"
                            "make 42 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain)
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
                            "insert_at"
                            [("0 <= i <= Sequence.length t.contents",
                               {
@@ -1556,10 +1568,12 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec"
+                     (Ortac_runtime.Report.report "Varray_circular_spec"
                         "make 42 'a'"
-                        (try Ortac_runtime.Exception "Invalid_argument"
-                         with | e -> Ortac_runtime.Out_of_domain) "pop_at"
+                        (try
+                           Ortac_runtime.Report.Exception "Invalid_argument"
+                         with | e -> Ortac_runtime.Report.Out_of_domain)
+                        "pop_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1594,12 +1608,13 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec"
+                        (Ortac_runtime.Report.report "Varray_circular_spec"
                            "make 42 'a'"
                            (try
-                              Ortac_runtime.Protected_value
-                                (Res (Ortac_runtime.dummy, ()))
-                            with | e -> Ortac_runtime.Out_of_domain) "pop_at"
+                              Ortac_runtime.Report.Protected_value
+                                (Res (Ortac_runtime.Report.dummy, ()))
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "pop_at"
                            [("(proj x) = old t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -1633,10 +1648,13 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec"
+                        (Ortac_runtime.Report.report "Varray_circular_spec"
                            "make 42 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "pop_at"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "pop_at"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1665,10 +1683,12 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec"
+                     (Ortac_runtime.Report.report "Varray_circular_spec"
                         "make 42 'a'"
-                        (try Ortac_runtime.Exception "Invalid_argument"
-                         with | e -> Ortac_runtime.Out_of_domain) "delete_at"
+                        (try
+                           Ortac_runtime.Report.Exception "Invalid_argument"
+                         with | e -> Ortac_runtime.Report.Out_of_domain)
+                        "delete_at"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1706,11 +1726,12 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec"
+                        (Ortac_runtime.Report.report "Varray_circular_spec"
                            "make 42 'a'"
                            (try
-                              Ortac_runtime.Protected_value (Res (unit, ()))
-                            with | e -> Ortac_runtime.Out_of_domain)
+                              Ortac_runtime.Report.Protected_value
+                                (Res (unit, ()))
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
                            "delete_at"
                            [("Sequence.length t.contents = Sequence.length (old t.contents) - 1",
                               {
@@ -1745,10 +1766,12 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec"
+                        (Ortac_runtime.Report.report "Varray_circular_spec"
                            "make 42 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain)
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
                            "delete_at"
                            [("inside i t.contents",
                               {
@@ -1778,10 +1801,12 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec"
+                     (Ortac_runtime.Report.report "Varray_circular_spec"
                         "make 42 'a'"
-                        (try Ortac_runtime.Exception "Invalid_argument"
-                         with | e -> Ortac_runtime.Out_of_domain) "get"
+                        (try
+                           Ortac_runtime.Report.Exception "Invalid_argument"
+                         with | e -> Ortac_runtime.Report.Out_of_domain)
+                        "get"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1816,12 +1841,13 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec"
+                        (Ortac_runtime.Report.report "Varray_circular_spec"
                            "make 42 'a'"
                            (try
-                              Ortac_runtime.Protected_value
-                                (Res (Ortac_runtime.dummy, ()))
-                            with | e -> Ortac_runtime.Out_of_domain) "get"
+                              Ortac_runtime.Report.Protected_value
+                                (Res (Ortac_runtime.Report.dummy, ()))
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "get"
                            [("(proj x) = t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -1855,10 +1881,13 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec"
+                        (Ortac_runtime.Report.report "Varray_circular_spec"
                            "make 42 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "get"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "get"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1887,10 +1916,12 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec"
+                     (Ortac_runtime.Report.report "Varray_circular_spec"
                         "make 42 'a'"
-                        (try Ortac_runtime.Exception "Invalid_argument"
-                         with | e -> Ortac_runtime.Out_of_domain) "set"
+                        (try
+                           Ortac_runtime.Report.Exception "Invalid_argument"
+                         with | e -> Ortac_runtime.Report.Out_of_domain)
+                        "set"
                         [("inside i t.contents",
                            {
                              Ortac_runtime.start =
@@ -1925,10 +1956,13 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec"
+                        (Ortac_runtime.Report.report "Varray_circular_spec"
                            "make 42 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "set"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "set"
                            [("inside i t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1958,9 +1992,10 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
+              (Ortac_runtime.Report.report "Varray_circular_spec"
+                 "make 42 'a'"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          (integer,
                            (let t_old__107_ = Model.get state__075_ 0
@@ -1968,7 +2003,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                               lazy (Model.get (Lazy.force new_state__077_) 0) in
                             Ortac_runtime.Gospelstdlib.Sequence.length
                               (Lazy.force t_new__108_).contents)))
-                  with | e -> Ortac_runtime.Out_of_domain) "length"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "length"
                  [("l = Sequence.length t.contents",
                     {
                       Ortac_runtime.start =
@@ -1996,10 +2031,12 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec"
+                     (Ortac_runtime.Report.report "Varray_circular_spec"
                         "make 42 'a'"
-                        (try Ortac_runtime.Exception "Invalid_argument"
-                         with | e -> Ortac_runtime.Out_of_domain) "make"
+                        (try
+                           Ortac_runtime.Report.Exception "Invalid_argument"
+                         with | e -> Ortac_runtime.Report.Out_of_domain)
+                        "make"
                         [("n >= 0",
                            {
                              Ortac_runtime.start =
@@ -2032,10 +2069,13 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec"
+                        (Ortac_runtime.Report.report "Varray_circular_spec"
                            "make 42 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "make"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "make"
                            [("n >= 0",
                               {
                                 Ortac_runtime.start =
@@ -2066,9 +2106,10 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Varray_circular_spec" "make 42 'a'"
+              (Ortac_runtime.Report.report "Varray_circular_spec"
+                 "make 42 'a'"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          (bool,
                            (let t_old__112_ = Model.get state__075_ 0
@@ -2076,7 +2117,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                               lazy (Model.get (Lazy.force new_state__077_) 0) in
                             (Lazy.force t_new__113_).contents =
                               Ortac_runtime.Gospelstdlib.Sequence.empty)))
-                  with | e -> Ortac_runtime.Out_of_domain) "is_empty"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "is_empty"
                  [("b <-> t.contents = Sequence.empty",
                     {
                       Ortac_runtime.start =
@@ -2096,7 +2137,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     })])
       | (Append, Res ((SUT, _), t_14)) -> None
       | (Sub (i_6, n_1), Res ((Result (SUT, Exn), _), r)) ->
-          (match Ortac_runtime.append
+          (match Ortac_runtime.Report.append
                    (if
                       let tmp__119_ = Model.get state__075_ 0 in
                       try
@@ -2114,10 +2155,13 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec"
+                        (Ortac_runtime.Report.report "Varray_circular_spec"
                            "make 42 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "sub"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "sub"
                            [("0 <= i <= Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -2156,10 +2200,13 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec"
+                        (Ortac_runtime.Report.report "Varray_circular_spec"
                            "make 42 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "sub"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "sub"
                            [("i <= i + n <= Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -2183,7 +2230,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                (match r with
                 | Error (Invalid_argument _) -> None
                 | _ ->
-                    Ortac_runtime.append
+                    Ortac_runtime.Report.append
                       (if
                          let tmp__119_ = Model.get state__075_ 0 in
                          try
@@ -2201,10 +2248,13 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Varray_circular_spec"
-                              "make 42 'a'"
-                              (try Ortac_runtime.Exception "Invalid_argument"
-                               with | e -> Ortac_runtime.Out_of_domain) "sub"
+                           (Ortac_runtime.Report.report
+                              "Varray_circular_spec" "make 42 'a'"
+                              (try
+                                 Ortac_runtime.Report.Exception
+                                   "Invalid_argument"
+                               with | e -> Ortac_runtime.Report.Out_of_domain)
+                              "sub"
                               [("0 <= i <= Sequence.length t.contents",
                                  {
                                    Ortac_runtime.start =
@@ -2247,10 +2297,13 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Varray_circular_spec"
-                              "make 42 'a'"
-                              (try Ortac_runtime.Exception "Invalid_argument"
-                               with | e -> Ortac_runtime.Out_of_domain) "sub"
+                           (Ortac_runtime.Report.report
+                              "Varray_circular_spec" "make 42 'a'"
+                              (try
+                                 Ortac_runtime.Report.Exception
+                                   "Invalid_argument"
+                               with | e -> Ortac_runtime.Report.Out_of_domain)
+                              "sub"
                               [("i <= i + n <= Sequence.length t.contents",
                                  {
                                    Ortac_runtime.start =
@@ -2295,10 +2348,12 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Varray_circular_spec"
+                     (Ortac_runtime.Report.report "Varray_circular_spec"
                         "make 42 'a'"
-                        (try Ortac_runtime.Exception "Invalid_argument"
-                         with | e -> Ortac_runtime.Out_of_domain) "fill"
+                        (try
+                           Ortac_runtime.Report.Exception "Invalid_argument"
+                         with | e -> Ortac_runtime.Report.Out_of_domain)
+                        "fill"
                         [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -2349,10 +2404,13 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec"
+                        (Ortac_runtime.Report.report "Varray_circular_spec"
                            "make 42 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "fill"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "fill"
                            [("0 <= pos /\\ 0 <= len /\\ pos + len < Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -2372,7 +2430,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                               })])))
       | (Blit (src_pos, dst_pos, len_1), Res ((Result (Unit, Exn), _), res))
           ->
-          (match Ortac_runtime.append
+          (match Ortac_runtime.Report.append
                    (if
                       let tmp__130_ = Model.get state__075_ 0
                       and tmp__131_ = Model.get state__075_ 1 in
@@ -2407,10 +2465,13 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec"
+                        (Ortac_runtime.Report.report "Varray_circular_spec"
                            "make 42 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "blit"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "blit"
                            [("0 <= src_pos <= src_pos + len <= Sequence.length src.contents",
                               {
                                 Ortac_runtime.start =
@@ -2462,10 +2523,13 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Varray_circular_spec"
+                        (Ortac_runtime.Report.report "Varray_circular_spec"
                            "make 42 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "blit"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "blit"
                            [("0 <= dst_pos <= dst_pos + len <= Sequence.length dst.contents",
                               {
                                 Ortac_runtime.start =
@@ -2489,7 +2553,7 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                (match res with
                 | Error (Invalid_argument _) -> None
                 | _ ->
-                    Ortac_runtime.append
+                    Ortac_runtime.Report.append
                       (if
                          let tmp__130_ = Model.get state__075_ 0
                          and tmp__131_ = Model.get state__075_ 1 in
@@ -2524,10 +2588,12 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Varray_circular_spec"
-                              "make 42 'a'"
-                              (try Ortac_runtime.Exception "Invalid_argument"
-                               with | e -> Ortac_runtime.Out_of_domain)
+                           (Ortac_runtime.Report.report
+                              "Varray_circular_spec" "make 42 'a'"
+                              (try
+                                 Ortac_runtime.Report.Exception
+                                   "Invalid_argument"
+                               with | e -> Ortac_runtime.Report.Out_of_domain)
                               "blit"
                               [("0 <= src_pos <= src_pos + len <= Sequence.length src.contents",
                                  {
@@ -2580,10 +2646,12 @@ let ortac_postcond cmd__074_ state__075_ res__076_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Varray_circular_spec"
-                              "make 42 'a'"
-                              (try Ortac_runtime.Exception "Invalid_argument"
-                               with | e -> Ortac_runtime.Out_of_domain)
+                           (Ortac_runtime.Report.report
+                              "Varray_circular_spec" "make 42 'a'"
+                              (try
+                                 Ortac_runtime.Report.Exception
+                                   "Invalid_argument"
+                               with | e -> Ortac_runtime.Report.Out_of_domain)
                               "blit"
                               [("0 <= dst_pos <= dst_pos + len <= Sequence.length dst.contents",
                                  {

--- a/examples/varray_circular_spec_tests.ml
+++ b/examples/varray_circular_spec_tests.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Varray_circular_spec
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 let inside i s =
   try
     if

--- a/plugins/dune-rules/src/qcheck_stm.ml
+++ b/plugins/dune-rules/src/qcheck_stm.ml
@@ -47,7 +47,7 @@ let libraries =
   let k ppf config =
     pf ppf
       "libraries@ %aqcheck-stm.stm@ qcheck-stm.sequential@ \
-       qcheck-multicoretests-util@ ortac-runtime-qcheck-stm"
+       qcheck-multicoretests-util@ ortac-runtime-qcheck-stm.sequential"
       library config
   in
   stanza k

--- a/plugins/dune-rules/test/test.t
+++ b/plugins/dune-rules/test/test.t
@@ -41,7 +41,7 @@ generated.
     qcheck-stm.stm
     qcheck-stm.sequential
     qcheck-multicoretests-util
-    ortac-runtime-qcheck-stm)
+    ortac-runtime-qcheck-stm.sequential)
    (package my_package)
    (action
     (run
@@ -83,7 +83,7 @@ When the optional output argument is set, rules will be written in the file.
     qcheck-stm.stm
     qcheck-stm.sequential
     qcheck-multicoretests-util
-    ortac-runtime-qcheck-stm)
+    ortac-runtime-qcheck-stm.sequential)
    (package my_package)
    (action
     (run
@@ -124,7 +124,7 @@ Specifying a timeout causes ORTAC_QCHECK_STM_TIMEOUT to be set before running th
     qcheck-stm.stm
     qcheck-stm.sequential
     qcheck-multicoretests-util
-    ortac-runtime-qcheck-stm)
+    ortac-runtime-qcheck-stm.sequential)
    (package my_package)
    (action
     (setenv

--- a/plugins/qcheck-stm/src/runtime/dune
+++ b/plugins/qcheck-stm/src/runtime/dune
@@ -1,10 +1,18 @@
 (library
- (name ortac_runtime_qcheck_stm)
- (public_name ortac-runtime-qcheck-stm)
+ (name ortac_runtime_qcheck_stm_util)
+ (package ortac-runtime-qcheck-stm)
+ (modules report stores)
+ (libraries qcheck-stm.stm ortac-runtime))
+
+(library
+ (name ortac_runtime_qcheck_stm_sequential)
+ (public_name ortac-runtime-qcheck-stm.sequential)
+ (modules ortac_runtime_qcheck_stm_sequential)
  (libraries
   qcheck-core
   qcheck-core.runner
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
+  ortac_runtime_qcheck_stm_util
   ortac-runtime))

--- a/plugins/qcheck-stm/src/runtime/ortac_runtime_qcheck_stm.ml
+++ b/plugins/qcheck-stm/src/runtime/ortac_runtime_qcheck_stm.ml
@@ -1,76 +1,12 @@
-open STM
 include Ortac_runtime
-
-type expected_result =
-  | Value of res
-  | Protected_value of res
-  | Exception of string
-  | Out_of_domain
-
-type report = {
-  mod_name : string;
-  init_sut : string;
-  ret : expected_result;
-  cmd : string;
-  terms : (string * location) list;
-}
-
-let report mod_name init_sut ret cmd terms =
-  { mod_name; init_sut; ret; cmd; terms }
-
-let append a b =
-  match (a, b) with
-  | None, None -> None
-  | Some _, None -> a
-  | None, Some _ -> b
-  | Some r0, Some r1 ->
-      assert (r0.cmd = r1.cmd);
-      Some { r0 with terms = r0.terms @ r1.terms }
-
-type _ ty += Dummy : _ ty
-
-let dummy = (Dummy, fun _ -> Printf.sprintf "unknown value")
-let is_dummy = function Res ((Dummy, _), _) -> true | _ -> false
-
-module Model = struct
-  module Make (M : sig
-    type elt
-
-    val init : elt
-  end) =
-  struct
-    type elt = M.elt
-    type t = elt list
-
-    let create n () : t = List.init n (fun _ -> M.init)
-    let size = List.length
-    let rec drop_n t n = if n = 0 then t else drop_n (List.tl t) (n - 1)
-    let push t e = e :: t
-
-    let get t n =
-      try List.nth t n with _ -> failwith ("nth: " ^ string_of_int n)
-  end
-end
-
-module SUT = struct
-  module Make (M : sig
-    type sut
-
-    val init : unit -> sut
-  end) =
-  struct
-    type elt = M.sut
-    type t = elt list ref
-
-    let create n () = ref @@ List.init n (fun _ -> M.init ())
-    let size t = List.length !t
-    let get t = List.nth !t
-    let push t e = t := e :: !t
-    let get_name t n = Format.asprintf "sut%d" (size t - n - 1)
-  end
-end
+module Report = Report
+module Model = Stores.Model
+module SUT = Stores.SUT
+open STM
 
 module Make (Spec : Spec) = struct
+  open Report
+  open Ortac_runtime
   open QCheck
   module Internal = Internal.Make (Spec) [@alert "-internal"]
 

--- a/plugins/qcheck-stm/src/runtime/ortac_runtime_qcheck_stm_sequential.ml
+++ b/plugins/qcheck-stm/src/runtime/ortac_runtime_qcheck_stm_sequential.ml
@@ -1,8 +1,9 @@
+open Ortac_runtime_qcheck_stm_util
+open STM
 include Ortac_runtime
 module Report = Report
 module Model = Stores.Model
 module SUT = Stores.SUT
-open STM
 
 module Make (Spec : Spec) = struct
   open Report

--- a/plugins/qcheck-stm/src/runtime/report.ml
+++ b/plugins/qcheck-stm/src/runtime/report.ml
@@ -1,0 +1,32 @@
+open STM
+
+type expected_result =
+  | Value of res
+  | Protected_value of res
+  | Exception of string
+  | Out_of_domain
+
+type t = {
+  mod_name : string;
+  init_sut : string;
+  ret : expected_result;
+  cmd : string;
+  terms : (string * Ortac_runtime.location) list;
+}
+
+let report mod_name init_sut ret cmd terms =
+  { mod_name; init_sut; ret; cmd; terms }
+
+let append a b =
+  match (a, b) with
+  | None, None -> None
+  | Some _, None -> a
+  | None, Some _ -> b
+  | Some r0, Some r1 ->
+      assert (r0.cmd = r1.cmd);
+      Some { r0 with terms = r0.terms @ r1.terms }
+
+type _ ty += Dummy : _ ty
+
+let dummy = (Dummy, fun _ -> Printf.sprintf "unknown value")
+let is_dummy = function Res ((Dummy, _), _) -> true | _ -> false

--- a/plugins/qcheck-stm/src/runtime/report.mli
+++ b/plugins/qcheck-stm/src/runtime/report.mli
@@ -1,0 +1,41 @@
+open STM
+
+(** This type carries the expected value computed from the Gospel specification
+    if possible. *)
+type expected_result =
+  | Value of res  (** The value has been computed *)
+  | Protected_value of res
+      (** The value has been computed but is protected as it could have been an
+          exception *)
+  | Exception of string  (** An exception is expected *)
+  | Out_of_domain
+      (** The computation of the expected returned value called a Gospel
+          function out of its domain *)
+
+type t = {
+  mod_name : string;  (** The name of the module under test *)
+  init_sut : string;  (** String representation of the init_sut function *)
+  ret : expected_result;  (** The expected result of the call *)
+  cmd : string;  (** String representation of the call *)
+  terms : (string * Ortac_runtime.location) list;
+      (** String representation and location of the violated specifications *)
+}
+(** Information for the bug report in case of test failure *)
+
+val report :
+  string ->
+  string ->
+  expected_result ->
+  string ->
+  (string * Ortac_runtime.location) list ->
+  t
+(** [report module_name init_sut ret cmd terms] *)
+
+val append : t option -> t option -> t option
+(** [append a b] appends the violated terms of [a] and [b] if any in the
+    returned report *)
+
+val dummy : 'a ty * ('b -> string)
+(** A dummy [STM.res] for unknown returned values *)
+
+val is_dummy : res -> bool

--- a/plugins/qcheck-stm/src/runtime/stores.ml
+++ b/plugins/qcheck-stm/src/runtime/stores.ml
@@ -1,0 +1,37 @@
+module Model = struct
+  module Make (M : sig
+    type elt
+
+    val init : elt
+  end) =
+  struct
+    type elt = M.elt
+    type t = elt list
+
+    let create n () : t = List.init n (fun _ -> M.init)
+    let size = List.length
+    let rec drop_n t n = if n = 0 then t else drop_n (List.tl t) (n - 1)
+    let push t e = e :: t
+
+    let get t n =
+      try List.nth t n with _ -> failwith ("nth: " ^ string_of_int n)
+  end
+end
+
+module SUT = struct
+  module Make (M : sig
+    type sut
+
+    val init : unit -> sut
+  end) =
+  struct
+    type elt = M.sut
+    type t = elt list ref
+
+    let create n () = ref @@ List.init n (fun _ -> M.init ())
+    let size t = List.length !t
+    let get t = List.nth !t
+    let push t e = t := e :: !t
+    let get_name t n = Format.asprintf "sut%d" (size t - n - 1)
+  end
+end

--- a/plugins/qcheck-stm/src/runtime/stores.mli
+++ b/plugins/qcheck-stm/src/runtime/stores.mli
@@ -1,37 +1,3 @@
-include module type of Ortac_runtime
-open STM
-
-(** This type carries the expected value computed from the Gospel specification
-    if possible. *)
-type expected_result =
-  | Value of res  (** The value has been computed *)
-  | Protected_value of res
-      (** The value has been computed but is protected as it could have been an
-          exception *)
-  | Exception of string  (** An exception is expected *)
-  | Out_of_domain
-      (** The computation of the expected returned value called a Gospel
-          function out of its domain *)
-
-type report
-(** Information for the bug report in case of test failure *)
-
-val report :
-  string ->
-  string ->
-  expected_result ->
-  string ->
-  (string * location) list ->
-  report
-(** [report module_name init_sut ret cmd terms] *)
-
-val append : report option -> report option -> report option
-(** [append a b] appends the violated terms of [a] and [b] if any in the
-    returned report *)
-
-val dummy : 'a ty * ('b -> string)
-(** A dummy [STM.res] for unknown returned values *)
-
 module Model : sig
   module Make (M : sig
     type elt
@@ -93,19 +59,4 @@ module SUT : sig
         of SUTs *)
   end
   with type elt = M.sut
-end
-
-module Make (Spec : Spec) : sig
-  open QCheck
-
-  val agree_test :
-    count:int ->
-    name:string ->
-    int ->
-    (unit -> unit) ->
-    (Spec.cmd -> Spec.sut -> bool -> res -> string) ->
-    (Spec.cmd -> Spec.state -> res -> report option) ->
-    Test.t
-  (** [agree_test ~count ~name max_suts init_state show_cmd postcond] An
-      agreement test specialised to be used by Ortac/QCheck-STM. *)
 end

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -1774,7 +1774,7 @@ let stm config ir =
   ok
     (warn
      :: open_mod opened_mod
-     :: [%stri module Ortac_runtime = Ortac_runtime_qcheck_stm]
+     :: [%stri module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential]
      :: ghost_types
     @ ghost_functions
     @ sut_mod

--- a/plugins/qcheck-stm/test/array_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/array_stm_tests.expected.ml
@@ -836,16 +836,16 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Array" "make 16 'a'"
+              (Ortac_runtime.Report.report "Array" "make 16 'a'"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          (integer,
                            (let t_old__050_ = Model.get state__047_ 0
                             and t_new__051_ =
                               lazy (Model.get (Lazy.force new_state__049_) 0) in
                             (Lazy.force t_new__051_).size)))
-                  with | e -> Ortac_runtime.Out_of_domain) "length"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "length"
                  [("i = t.size",
                     {
                       Ortac_runtime.start =
@@ -880,9 +880,11 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Array" "make 16 'a'"
-                        (try Ortac_runtime.Exception "Invalid_argument"
-                         with | e -> Ortac_runtime.Out_of_domain) "get"
+                     (Ortac_runtime.Report.report "Array" "make 16 'a'"
+                        (try
+                           Ortac_runtime.Report.Exception "Invalid_argument"
+                         with | e -> Ortac_runtime.Report.Out_of_domain)
+                        "get"
                         [("0 <= i < t.size",
                            {
                              Ortac_runtime.start =
@@ -917,9 +919,9 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Array" "make 16 'a'"
+                        (Ortac_runtime.Report.report "Array" "make 16 'a'"
                            (try
-                              Ortac_runtime.Protected_value
+                              Ortac_runtime.Report.Protected_value
                                 (Res
                                    (char,
                                      (let t_old__055_ =
@@ -932,7 +934,8 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                                         (Lazy.force t_new__056_).contents
                                         (Ortac_runtime.Gospelstdlib.integer_of_int
                                            i))))
-                            with | e -> Ortac_runtime.Out_of_domain) "get"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "get"
                            [("a = t.contents[i]",
                               {
                                 Ortac_runtime.start =
@@ -971,9 +974,12 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Array" "make 16 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "get"
+                        (Ortac_runtime.Report.report "Array" "make 16 'a'"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "get"
                            [("0 <= i < t.size",
                               {
                                 Ortac_runtime.start =
@@ -1008,9 +1014,11 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Array" "make 16 'a'"
-                        (try Ortac_runtime.Exception "Invalid_argument"
-                         with | e -> Ortac_runtime.Out_of_domain) "set"
+                     (Ortac_runtime.Report.report "Array" "make 16 'a'"
+                        (try
+                           Ortac_runtime.Report.Exception "Invalid_argument"
+                         with | e -> Ortac_runtime.Report.Out_of_domain)
+                        "set"
                         [("0 <= i < t.size",
                            {
                              Ortac_runtime.start =
@@ -1050,9 +1058,12 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Array" "make 16 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "set"
+                        (Ortac_runtime.Report.report "Array" "make 16 'a'"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "set"
                            [("0 <= i < t.size",
                               {
                                 Ortac_runtime.start =
@@ -1080,9 +1091,11 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Array" "make 16 'a'"
-                        (try Ortac_runtime.Exception "Invalid_argument"
-                         with | e -> Ortac_runtime.Out_of_domain) "make"
+                     (Ortac_runtime.Report.report "Array" "make 16 'a'"
+                        (try
+                           Ortac_runtime.Report.Exception "Invalid_argument"
+                         with | e -> Ortac_runtime.Report.Out_of_domain)
+                        "make"
                         [("i >= 0",
                            {
                              Ortac_runtime.start =
@@ -1115,9 +1128,12 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Array" "make 16 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "make"
+                        (Ortac_runtime.Report.report "Array" "make 16 'a'"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "make"
                            [("i >= 0",
                               {
                                 Ortac_runtime.start =
@@ -1137,7 +1153,7 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                               })])))
       | (Append, Res ((SUT, _), t_5)) -> None
       | (Sub (i_3, n), Res ((Result (SUT, Exn), _), r)) ->
-          (match Ortac_runtime.append
+          (match Ortac_runtime.Report.append
                    (if
                       let tmp__067_ = Model.get state__047_ 0 in
                       try
@@ -1155,9 +1171,12 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Array" "make 16 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "sub"
+                        (Ortac_runtime.Report.report "Array" "make 16 'a'"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "sub"
                            [("0 <= i <= Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1196,9 +1215,12 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Array" "make 16 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "sub"
+                        (Ortac_runtime.Report.report "Array" "make 16 'a'"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "sub"
                            [("i <= i + n <= Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -1222,7 +1244,7 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                (match r with
                 | Error (Invalid_argument _) -> None
                 | _ ->
-                    Ortac_runtime.append
+                    Ortac_runtime.Report.append
                       (if
                          let tmp__067_ = Model.get state__047_ 0 in
                          try
@@ -1240,9 +1262,12 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Array" "make 16 'a'"
-                              (try Ortac_runtime.Exception "Invalid_argument"
-                               with | e -> Ortac_runtime.Out_of_domain) "sub"
+                           (Ortac_runtime.Report.report "Array" "make 16 'a'"
+                              (try
+                                 Ortac_runtime.Report.Exception
+                                   "Invalid_argument"
+                               with | e -> Ortac_runtime.Report.Out_of_domain)
+                              "sub"
                               [("0 <= i <= Sequence.length t.contents",
                                  {
                                    Ortac_runtime.start =
@@ -1285,9 +1310,12 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Array" "make 16 'a'"
-                              (try Ortac_runtime.Exception "Invalid_argument"
-                               with | e -> Ortac_runtime.Out_of_domain) "sub"
+                           (Ortac_runtime.Report.report "Array" "make 16 'a'"
+                              (try
+                                 Ortac_runtime.Report.Exception
+                                   "Invalid_argument"
+                               with | e -> Ortac_runtime.Report.Out_of_domain)
+                              "sub"
                               [("i <= i + n <= Sequence.length t.contents",
                                  {
                                    Ortac_runtime.start =
@@ -1307,7 +1335,7 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                                  })]))))
       | (Copy, Res ((SUT, _), r_1)) -> None
       | (Fill (pos, len, x), Res ((Result (Unit, Exn), _), res)) ->
-          (match Ortac_runtime.append
+          (match Ortac_runtime.Report.append
                    (if
                       let tmp__073_ = Model.get state__047_ 0 in
                       try
@@ -1318,9 +1346,12 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Array" "make 16 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "fill"
+                        (Ortac_runtime.Report.report "Array" "make 16 'a'"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "fill"
                            [("0 <= pos",
                               {
                                 Ortac_runtime.start =
@@ -1338,7 +1369,7 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                                     pos_cnum = 1948
                                   }
                               })]))
-                   (Ortac_runtime.append
+                   (Ortac_runtime.Report.append
                       (if
                          let tmp__073_ = Model.get state__047_ 0 in
                          try
@@ -1349,9 +1380,11 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Array" "make 16 'a'"
-                              (try Ortac_runtime.Exception "Invalid_argument"
-                               with | e -> Ortac_runtime.Out_of_domain)
+                           (Ortac_runtime.Report.report "Array" "make 16 'a'"
+                              (try
+                                 Ortac_runtime.Report.Exception
+                                   "Invalid_argument"
+                               with | e -> Ortac_runtime.Report.Out_of_domain)
                               "fill"
                               [("0 <= len",
                                  {
@@ -1383,9 +1416,11 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Array" "make 16 'a'"
-                              (try Ortac_runtime.Exception "Invalid_argument"
-                               with | e -> Ortac_runtime.Out_of_domain)
+                           (Ortac_runtime.Report.report "Array" "make 16 'a'"
+                              (try
+                                 Ortac_runtime.Report.Exception
+                                   "Invalid_argument"
+                               with | e -> Ortac_runtime.Report.Out_of_domain)
                               "fill"
                               [("pos + len <= t.size",
                                  {
@@ -1410,7 +1445,7 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                (match res with
                 | Error (Invalid_argument _) -> None
                 | _ ->
-                    Ortac_runtime.append
+                    Ortac_runtime.Report.append
                       (if
                          let tmp__073_ = Model.get state__047_ 0 in
                          try
@@ -1421,9 +1456,11 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Array" "make 16 'a'"
-                              (try Ortac_runtime.Exception "Invalid_argument"
-                               with | e -> Ortac_runtime.Out_of_domain)
+                           (Ortac_runtime.Report.report "Array" "make 16 'a'"
+                              (try
+                                 Ortac_runtime.Report.Exception
+                                   "Invalid_argument"
+                               with | e -> Ortac_runtime.Report.Out_of_domain)
                               "fill"
                               [("0 <= pos",
                                  {
@@ -1442,7 +1479,7 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                                        pos_cnum = 1948
                                      }
                                  })]))
-                      (Ortac_runtime.append
+                      (Ortac_runtime.Report.append
                          (if
                             let tmp__073_ = Model.get state__047_ 0 in
                             try
@@ -1454,11 +1491,13 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                           then None
                           else
                             Some
-                              (Ortac_runtime.report "Array" "make 16 'a'"
+                              (Ortac_runtime.Report.report "Array"
+                                 "make 16 'a'"
                                  (try
-                                    Ortac_runtime.Exception
+                                    Ortac_runtime.Report.Exception
                                       "Invalid_argument"
-                                  with | e -> Ortac_runtime.Out_of_domain)
+                                  with
+                                  | e -> Ortac_runtime.Report.Out_of_domain)
                                  "fill"
                                  [("0 <= len",
                                     {
@@ -1490,11 +1529,13 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                           then None
                           else
                             Some
-                              (Ortac_runtime.report "Array" "make 16 'a'"
+                              (Ortac_runtime.Report.report "Array"
+                                 "make 16 'a'"
                                  (try
-                                    Ortac_runtime.Exception
+                                    Ortac_runtime.Report.Exception
                                       "Invalid_argument"
-                                  with | e -> Ortac_runtime.Out_of_domain)
+                                  with
+                                  | e -> Ortac_runtime.Report.Out_of_domain)
                                  "fill"
                                  [("pos + len <= t.size",
                                     {
@@ -1525,9 +1566,9 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Array" "make 16 'a'"
+              (Ortac_runtime.Report.report "Array" "make 16 'a'"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          ((list char),
                            (let t_old__074_ = Model.get state__047_ 0
@@ -1535,7 +1576,7 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                               lazy (Model.get (Lazy.force new_state__049_) 0) in
                             Ortac_runtime.Gospelstdlib.List.of_seq
                               (Lazy.force t_new__075_).contents)))
-                  with | e -> Ortac_runtime.Out_of_domain) "to_list"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "to_list"
                  [("l = List.of_seq t.contents",
                     {
                       Ortac_runtime.start =
@@ -1566,9 +1607,9 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Array" "make 16 'a'"
+              (Ortac_runtime.Report.report "Array" "make 16 'a'"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          (bool,
                            (let t_old__079_ = Model.get state__047_ 0
@@ -1576,7 +1617,7 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                               lazy (Model.get (Lazy.force new_state__049_) 0) in
                             Ortac_runtime.Gospelstdlib.Sequence.mem
                               (Lazy.force t_new__080_).contents a_3)))
-                  with | e -> Ortac_runtime.Out_of_domain) "mem"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "mem"
                  [("b = Sequence.mem t.contents a",
                     {
                       Ortac_runtime.start =
@@ -1610,9 +1651,9 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Array" "make 16 'a'"
+              (Ortac_runtime.Report.report "Array" "make 16 'a'"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          (bool,
                            (let t_old__084_ = Model.get state__047_ 0
@@ -1627,7 +1668,7 @@ let ortac_postcond cmd__046_ state__047_ res__048_ =
                                    then true
                                    else false) true
                               (Lazy.force t_new__085_).contents)))
-                  with | e -> Ortac_runtime.Out_of_domain) "for_all"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "for_all"
                  [("b = Sequence.fold_left (fun acc a -> p a && acc) true t.contents",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/array_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/array_stm_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Array
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 module SUT =
   (Ortac_runtime.SUT.Make)(struct
                              type sut = char t

--- a/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
@@ -228,10 +228,12 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Conjunctive_clauses"
+                     (Ortac_runtime.Report.report "Conjunctive_clauses"
                         "make 42 'a'"
-                        (try Ortac_runtime.Exception "Invalid_argument"
-                         with | e -> Ortac_runtime.Out_of_domain) "make"
+                        (try
+                           Ortac_runtime.Report.Exception "Invalid_argument"
+                         with | e -> Ortac_runtime.Report.Out_of_domain)
+                        "make"
                         [("i >= 0",
                            {
                              Ortac_runtime.start =
@@ -264,10 +266,13 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Conjunctive_clauses"
+                        (Ortac_runtime.Report.report "Conjunctive_clauses"
                            "make 42 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "make"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "make"
                            [("i >= 0",
                               {
                                 Ortac_runtime.start =
@@ -303,10 +308,12 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Conjunctive_clauses"
+                     (Ortac_runtime.Report.report "Conjunctive_clauses"
                         "make 42 'a'"
-                        (try Ortac_runtime.Exception "Invalid_argument"
-                         with | e -> Ortac_runtime.Out_of_domain) "set"
+                        (try
+                           Ortac_runtime.Report.Exception "Invalid_argument"
+                         with | e -> Ortac_runtime.Report.Out_of_domain)
+                        "set"
                         [("0 <= i < Sequence.length t.contents",
                            {
                              Ortac_runtime.start =
@@ -347,10 +354,13 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Conjunctive_clauses"
+                        (Ortac_runtime.Report.report "Conjunctive_clauses"
                            "make 42 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "set"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "set"
                            [("0 <= i < Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Conjunctive_clauses
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 module SUT =
   (Ortac_runtime.SUT.Make)(struct
                              type sut = char t

--- a/plugins/qcheck-stm/test/custom_config_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/custom_config_stm_tests.expected.ml
@@ -251,9 +251,11 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Custom_config" "empty ()"
-                        (try Ortac_runtime.Exception "Invalid_argument"
-                         with | e -> Ortac_runtime.Out_of_domain) "top"
+                     (Ortac_runtime.Report.report "Custom_config" "empty ()"
+                        (try
+                           Ortac_runtime.Report.Exception "Invalid_argument"
+                         with | e -> Ortac_runtime.Report.Out_of_domain)
+                        "top"
                         [("t.contents <> Sequence.empty",
                            {
                              Ortac_runtime.start =
@@ -287,11 +289,13 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Custom_config" "empty ()"
+                        (Ortac_runtime.Report.report "Custom_config"
+                           "empty ()"
                            (try
-                              Ortac_runtime.Protected_value
-                                (Res (Ortac_runtime.dummy, ()))
-                            with | e -> Ortac_runtime.Out_of_domain) "top"
+                              Ortac_runtime.Report.Protected_value
+                                (Res (Ortac_runtime.Report.dummy, ()))
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "top"
                            [("proj a = Sequence.hd t.contents",
                               {
                                 Ortac_runtime.start =
@@ -324,9 +328,13 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Custom_config" "empty ()"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "top"
+                        (Ortac_runtime.Report.report "Custom_config"
+                           "empty ()"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "top"
                            [("t.contents <> Sequence.empty",
                               {
                                 Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/custom_config_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/custom_config_stm_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Custom_config
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 module SUT =
   (Ortac_runtime.SUT.Make)(struct type sut = int t
                                   let init () = empty () end)

--- a/plugins/qcheck-stm/test/dune
+++ b/plugins/qcheck-stm/test/dune
@@ -73,7 +73,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   submodule)
  (action
   (echo
@@ -122,7 +122,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   module_prefix_lib)
  (action
   (echo
@@ -174,7 +174,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   submodule_and_prefix_lib)
  (action
   (echo

--- a/plugins/qcheck-stm/test/dune.inc
+++ b/plugins/qcheck-stm/test/dune.inc
@@ -32,7 +32,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   array)
  (action
   (echo
@@ -85,7 +85,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   hashtbl)
  (action
   (echo
@@ -138,7 +138,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   record)
  (action
   (echo
@@ -191,7 +191,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   ref)
  (action
   (echo
@@ -244,7 +244,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   conjunctive_clauses)
  (action
   (echo
@@ -297,7 +297,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   sequence_model)
  (action
   (echo
@@ -350,7 +350,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   invariants)
  (action
   (echo
@@ -403,7 +403,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   integer_in_model)
  (action
   (echo
@@ -456,7 +456,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   ghost_as_model)
  (action
   (echo
@@ -509,7 +509,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   custom_config)
  (action
   (echo
@@ -562,7 +562,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   test_without_sut)
  (action
   (echo
@@ -615,7 +615,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   tuples)
  (action
   (echo
@@ -668,7 +668,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   functional_model)
  (action
   (echo
@@ -721,7 +721,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   test_cleanup)
  (action
   (echo
@@ -774,7 +774,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   sut_in_type)
  (action
   (echo
@@ -827,7 +827,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   queue)
  (action
   (echo
@@ -880,7 +880,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   stack)
  (action
   (echo
@@ -933,7 +933,7 @@
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   function_args)
  (action
   (echo

--- a/plugins/qcheck-stm/test/dune_gen.ml
+++ b/plugins/qcheck-stm/test/dune_gen.ml
@@ -46,7 +46,7 @@ let rec print_rules pos =
   qcheck-stm.stm
   qcheck-stm.sequential
   qcheck-multicoretests-util
-  ortac-runtime-qcheck-stm
+  ortac-runtime-qcheck-stm.sequential
   %s)
  (action
   (echo

--- a/plugins/qcheck-stm/test/function_args_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/function_args_stm_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Function_args
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 module SUT =
   (Ortac_runtime.SUT.Make)(struct type sut = t
                                   let init () = make 16 'a' end)

--- a/plugins/qcheck-stm/test/function_args_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/function_args_stm_tests.expected.ml
@@ -290,9 +290,12 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Function_args" "make 16 'a'"
-                        (try Ortac_runtime.Exception "Invalid_argument"
-                         with | e -> Ortac_runtime.Out_of_domain) "make"
+                     (Ortac_runtime.Report.report "Function_args"
+                        "make 16 'a'"
+                        (try
+                           Ortac_runtime.Report.Exception "Invalid_argument"
+                         with | e -> Ortac_runtime.Report.Out_of_domain)
+                        "make"
                         [("len >= 0",
                            {
                              Ortac_runtime.start =
@@ -325,9 +328,13 @@ let ortac_postcond cmd__010_ state__011_ res__012_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Function_args" "make 16 'a'"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "make"
+                        (Ortac_runtime.Report.report "Function_args"
+                           "make 16 'a'"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "make"
                            [("len >= 0",
                               {
                                 Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/functional_model_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/functional_model_stm_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Functional_model
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 module SUT =
   (Ortac_runtime.SUT.Make)(struct
                              type sut = (char, int) t

--- a/plugins/qcheck-stm/test/ghost_as_model_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/ghost_as_model_stm_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Ghost_as_model
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 type m =
   | A of Ortac_runtime.integer 
 module SUT =

--- a/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Hashtbl
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 let rec remove_first x xs =
   try
     if Ortac_runtime.Gospelstdlib.Sequence.empty = xs

--- a/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
@@ -617,11 +617,12 @@ let ortac_postcond cmd__032_ state__033_ res__034_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
+                   (Ortac_runtime.Report.report "Hashtbl"
+                      "create ~random:false 16"
                       (try
-                         Ortac_runtime.Protected_value
-                           (Res (Ortac_runtime.dummy, ()))
-                       with | e -> Ortac_runtime.Out_of_domain) "find"
+                         Ortac_runtime.Report.Protected_value
+                           (Res (Ortac_runtime.Report.dummy, ()))
+                       with | e -> Ortac_runtime.Report.Out_of_domain) "find"
                       [("Sequence.mem h.contents (a, b)",
                          {
                            Ortac_runtime.start =
@@ -654,9 +655,10 @@ let ortac_postcond cmd__032_ state__033_ res__034_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
-                      (try Ortac_runtime.Exception "Not_found"
-                       with | e -> Ortac_runtime.Out_of_domain) "find"
+                   (Ortac_runtime.Report.report "Hashtbl"
+                      "create ~random:false 16"
+                      (try Ortac_runtime.Report.Exception "Not_found"
+                       with | e -> Ortac_runtime.Report.Out_of_domain) "find"
                       [("not (Sequence.mem (Sequence.map fst h.contents) a)",
                          {
                            Ortac_runtime.start =
@@ -701,9 +703,12 @@ let ortac_postcond cmd__032_ state__033_ res__034_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
-                 (try Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))
-                  with | e -> Ortac_runtime.Out_of_domain) "find_opt"
+              (Ortac_runtime.Report.report "Hashtbl"
+                 "create ~random:false 16"
+                 (try
+                    Ortac_runtime.Report.Value
+                      (Res (Ortac_runtime.Report.dummy, ()))
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "find_opt"
                  [("match o with\n      | None -> not (Sequence.mem (Sequence.map fst h.contents) a)\n      | Some b -> Sequence.mem h.contents (a, b)",
                     {
                       Ortac_runtime.start =
@@ -734,9 +739,12 @@ let ortac_postcond cmd__032_ state__033_ res__034_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
-                 (try Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))
-                  with | e -> Ortac_runtime.Out_of_domain) "find_all"
+              (Ortac_runtime.Report.report "Hashtbl"
+                 "create ~random:false 16"
+                 (try
+                    Ortac_runtime.Report.Value
+                      (Res (Ortac_runtime.Report.dummy, ()))
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "find_all"
                  [("bs = Sequence.filter_map (fun (x, y) -> if x = a then Some y else None) h.contents",
                     {
                       Ortac_runtime.start =
@@ -768,9 +776,10 @@ let ortac_postcond cmd__032_ state__033_ res__034_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
+              (Ortac_runtime.Report.report "Hashtbl"
+                 "create ~random:false 16"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          (bool,
                            (let h_old__053_ = Model.get state__033_ 0
@@ -780,7 +789,7 @@ let ortac_postcond cmd__032_ state__033_ res__034_ =
                               (Ortac_runtime.Gospelstdlib.Sequence.map
                                  Ortac_runtime.Gospelstdlib.fst
                                  (Lazy.force h_new__054_).contents) a_5)))
-                  with | e -> Ortac_runtime.Out_of_domain) "mem"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "mem"
                  [("b = Sequence.mem (Sequence.map fst h.contents) a",
                     {
                       Ortac_runtime.start =
@@ -813,9 +822,10 @@ let ortac_postcond cmd__032_ state__033_ res__034_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Hashtbl" "create ~random:false 16"
+              (Ortac_runtime.Report.report "Hashtbl"
+                 "create ~random:false 16"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          (integer,
                            (let h_old__061_ = Model.get state__033_ 0
@@ -823,7 +833,7 @@ let ortac_postcond cmd__032_ state__033_ res__034_ =
                               lazy (Model.get (Lazy.force new_state__035_) 0) in
                             Ortac_runtime.Gospelstdlib.Sequence.length
                               (Lazy.force h_new__062_).contents)))
-                  with | e -> Ortac_runtime.Out_of_domain) "length"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "length"
                  [("i = Sequence.length h.contents",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/integer_in_model_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/integer_in_model_stm_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Integer_in_model
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 module SUT =
   (Ortac_runtime.SUT.Make)(struct type sut = t
                                   let init () = create () end)

--- a/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Invariants
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 module SUT =
   (Ortac_runtime.SUT.Make)(struct type sut = int t
                                   let init () = create 42 end)

--- a/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
@@ -469,9 +469,11 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Invariants" "create 42"
-                 (try Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))
-                  with | e -> Ortac_runtime.Out_of_domain) "create"
+              (Ortac_runtime.Report.report "Invariants" "create 42"
+                 (try
+                    Ortac_runtime.Report.Value
+                      (Res (Ortac_runtime.Report.dummy, ()))
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "create"
                  [("Sequence.length x.contents > 0",
                     {
                       Ortac_runtime.start =
@@ -521,9 +523,9 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Invariants" "create 42"
-                 (try Ortac_runtime.Value (Res (unit, ()))
-                  with | e -> Ortac_runtime.Out_of_domain) "push"
+              (Ortac_runtime.Report.report "Invariants" "create 42"
+                 (try Ortac_runtime.Report.Value (Res (unit, ()))
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "push"
                  [("Sequence.length x.contents > 0",
                     {
                       Ortac_runtime.start =
@@ -542,7 +544,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                         }
                     })])
       | (Transfer, Res ((Unit, _), _)) ->
-          Ortac_runtime.append
+          Ortac_runtime.Report.append
             (if
                let t1__031_ = lazy (Model.get (Lazy.force new_state__027_) 0) in
                try
@@ -574,9 +576,10 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
              then None
              else
                Some
-                 (Ortac_runtime.report "Invariants" "create 42"
-                    (try Ortac_runtime.Value (Res (unit, ()))
-                     with | e -> Ortac_runtime.Out_of_domain) "transfer"
+                 (Ortac_runtime.Report.report "Invariants" "create 42"
+                    (try Ortac_runtime.Report.Value (Res (unit, ()))
+                     with | e -> Ortac_runtime.Report.Out_of_domain)
+                    "transfer"
                     [("Sequence.length x.contents > 0",
                        {
                          Ortac_runtime.start =
@@ -625,9 +628,10 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
              then None
              else
                Some
-                 (Ortac_runtime.report "Invariants" "create 42"
-                    (try Ortac_runtime.Value (Res (unit, ()))
-                     with | e -> Ortac_runtime.Out_of_domain) "transfer"
+                 (Ortac_runtime.Report.report "Invariants" "create 42"
+                    (try Ortac_runtime.Report.Value (Res (unit, ()))
+                     with | e -> Ortac_runtime.Report.Out_of_domain)
+                    "transfer"
                     [("Sequence.length x.contents > 0",
                        {
                          Ortac_runtime.start =
@@ -646,7 +650,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                            }
                        })]))
       | (Copy, Res ((SUT, _), r)) ->
-          Ortac_runtime.append
+          Ortac_runtime.Report.append
             (if
                let r__035_ = lazy (Model.get (Lazy.force new_state__027_) 0) in
                try
@@ -678,9 +682,11 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
              then None
              else
                Some
-                 (Ortac_runtime.report "Invariants" "create 42"
-                    (try Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))
-                     with | e -> Ortac_runtime.Out_of_domain) "copy"
+                 (Ortac_runtime.Report.report "Invariants" "create 42"
+                    (try
+                       Ortac_runtime.Report.Value
+                         (Res (Ortac_runtime.Report.dummy, ()))
+                     with | e -> Ortac_runtime.Report.Out_of_domain) "copy"
                     [("Sequence.length x.contents > 0",
                        {
                          Ortac_runtime.start =
@@ -729,9 +735,11 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
              then None
              else
                Some
-                 (Ortac_runtime.report "Invariants" "create 42"
-                    (try Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))
-                     with | e -> Ortac_runtime.Out_of_domain) "copy"
+                 (Ortac_runtime.Report.report "Invariants" "create 42"
+                    (try
+                       Ortac_runtime.Report.Value
+                         (Res (Ortac_runtime.Report.dummy, ()))
+                     with | e -> Ortac_runtime.Report.Out_of_domain) "copy"
                     [("Sequence.length x.contents > 0",
                        {
                          Ortac_runtime.start =
@@ -750,7 +758,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                            }
                        })]))
       | (Sub (i, n), Res ((Result (SUT, Exn), _), r_1)) ->
-          (match Ortac_runtime.append
+          (match Ortac_runtime.Report.append
                    (if
                       let tmp__040_ = Model.get state__025_ 0 in
                       try
@@ -768,9 +776,12 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Invariants" "create 42"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "sub"
+                        (Ortac_runtime.Report.report "Invariants" "create 42"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "sub"
                            [("0 <= i <= Sequence.length t.contents",
                               {
                                 Ortac_runtime.start =
@@ -788,7 +799,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                                     pos_cnum = 1344
                                   }
                               })]))
-                   (Ortac_runtime.append
+                   (Ortac_runtime.Report.append
                       (if
                          let tmp__040_ = Model.get state__025_ 0 in
                          try
@@ -814,9 +825,13 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Invariants" "create 42"
-                              (try Ortac_runtime.Exception "Invalid_argument"
-                               with | e -> Ortac_runtime.Out_of_domain) "sub"
+                           (Ortac_runtime.Report.report "Invariants"
+                              "create 42"
+                              (try
+                                 Ortac_runtime.Report.Exception
+                                   "Invalid_argument"
+                               with | e -> Ortac_runtime.Report.Out_of_domain)
+                              "sub"
                               [("i <= i + n <= Sequence.length t.contents",
                                  {
                                    Ortac_runtime.start =
@@ -844,9 +859,13 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Invariants" "create 42"
-                              (try Ortac_runtime.Exception "Invalid_argument"
-                               with | e -> Ortac_runtime.Out_of_domain) "sub"
+                           (Ortac_runtime.Report.report "Invariants"
+                              "create 42"
+                              (try
+                                 Ortac_runtime.Report.Exception
+                                   "Invalid_argument"
+                               with | e -> Ortac_runtime.Report.Out_of_domain)
+                              "sub"
                               [("n >= 1",
                                  {
                                    Ortac_runtime.start =
@@ -868,7 +887,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
            | None ->
                (match r_1 with
                 | Ok r_1 ->
-                    Ortac_runtime.append
+                    Ortac_runtime.Report.append
                       (if
                          let r__038_ =
                            lazy (Model.get (Lazy.force new_state__027_) 0) in
@@ -901,11 +920,13 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Invariants" "create 42"
+                           (Ortac_runtime.Report.report "Invariants"
+                              "create 42"
                               (try
-                                 Ortac_runtime.Protected_value
-                                   (Res (Ortac_runtime.dummy, ()))
-                               with | e -> Ortac_runtime.Out_of_domain) "sub"
+                                 Ortac_runtime.Report.Protected_value
+                                   (Res (Ortac_runtime.Report.dummy, ()))
+                               with | e -> Ortac_runtime.Report.Out_of_domain)
+                              "sub"
                               [("Sequence.length x.contents > 0",
                                  {
                                    Ortac_runtime.start =
@@ -955,11 +976,13 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Invariants" "create 42"
+                           (Ortac_runtime.Report.report "Invariants"
+                              "create 42"
                               (try
-                                 Ortac_runtime.Protected_value
-                                   (Res (Ortac_runtime.dummy, ()))
-                               with | e -> Ortac_runtime.Out_of_domain) "sub"
+                                 Ortac_runtime.Report.Protected_value
+                                   (Res (Ortac_runtime.Report.dummy, ()))
+                               with | e -> Ortac_runtime.Report.Out_of_domain)
+                              "sub"
                               [("Sequence.length x.contents > 0",
                                  {
                                    Ortac_runtime.start =
@@ -982,7 +1005,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                (match r_1 with
                 | Error (Invalid_argument _) -> None
                 | _ ->
-                    Ortac_runtime.append
+                    Ortac_runtime.Report.append
                       (if
                          let tmp__040_ = Model.get state__025_ 0 in
                          try
@@ -1000,9 +1023,13 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                        then None
                        else
                          Some
-                           (Ortac_runtime.report "Invariants" "create 42"
-                              (try Ortac_runtime.Exception "Invalid_argument"
-                               with | e -> Ortac_runtime.Out_of_domain) "sub"
+                           (Ortac_runtime.Report.report "Invariants"
+                              "create 42"
+                              (try
+                                 Ortac_runtime.Report.Exception
+                                   "Invalid_argument"
+                               with | e -> Ortac_runtime.Report.Out_of_domain)
+                              "sub"
                               [("0 <= i <= Sequence.length t.contents",
                                  {
                                    Ortac_runtime.start =
@@ -1020,7 +1047,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                                        pos_cnum = 1344
                                      }
                                  })]))
-                      (Ortac_runtime.append
+                      (Ortac_runtime.Report.append
                          (if
                             let tmp__040_ = Model.get state__025_ 0 in
                             try
@@ -1047,11 +1074,13 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                           then None
                           else
                             Some
-                              (Ortac_runtime.report "Invariants" "create 42"
+                              (Ortac_runtime.Report.report "Invariants"
+                                 "create 42"
                                  (try
-                                    Ortac_runtime.Exception
+                                    Ortac_runtime.Report.Exception
                                       "Invalid_argument"
-                                  with | e -> Ortac_runtime.Out_of_domain)
+                                  with
+                                  | e -> Ortac_runtime.Report.Out_of_domain)
                                  "sub"
                                  [("i <= i + n <= Sequence.length t.contents",
                                     {
@@ -1080,11 +1109,13 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                           then None
                           else
                             Some
-                              (Ortac_runtime.report "Invariants" "create 42"
+                              (Ortac_runtime.Report.report "Invariants"
+                                 "create 42"
                                  (try
-                                    Ortac_runtime.Exception
+                                    Ortac_runtime.Report.Exception
                                       "Invalid_argument"
-                                  with | e -> Ortac_runtime.Out_of_domain)
+                                  with
+                                  | e -> Ortac_runtime.Report.Out_of_domain)
                                  "sub"
                                  [("n >= 1",
                                     {

--- a/plugins/qcheck-stm/test/module_prefix_tests.expected.ml
+++ b/plugins/qcheck-stm/test/module_prefix_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Module_prefix_lib.Module_prefix
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 module SUT =
   (Ortac_runtime.SUT.Make)(struct type sut = int t
                                   let init () = make 0 end)

--- a/plugins/qcheck-stm/test/queue_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/queue_stm_tests.expected.ml
@@ -652,7 +652,7 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
       | (Take, Res ((Result (Int, Exn), _), v_2)) ->
           (match v_2 with
            | Ok v_2 ->
-               Ortac_runtime.append
+               Ortac_runtime.Report.append
                  (if
                     let t_old__046_ = Model.get state__039_ 0
                     and t_new__047_ =
@@ -665,9 +665,9 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                   then None
                   else
                     Some
-                      (Ortac_runtime.report "Queue" "create ()"
+                      (Ortac_runtime.Report.report "Queue" "create ()"
                          (try
-                            Ortac_runtime.Protected_value
+                            Ortac_runtime.Report.Protected_value
                               (Res
                                  (int,
                                    (let t_old__044_ = Model.get state__039_ 0
@@ -677,7 +677,8 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                                            (Lazy.force new_state__041_) 0) in
                                     Ortac_runtime.Gospelstdlib.Sequence.hd
                                       t_old__044_.contents)))
-                          with | e -> Ortac_runtime.Out_of_domain) "take"
+                          with | e -> Ortac_runtime.Report.Out_of_domain)
+                         "take"
                          [("v = Sequence.hd (old t.contents)",
                             {
                               Ortac_runtime.start =
@@ -707,9 +708,9 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                   then None
                   else
                     Some
-                      (Ortac_runtime.report "Queue" "create ()"
+                      (Ortac_runtime.Report.report "Queue" "create ()"
                          (try
-                            Ortac_runtime.Protected_value
+                            Ortac_runtime.Report.Protected_value
                               (Res
                                  (int,
                                    (let t_old__044_ = Model.get state__039_ 0
@@ -719,7 +720,8 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                                            (Lazy.force new_state__041_) 0) in
                                     Ortac_runtime.Gospelstdlib.Sequence.hd
                                       t_old__044_.contents)))
-                          with | e -> Ortac_runtime.Out_of_domain) "take"
+                          with | e -> Ortac_runtime.Report.Out_of_domain)
+                         "take"
                          [("old t.contents <> Sequence.empty",
                             {
                               Ortac_runtime.start =
@@ -754,9 +756,9 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Queue" "create ()"
-                      (try Ortac_runtime.Exception "Empty"
-                       with | e -> Ortac_runtime.Out_of_domain) "take"
+                   (Ortac_runtime.Report.report "Queue" "create ()"
+                      (try Ortac_runtime.Report.Exception "Empty"
+                       with | e -> Ortac_runtime.Report.Out_of_domain) "take"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -793,9 +795,9 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Queue" "create ()"
+              (Ortac_runtime.Report.report "Queue" "create ()"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          ((option int),
                            (let t_old__055_ = Model.get state__039_ 0
@@ -809,7 +811,7 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                               Some
                                 (Ortac_runtime.Gospelstdlib.Sequence.hd
                                    t_old__055_.contents))))
-                  with | e -> Ortac_runtime.Out_of_domain) "take_opt"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "take_opt"
                  [("r = if (old t.contents) = Sequence.empty then\n        None else Some (Sequence.hd (old t.contents))",
                     {
                       Ortac_runtime.start =
@@ -830,7 +832,7 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
       | (Pop, Res ((Result (Int, Exn), _), v_3)) ->
           (match v_3 with
            | Ok v_3 ->
-               Ortac_runtime.append
+               Ortac_runtime.Report.append
                  (if
                     let t_old__062_ = Model.get state__039_ 0
                     and t_new__063_ =
@@ -843,9 +845,9 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                   then None
                   else
                     Some
-                      (Ortac_runtime.report "Queue" "create ()"
+                      (Ortac_runtime.Report.report "Queue" "create ()"
                          (try
-                            Ortac_runtime.Protected_value
+                            Ortac_runtime.Report.Protected_value
                               (Res
                                  (int,
                                    (let t_old__060_ = Model.get state__039_ 0
@@ -855,7 +857,8 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                                            (Lazy.force new_state__041_) 0) in
                                     Ortac_runtime.Gospelstdlib.Sequence.hd
                                       t_old__060_.contents)))
-                          with | e -> Ortac_runtime.Out_of_domain) "pop"
+                          with | e -> Ortac_runtime.Report.Out_of_domain)
+                         "pop"
                          [("v = Sequence.hd (old t.contents)",
                             {
                               Ortac_runtime.start =
@@ -885,9 +888,9 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                   then None
                   else
                     Some
-                      (Ortac_runtime.report "Queue" "create ()"
+                      (Ortac_runtime.Report.report "Queue" "create ()"
                          (try
-                            Ortac_runtime.Protected_value
+                            Ortac_runtime.Report.Protected_value
                               (Res
                                  (int,
                                    (let t_old__060_ = Model.get state__039_ 0
@@ -897,7 +900,8 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                                            (Lazy.force new_state__041_) 0) in
                                     Ortac_runtime.Gospelstdlib.Sequence.hd
                                       t_old__060_.contents)))
-                          with | e -> Ortac_runtime.Out_of_domain) "pop"
+                          with | e -> Ortac_runtime.Report.Out_of_domain)
+                         "pop"
                          [("old t.contents <> Sequence.empty",
                             {
                               Ortac_runtime.start =
@@ -932,9 +936,9 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Queue" "create ()"
-                      (try Ortac_runtime.Exception "Empty"
-                       with | e -> Ortac_runtime.Out_of_domain) "pop"
+                   (Ortac_runtime.Report.report "Queue" "create ()"
+                      (try Ortac_runtime.Report.Exception "Empty"
+                       with | e -> Ortac_runtime.Report.Out_of_domain) "pop"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -968,9 +972,9 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Queue" "create ()"
+                   (Ortac_runtime.Report.report "Queue" "create ()"
                       (try
-                         Ortac_runtime.Protected_value
+                         Ortac_runtime.Report.Protected_value
                            (Res
                               (int,
                                 (let t_old__071_ = Model.get state__039_ 0
@@ -980,7 +984,7 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                                         0) in
                                  Ortac_runtime.Gospelstdlib.Sequence.hd
                                    (Lazy.force t_new__072_).contents)))
-                       with | e -> Ortac_runtime.Out_of_domain) "peek"
+                       with | e -> Ortac_runtime.Report.Out_of_domain) "peek"
                       [("v = Sequence.hd t.contents",
                          {
                            Ortac_runtime.start =
@@ -1015,9 +1019,9 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Queue" "create ()"
-                      (try Ortac_runtime.Exception "Empty"
-                       with | e -> Ortac_runtime.Out_of_domain) "peek"
+                   (Ortac_runtime.Report.report "Queue" "create ()"
+                      (try Ortac_runtime.Report.Exception "Empty"
+                       with | e -> Ortac_runtime.Report.Out_of_domain) "peek"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -1051,9 +1055,9 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Queue" "create ()"
+                   (Ortac_runtime.Report.report "Queue" "create ()"
                       (try
-                         Ortac_runtime.Protected_value
+                         Ortac_runtime.Report.Protected_value
                            (Res
                               (int,
                                 (let t_old__080_ = Model.get state__039_ 0
@@ -1063,7 +1067,7 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                                         0) in
                                  Ortac_runtime.Gospelstdlib.Sequence.hd
                                    (Lazy.force t_new__081_).contents)))
-                       with | e -> Ortac_runtime.Out_of_domain) "top"
+                       with | e -> Ortac_runtime.Report.Out_of_domain) "top"
                       [("v = Sequence.hd t.contents",
                          {
                            Ortac_runtime.start =
@@ -1098,9 +1102,9 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Queue" "create ()"
-                      (try Ortac_runtime.Exception "Empty"
-                       with | e -> Ortac_runtime.Out_of_domain) "top"
+                   (Ortac_runtime.Report.report "Queue" "create ()"
+                      (try Ortac_runtime.Report.Exception "Empty"
+                       with | e -> Ortac_runtime.Report.Out_of_domain) "top"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -1143,9 +1147,11 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Queue" "create ()"
-                 (try Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))
-                  with | e -> Ortac_runtime.Out_of_domain) "peek_opt"
+              (Ortac_runtime.Report.report "Queue" "create ()"
+                 (try
+                    Ortac_runtime.Report.Value
+                      (Res (Ortac_runtime.Report.dummy, ()))
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "peek_opt"
                  [("match v with\n        | None -> t.contents = Sequence.empty\n        | Some a -> a = Sequence.hd t.contents",
                     {
                       Ortac_runtime.start =
@@ -1183,9 +1189,9 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Queue" "create ()"
+              (Ortac_runtime.Report.report "Queue" "create ()"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          (bool,
                            (let t_old__094_ = Model.get state__039_ 0
@@ -1200,7 +1206,7 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                                      0)
                                 -> true
                             | _ -> false)))
-                  with | e -> Ortac_runtime.Out_of_domain) "is_empty"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "is_empty"
                  [("b = match Sequence.length t.contents with\n        | 0 -> true\n        | _ -> false",
                     {
                       Ortac_runtime.start =
@@ -1230,9 +1236,9 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Queue" "create ()"
+              (Ortac_runtime.Report.report "Queue" "create ()"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          (integer,
                            (let t_old__101_ = Model.get state__039_ 0
@@ -1240,7 +1246,7 @@ let ortac_postcond cmd__038_ state__039_ res__040_ =
                               lazy (Model.get (Lazy.force new_state__041_) 0) in
                             Ortac_runtime.Gospelstdlib.Sequence.length
                               (Lazy.force t_new__102_).contents)))
-                  with | e -> Ortac_runtime.Out_of_domain) "length"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "length"
                  [("l = Sequence.length t.contents",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/queue_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/queue_stm_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Queue
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 module SUT =
   (Ortac_runtime.SUT.Make)(struct type sut = int t
                                   let init () = create () end)

--- a/plugins/qcheck-stm/test/record_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/record_stm_tests.expected.ml
@@ -203,15 +203,15 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Record" "make 42"
+              (Ortac_runtime.Report.report "Record" "make 42"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          (integer,
                            (Ortac_runtime.Gospelstdlib.(+)
                               (Ortac_runtime.Gospelstdlib.integer_of_int i_2)
                               (Ortac_runtime.Gospelstdlib.integer_of_int 1))))
-                  with | e -> Ortac_runtime.Out_of_domain) "plus1"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "plus1"
                  [("i1 = i + 1",
                     {
                       Ortac_runtime.start =
@@ -240,15 +240,15 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Record" "make 42"
+              (Ortac_runtime.Report.report "Record" "make 42"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          (integer,
                            (Ortac_runtime.Gospelstdlib.(+)
                               (Ortac_runtime.Gospelstdlib.integer_of_int i_3)
                               (Ortac_runtime.Gospelstdlib.integer_of_int 2))))
-                  with | e -> Ortac_runtime.Out_of_domain) "plus2"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "plus2"
                  [("i2 = i + 2",
                     {
                       Ortac_runtime.start =
@@ -267,7 +267,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                         }
                     })])
       | (Get, Res ((Int, _), i_4)) ->
-          Ortac_runtime.append
+          Ortac_runtime.Report.append
             (if
                let r_old__017_ = Model.get state__009_ 0
                and r_new__018_ =
@@ -279,9 +279,9 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
              then None
              else
                Some
-                 (Ortac_runtime.report "Record" "make 42"
+                 (Ortac_runtime.Report.report "Record" "make 42"
                     (try
-                       Ortac_runtime.Value
+                       Ortac_runtime.Report.Value
                          (Res
                             (integer,
                               (let r_old__013_ = Model.get state__009_ 0
@@ -289,7 +289,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                                  lazy
                                    (Model.get (Lazy.force new_state__011_) 0) in
                                (Lazy.force r_new__014_).value)))
-                     with | e -> Ortac_runtime.Out_of_domain) "get"
+                     with | e -> Ortac_runtime.Report.Out_of_domain) "get"
                     [("i = r.value",
                        {
                          Ortac_runtime.start =
@@ -307,7 +307,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                              pos_cnum = 891
                            }
                        })]))
-            (Ortac_runtime.append
+            (Ortac_runtime.Report.append
                (if
                   let r_old__021_ = Model.get state__009_ 0
                   and r_new__022_ =
@@ -322,9 +322,9 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                 then None
                 else
                   Some
-                    (Ortac_runtime.report "Record" "make 42"
+                    (Ortac_runtime.Report.report "Record" "make 42"
                        (try
-                          Ortac_runtime.Value
+                          Ortac_runtime.Report.Value
                             (Res
                                (integer,
                                  (let r_old__013_ = Model.get state__009_ 0
@@ -333,7 +333,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                                       (Model.get (Lazy.force new_state__011_)
                                          0) in
                                   (Lazy.force r_new__014_).value)))
-                        with | e -> Ortac_runtime.Out_of_domain) "get"
+                        with | e -> Ortac_runtime.Report.Out_of_domain) "get"
                        [("plus1 i = i + 1",
                           {
                             Ortac_runtime.start =
@@ -364,9 +364,9 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                 then None
                 else
                   Some
-                    (Ortac_runtime.report "Record" "make 42"
+                    (Ortac_runtime.Report.report "Record" "make 42"
                        (try
-                          Ortac_runtime.Value
+                          Ortac_runtime.Report.Value
                             (Res
                                (integer,
                                  (let r_old__013_ = Model.get state__009_ 0
@@ -375,7 +375,7 @@ let ortac_postcond cmd__008_ state__009_ res__010_ =
                                       (Model.get (Lazy.force new_state__011_)
                                          0) in
                                   (Lazy.force r_new__014_).value)))
-                        with | e -> Ortac_runtime.Out_of_domain) "get"
+                        with | e -> Ortac_runtime.Report.Out_of_domain) "get"
                        [("plus2 i = i + 2",
                           {
                             Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/record_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/record_stm_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Record
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 let plus1_1 i =
   try
     Ortac_runtime.Gospelstdlib.(+) i

--- a/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
@@ -243,16 +243,16 @@ let ortac_postcond cmd__012_ state__013_ res__014_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Ref" "make 42"
+              (Ortac_runtime.Report.report "Ref" "make 42"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          (int,
                            (let r_old__016_ = Model.get state__013_ 0
                             and r_new__017_ =
                               lazy (Model.get (Lazy.force new_state__015_) 0) in
                             (Lazy.force r_new__017_).value)))
-                  with | e -> Ortac_runtime.Out_of_domain) "get"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "get"
                  [("v = r.value",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Ref
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 module SUT =
   (Ortac_runtime.SUT.Make)(struct type sut = int t
                                   let init () = make 42 end)

--- a/plugins/qcheck-stm/test/sequence_model_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/sequence_model_stm_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Sequence_model
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 let length_opt s =
   try Some (Ortac_runtime.Gospelstdlib.Sequence.length s)
   with

--- a/plugins/qcheck-stm/test/stack_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/stack_stm_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Stack
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 module SUT =
   (Ortac_runtime.SUT.Make)(struct
                              type sut = char t

--- a/plugins/qcheck-stm/test/stack_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/stack_stm_tests.expected.ml
@@ -430,7 +430,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
       | (Pop, Res ((Result (Char, Exn), _), v_1)) ->
           (match v_1 with
            | Ok v_1 ->
-               Ortac_runtime.append
+               Ortac_runtime.Report.append
                  (if
                     let t_old__031_ = Model.get state__025_ 0
                     and t_new__032_ =
@@ -443,9 +443,9 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                   then None
                   else
                     Some
-                      (Ortac_runtime.report "Stack" "create ()"
+                      (Ortac_runtime.Report.report "Stack" "create ()"
                          (try
-                            Ortac_runtime.Protected_value
+                            Ortac_runtime.Report.Protected_value
                               (Res
                                  (char,
                                    (let t_old__029_ = Model.get state__025_ 0
@@ -455,7 +455,8 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                                            (Lazy.force new_state__027_) 0) in
                                     Ortac_runtime.Gospelstdlib.Sequence.hd
                                       t_old__029_.contents)))
-                          with | e -> Ortac_runtime.Out_of_domain) "pop"
+                          with | e -> Ortac_runtime.Report.Out_of_domain)
+                         "pop"
                          [("v = Sequence.hd (old t.contents)",
                             {
                               Ortac_runtime.start =
@@ -485,9 +486,9 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                   then None
                   else
                     Some
-                      (Ortac_runtime.report "Stack" "create ()"
+                      (Ortac_runtime.Report.report "Stack" "create ()"
                          (try
-                            Ortac_runtime.Protected_value
+                            Ortac_runtime.Report.Protected_value
                               (Res
                                  (char,
                                    (let t_old__029_ = Model.get state__025_ 0
@@ -497,7 +498,8 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                                            (Lazy.force new_state__027_) 0) in
                                     Ortac_runtime.Gospelstdlib.Sequence.hd
                                       t_old__029_.contents)))
-                          with | e -> Ortac_runtime.Out_of_domain) "pop"
+                          with | e -> Ortac_runtime.Report.Out_of_domain)
+                         "pop"
                          [("old t.contents <> Sequence.empty",
                             {
                               Ortac_runtime.start =
@@ -532,9 +534,9 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Stack" "create ()"
-                      (try Ortac_runtime.Exception "Empty"
-                       with | e -> Ortac_runtime.Out_of_domain) "pop"
+                   (Ortac_runtime.Report.report "Stack" "create ()"
+                      (try Ortac_runtime.Report.Exception "Empty"
+                       with | e -> Ortac_runtime.Report.Out_of_domain) "pop"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -571,9 +573,9 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Stack" "create ()"
+              (Ortac_runtime.Report.report "Stack" "create ()"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          ((option char),
                            (let t_old__040_ = Model.get state__025_ 0
@@ -587,7 +589,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                               Some
                                 (Ortac_runtime.Gospelstdlib.Sequence.hd
                                    t_old__040_.contents))))
-                  with | e -> Ortac_runtime.Out_of_domain) "pop_opt"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "pop_opt"
                  [("v = if (old t.contents) = Sequence.empty then\n        None else Some (Sequence.hd (old t.contents))",
                     {
                       Ortac_runtime.start =
@@ -620,9 +622,9 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Stack" "create ()"
+                   (Ortac_runtime.Report.report "Stack" "create ()"
                       (try
-                         Ortac_runtime.Protected_value
+                         Ortac_runtime.Report.Protected_value
                            (Res
                               (char,
                                 (let t_old__045_ = Model.get state__025_ 0
@@ -632,7 +634,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                                         0) in
                                  Ortac_runtime.Gospelstdlib.Sequence.hd
                                    (Lazy.force t_new__046_).contents)))
-                       with | e -> Ortac_runtime.Out_of_domain) "top"
+                       with | e -> Ortac_runtime.Report.Out_of_domain) "top"
                       [("v = Sequence.hd t.contents",
                          {
                            Ortac_runtime.start =
@@ -667,9 +669,9 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                then None
                else
                  Some
-                   (Ortac_runtime.report "Stack" "create ()"
-                      (try Ortac_runtime.Exception "Empty"
-                       with | e -> Ortac_runtime.Out_of_domain) "top"
+                   (Ortac_runtime.Report.report "Stack" "create ()"
+                      (try Ortac_runtime.Report.Exception "Empty"
+                       with | e -> Ortac_runtime.Report.Out_of_domain) "top"
                       [("t.contents = old t.contents = Sequence.empty",
                          {
                            Ortac_runtime.start =
@@ -712,9 +714,11 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Stack" "create ()"
-                 (try Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))
-                  with | e -> Ortac_runtime.Out_of_domain) "top_opt"
+              (Ortac_runtime.Report.report "Stack" "create ()"
+                 (try
+                    Ortac_runtime.Report.Value
+                      (Res (Ortac_runtime.Report.dummy, ()))
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "top_opt"
                  [("match v with\n        | None -> t.contents = Sequence.empty\n        | Some x -> x = Sequence.hd t.contents",
                     {
                       Ortac_runtime.start =
@@ -752,9 +756,9 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Stack" "create ()"
+              (Ortac_runtime.Report.report "Stack" "create ()"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          (bool,
                            (let t_old__059_ = Model.get state__025_ 0
@@ -769,7 +773,7 @@ let ortac_postcond cmd__024_ state__025_ res__026_ =
                                      0)
                                 -> true
                             | _ -> false)))
-                  with | e -> Ortac_runtime.Out_of_domain) "is_empty"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "is_empty"
                  [("b = match Sequence.length t.contents with\n        | 0 -> true\n        | _ -> false",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/submodule_and_prefix_tests.expected.ml
+++ b/plugins/qcheck-stm/test/submodule_and_prefix_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Submodule_and_prefix_lib.Submodule_and_prefix.M
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 module SUT =
   (Ortac_runtime.SUT.Make)(struct type sut = int t
                                   let init () = make 0 end)

--- a/plugins/qcheck-stm/test/submodule_tests.expected.ml
+++ b/plugins/qcheck-stm/test/submodule_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Submodule.M
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 module SUT =
   (Ortac_runtime.SUT.Make)(struct type sut = int t
                                   let init () = make 0 end)

--- a/plugins/qcheck-stm/test/sut_in_type_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/sut_in_type_stm_tests.expected.ml
@@ -166,9 +166,11 @@ let ortac_postcond cmd__006_ state__007_ res__008_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Sut_in_type" "make 16 0"
-                        (try Ortac_runtime.Exception "Invalid_argument"
-                         with | e -> Ortac_runtime.Out_of_domain) "make"
+                     (Ortac_runtime.Report.report "Sut_in_type" "make 16 0"
+                        (try
+                           Ortac_runtime.Report.Exception "Invalid_argument"
+                         with | e -> Ortac_runtime.Report.Out_of_domain)
+                        "make"
                         [("i >= 0",
                            {
                              Ortac_runtime.start =
@@ -201,9 +203,13 @@ let ortac_postcond cmd__006_ state__007_ res__008_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Sut_in_type" "make 16 0"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "make"
+                        (Ortac_runtime.Report.report "Sut_in_type"
+                           "make 16 0"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "make"
                            [("i >= 0",
                               {
                                 Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/sut_in_type_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/sut_in_type_stm_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Sut_in_type
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 module SUT =
   (Ortac_runtime.SUT.Make)(struct type sut = int t
                                   let init () = make 16 0 end)

--- a/plugins/qcheck-stm/test/test_cleanup_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/test_cleanup_stm_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Test_cleanup
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 module SUT =
   (Ortac_runtime.SUT.Make)(struct type sut = t
                                   let init () = create () end)

--- a/plugins/qcheck-stm/test/test_without_sut_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/test_without_sut_stm_tests.expected.ml
@@ -178,9 +178,12 @@ let ortac_postcond cmd__006_ state__007_ res__008_ =
                  then None
                  else
                    Some
-                     (Ortac_runtime.report "Test_without_sut" "make 16 0"
-                        (try Ortac_runtime.Exception "Invalid_argument"
-                         with | e -> Ortac_runtime.Out_of_domain) "make"
+                     (Ortac_runtime.Report.report "Test_without_sut"
+                        "make 16 0"
+                        (try
+                           Ortac_runtime.Report.Exception "Invalid_argument"
+                         with | e -> Ortac_runtime.Report.Out_of_domain)
+                        "make"
                         [("i >= 0",
                            {
                              Ortac_runtime.start =
@@ -213,9 +216,13 @@ let ortac_postcond cmd__006_ state__007_ res__008_ =
                     then None
                     else
                       Some
-                        (Ortac_runtime.report "Test_without_sut" "make 16 0"
-                           (try Ortac_runtime.Exception "Invalid_argument"
-                            with | e -> Ortac_runtime.Out_of_domain) "make"
+                        (Ortac_runtime.Report.report "Test_without_sut"
+                           "make 16 0"
+                           (try
+                              Ortac_runtime.Report.Exception
+                                "Invalid_argument"
+                            with | e -> Ortac_runtime.Report.Out_of_domain)
+                           "make"
                            [("i >= 0",
                               {
                                 Ortac_runtime.start =
@@ -244,15 +251,15 @@ let ortac_postcond cmd__006_ state__007_ res__008_ =
           then None
           else
             Some
-              (Ortac_runtime.report "Test_without_sut" "make 16 0"
+              (Ortac_runtime.Report.report "Test_without_sut" "make 16 0"
                  (try
-                    Ortac_runtime.Value
+                    Ortac_runtime.Report.Value
                       (Res
                          (integer,
                            (Ortac_runtime.Gospelstdlib.(+)
                               (Ortac_runtime.Gospelstdlib.integer_of_int a_2)
                               (Ortac_runtime.Gospelstdlib.integer_of_int b))))
-                  with | e -> Ortac_runtime.Out_of_domain) "add"
+                  with | e -> Ortac_runtime.Report.Out_of_domain) "add"
                  [("c = a + b",
                     {
                       Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/test_without_sut_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/test_without_sut_stm_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Test_without_sut
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 module SUT =
   (Ortac_runtime.SUT.Make)(struct type sut = int t
                                   let init () = make 16 0 end)

--- a/plugins/qcheck-stm/test/tuples_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/tuples_stm_tests.expected.ml
@@ -395,7 +395,7 @@ let ortac_postcond cmd__018_ state__019_ res__020_ =
       | (Add' tup_1, Res ((Unit, _), _)) -> None
       | (Add'' tup_2, Res ((Unit, _), _)) -> None
       | (Size_tup, Res ((Tup2 (Int, Int), _), (x, y))) ->
-          Ortac_runtime.append
+          Ortac_runtime.Report.append
             (if
                let t_old__026_ = Model.get state__019_ 0
                and t_new__027_ =
@@ -408,9 +408,12 @@ let ortac_postcond cmd__018_ state__019_ res__020_ =
              then None
              else
                Some
-                 (Ortac_runtime.report "Tuples" "create ()"
-                    (try Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))
-                     with | e -> Ortac_runtime.Out_of_domain) "size_tup"
+                 (Ortac_runtime.Report.report "Tuples" "create ()"
+                    (try
+                       Ortac_runtime.Report.Value
+                         (Res (Ortac_runtime.Report.dummy, ()))
+                     with | e -> Ortac_runtime.Report.Out_of_domain)
+                    "size_tup"
                     [("x = Sequence.length t.contents",
                        {
                          Ortac_runtime.start =
@@ -440,9 +443,12 @@ let ortac_postcond cmd__018_ state__019_ res__020_ =
              then None
              else
                Some
-                 (Ortac_runtime.report "Tuples" "create ()"
-                    (try Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))
-                     with | e -> Ortac_runtime.Out_of_domain) "size_tup"
+                 (Ortac_runtime.Report.report "Tuples" "create ()"
+                    (try
+                       Ortac_runtime.Report.Value
+                         (Res (Ortac_runtime.Report.dummy, ()))
+                     with | e -> Ortac_runtime.Report.Out_of_domain)
+                    "size_tup"
                     [("y = Sequence.length t.contents",
                        {
                          Ortac_runtime.start =
@@ -461,7 +467,7 @@ let ortac_postcond cmd__018_ state__019_ res__020_ =
                            }
                        })]))
       | (Size_tup', Res ((Tup3 (Int, Int, Int), _), (x_1, y_1, z))) ->
-          Ortac_runtime.append
+          Ortac_runtime.Report.append
             (if
                let t_old__031_ = Model.get state__019_ 0
                and t_new__032_ =
@@ -474,9 +480,12 @@ let ortac_postcond cmd__018_ state__019_ res__020_ =
              then None
              else
                Some
-                 (Ortac_runtime.report "Tuples" "create ()"
-                    (try Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))
-                     with | e -> Ortac_runtime.Out_of_domain) "size_tup'"
+                 (Ortac_runtime.Report.report "Tuples" "create ()"
+                    (try
+                       Ortac_runtime.Report.Value
+                         (Res (Ortac_runtime.Report.dummy, ()))
+                     with | e -> Ortac_runtime.Report.Out_of_domain)
+                    "size_tup'"
                     [("x = Sequence.length t.contents",
                        {
                          Ortac_runtime.start =
@@ -494,7 +503,7 @@ let ortac_postcond cmd__018_ state__019_ res__020_ =
                              pos_cnum = 1826
                            }
                        })]))
-            (Ortac_runtime.append
+            (Ortac_runtime.Report.append
                (if
                   let t_old__033_ = Model.get state__019_ 0
                   and t_new__034_ =
@@ -507,10 +516,12 @@ let ortac_postcond cmd__018_ state__019_ res__020_ =
                 then None
                 else
                   Some
-                    (Ortac_runtime.report "Tuples" "create ()"
+                    (Ortac_runtime.Report.report "Tuples" "create ()"
                        (try
-                          Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))
-                        with | e -> Ortac_runtime.Out_of_domain) "size_tup'"
+                          Ortac_runtime.Report.Value
+                            (Res (Ortac_runtime.Report.dummy, ()))
+                        with | e -> Ortac_runtime.Report.Out_of_domain)
+                       "size_tup'"
                        [("y = Sequence.length t.contents",
                           {
                             Ortac_runtime.start =
@@ -540,10 +551,12 @@ let ortac_postcond cmd__018_ state__019_ res__020_ =
                 then None
                 else
                   Some
-                    (Ortac_runtime.report "Tuples" "create ()"
+                    (Ortac_runtime.Report.report "Tuples" "create ()"
                        (try
-                          Ortac_runtime.Value (Res (Ortac_runtime.dummy, ()))
-                        with | e -> Ortac_runtime.Out_of_domain) "size_tup'"
+                          Ortac_runtime.Report.Value
+                            (Res (Ortac_runtime.Report.dummy, ()))
+                        with | e -> Ortac_runtime.Report.Out_of_domain)
+                       "size_tup'"
                        [("z = Sequence.length t.contents",
                           {
                             Ortac_runtime.start =

--- a/plugins/qcheck-stm/test/tuples_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/tuples_stm_tests.expected.ml
@@ -2,7 +2,7 @@
    edit how you run the tool instead *)
 [@@@ocaml.warning "-26-27-69-32-34-38"]
 open Tuples
-module Ortac_runtime = Ortac_runtime_qcheck_stm
+module Ortac_runtime = Ortac_runtime_qcheck_stm_sequential
 module SUT =
   (Ortac_runtime.SUT.Make)(struct
                              type sut = (char, int) t


### PR DESCRIPTION
Refactor runtime to allow for OCaml5-only sub-library

This PR is part of the implementation of #274.

1. extraction of common functionalities in a library
2. runtime for sequential test is now a sub-library of the runtime package so that there is room to declare another sub-library for domains testing, available only for OCaml >= 5.0
