### PR TITLE
[QCheck-STM] Fix next-state computation for functions specialised for `int`s

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [QCheck-STM] Fix next-state computation for functions specialised for `int`s
+  [\#326](https://github.com/ocaml-gospel/ortac/pull/326)
 - [Wrapper] Add header message in generated files with wrapper mode
   [\#322](https://github.com/ocaml-gospel/ortac/pull/322)
 - [Dune] Add automatic dune file generation to the wrapper plugin

--- a/plugins/qcheck-stm/test/ref.ml
+++ b/plugins/qcheck-stm/test/ref.ml
@@ -1,4 +1,6 @@
-type t = int ref
+type 'a t = 'a ref
 
 let make = ref
 let get r = !r
+let set r v = r := v
+let incr = incr

--- a/plugins/qcheck-stm/test/ref.mli
+++ b/plugins/qcheck-stm/test/ref.mli
@@ -1,12 +1,21 @@
-type t = private int ref
-(*@ mutable model value : integer *)
+type 'a t
+(*@ mutable model value : 'a *)
 
-val make : int -> t
-(*@ r = make i
-    ensures r.value = i *)
+val make : 'a -> 'a t
+(*@ r = make v
+    ensures r.value = v *)
 
-val get : t -> int
-(*@ i = get r
+val get : 'a t -> 'a
+(*@ v = get r
     pure
-    ensures i = r.value
-    ensures i + 1 = succ !r *)
+    ensures v = r.value *)
+
+val set : 'a t -> 'a -> unit
+(*@ set r v
+    modifies r.value
+    ensures r.value = v *)
+
+val incr : int t -> unit
+(*@ incr r
+    modifies r.value
+    ensures r.value = succ (old r.value) *)

--- a/plugins/qcheck-stm/test/ref_config.ml
+++ b/plugins/qcheck-stm/test/ref_config.ml
@@ -1,5 +1,3 @@
-open Ref
-
 let init_sut = make 42
 
-type sut = t
+type sut = int t

--- a/plugins/qcheck-stm/test/ref_errors.expected
+++ b/plugins/qcheck-stm/test/ref_errors.expected
@@ -1,5 +1,8 @@
-File "ref.mli", line 12, characters 26-27:
-12 |     ensures i + 1 = succ !r *)
-                               ^
-Warning: Skipping clause: occurrences of the SUT in clauses are only
-         supported to access its model fields.
+File "ref.mli", line 20, characters 13-20:
+20 |     modifies r.value
+                  ^^^^^^^
+Warning: Skipping incr: model value is declared as modified by the function
+         but no suitable ensures clause was found. Specifications should
+         contain at least one "ensures x.value = expr" where x is the SUT and
+         expr can refer to the SUT only under an old operator and can't refer
+         to the returned value.

--- a/plugins/qcheck-stm/test/ref_errors.expected
+++ b/plugins/qcheck-stm/test/ref_errors.expected
@@ -1,8 +1,0 @@
-File "ref.mli", line 20, characters 13-20:
-20 |     modifies r.value
-                  ^^^^^^^
-Warning: Skipping incr: model value is declared as modified by the function
-         but no suitable ensures clause was found. Specifications should
-         contain at least one "ensures x.value = expr" where x is the SUT and
-         expr can refer to the SUT only under an old operator and can't refer
-         to the returned value.

--- a/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
@@ -141,63 +141,93 @@ module Spec =
           Model.push (Model.drop_n state__003_ 1) r_2__009_
       | Incr ->
           let r_3__010_ = Model.get state__003_ 0 in
-          let r_3__011_ = r_3__010_ in
+          let r_3__011_ =
+            let open ModelElt in
+              {
+                value =
+                  (try
+                     Ortac_runtime.Gospelstdlib.int_of_integer
+                       (Ortac_runtime.Gospelstdlib.succ
+                          (Ortac_runtime.Gospelstdlib.integer_of_int
+                             r_3__010_.value))
+                   with
+                   | e ->
+                       raise
+                         (Ortac_runtime.Partial_function
+                            (e,
+                              {
+                                Ortac_runtime.start =
+                                  {
+                                    pos_fname = "_none_";
+                                    pos_lnum = 0;
+                                    pos_bol = 0;
+                                    pos_cnum = (-1)
+                                  };
+                                Ortac_runtime.stop =
+                                  {
+                                    pos_fname = "_none_";
+                                    pos_lnum = 0;
+                                    pos_bol = 0;
+                                    pos_cnum = (-1)
+                                  }
+                              })))
+              } in
           Model.push (Model.drop_n state__003_ 1) r_3__011_
-    let precond cmd__025_ state__026_ =
-      match cmd__025_ with
+    let precond cmd__023_ state__024_ =
+      match cmd__023_ with
       | Make v -> true
       | Get -> true
       | Set v_1 -> true
       | Incr -> true
     let postcond _ _ _ = true
-    let run cmd__027_ sut__028_ =
-      match cmd__027_ with
+    let run cmd__025_ sut__026_ =
+      match cmd__025_ with
       | Make v ->
           Res
             (sut,
-              (let res__029_ = make v in
-               (SUT.push sut__028_ res__029_; res__029_)))
+              (let res__027_ = make v in
+               (SUT.push sut__026_ res__027_; res__027_)))
       | Get ->
           Res
             (int,
-              (let r_1__030_ = SUT.get sut__028_ 0 in
-               let res__031_ = get r_1__030_ in res__031_))
+              (let r_1__028_ = SUT.get sut__026_ 0 in
+               let res__029_ = get r_1__028_ in res__029_))
       | Set v_1 ->
           Res
             (unit,
-              (let r_2__032_ = SUT.get sut__028_ 0 in
-               let res__033_ = set r_2__032_ v_1 in res__033_))
+              (let r_2__030_ = SUT.get sut__026_ 0 in
+               let res__031_ = set r_2__030_ v_1 in res__031_))
       | Incr ->
           Res
             (unit,
-              (let r_3__034_ = SUT.get sut__028_ 0 in
-               let res__035_ = incr r_3__034_ in res__035_))
+              (let r_3__032_ = SUT.get sut__026_ 0 in
+               let res__033_ = incr r_3__032_ in res__033_))
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__037_ state__038_ last__040_ res__039_ =
+let ortac_show_cmd cmd__035_ state__036_ last__038_ res__037_ =
   let open Spec in
     let open STM in
-      match (cmd__037_, res__039_) with
+      match (cmd__035_, res__037_) with
       | (Make v, Res ((SUT, _), r)) ->
-          let lhs = if last__040_ then "r" else SUT.get_name state__038_ 0
+          let lhs = if last__038_ then "r" else SUT.get_name state__036_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "make" (Util.Pp.pp_int true) v
       | (Get, Res ((Int, _), _)) ->
-          let lhs = if last__040_ then "r" else "_"
+          let lhs = if last__038_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "get"
-            (SUT.get_name state__038_ (0 + shift))
+            (SUT.get_name state__036_ (0 + shift))
       | (Set v_1, Res ((Unit, _), _)) ->
-          let lhs = if last__040_ then "r" else "_"
+          let lhs = if last__038_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "set"
-            (SUT.get_name state__038_ (0 + shift)) (Util.Pp.pp_int true) v_1
+            (SUT.get_name state__036_ (0 + shift)) (Util.Pp.pp_int true) v_1
       | (Incr, Res ((Unit, _), _)) ->
-          let lhs = if last__040_ then "r" else "_"
+          let lhs = if last__038_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "incr"
-            (SUT.get_name state__038_ (0 + shift))
+            (SUT.get_name state__036_ (0 + shift))
       | _ -> assert false
 let ortac_postcond cmd__012_ state__013_ res__014_ =
   let open Spec in
@@ -241,41 +271,7 @@ let ortac_postcond cmd__012_ state__013_ res__014_ =
                         }
                     })])
       | (Set v_1, Res ((Unit, _), _)) -> None
-      | (Incr, Res ((Unit, _), _)) ->
-          if
-            let r_old__022_ = Model.get state__013_ 0
-            and r_new__023_ = lazy (Model.get (Lazy.force new_state__015_) 0) in
-            (try
-               (Ortac_runtime.Gospelstdlib.integer_of_int
-                  (Lazy.force r_new__023_).value)
-                 =
-                 (Ortac_runtime.Gospelstdlib.succ
-                    (Ortac_runtime.Gospelstdlib.integer_of_int
-                       r_old__022_.value))
-             with | e -> false)
-          then None
-          else
-            Some
-              (Ortac_runtime.report "Ref" "make 42"
-                 (try Ortac_runtime.Value (Res (unit, ()))
-                  with | e -> Ortac_runtime.Out_of_domain) "incr"
-                 [("r.value = succ (old r.value)",
-                    {
-                      Ortac_runtime.start =
-                        {
-                          pos_fname = "ref.mli";
-                          pos_lnum = 21;
-                          pos_bol = 634;
-                          pos_cnum = 646
-                        };
-                      Ortac_runtime.stop =
-                        {
-                          pos_fname = "ref.mli";
-                          pos_lnum = 21;
-                          pos_bol = 634;
-                          pos_cnum = 674
-                        }
-                    })])
+      | (Incr, Res ((Unit, _), _)) -> None
       | _ -> None
 let _ =
   QCheck_base_runner.run_tests_main

--- a/src/runtime/ortac_runtime.ml
+++ b/src/runtime/ortac_runtime.ml
@@ -219,6 +219,7 @@ module Gospelstdlib = struct
   let shift_right v s = Z.shift_right v (Z.to_int s)
   let shift_right_trunc v s = Z.shift_right_trunc v (Z.to_int s)
   let integer_of_int = Z.of_int
+  let int_of_integer = Z.to_int
   let max_int = Z.of_int max_int
   let min_int = Z.of_int min_int
   let fst = fst

--- a/src/runtime/ortac_runtime.mli
+++ b/src/runtime/ortac_runtime.mli
@@ -82,6 +82,7 @@ module Gospelstdlib : sig
   (** {2 Machine integers} *)
 
   val integer_of_int : int -> integer
+  val int_of_integer : integer -> int
   val max_int : integer
   val min_int : integer
 


### PR DESCRIPTION

Fixes #325

This PR adds `int_of_integer` to the implementation of the Gospel stdlib in Ortac runtime. This function is not present in Gospel logical library, but I do think it is safe to add as we are checking for partial applications (wrapped in a `try ... with`). A case could be done to add it only to the Ortac/QCheck-STM runtime rather than the general Ortac runtime.

Other than that, we are just looking past the application of `integer_of_int` in the post-conditions in the form of an equality in order to determine whether the left term of the equality is part of the model.

This fixes the issue as shown by the tests.