### PR TITLE
Prevent code generation if required model projection is absent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [Wrapper] Prevent code generation if required model projection is absent
+  [\#327](https://github.com/ocaml-gospel/ortac/pull/327)
 - [QCheck-STM] Fix next-state computation for functions specialised for `int`s
   [\#326](https://github.com/ocaml-gospel/ortac/pull/326)
 - [Wrapper] Fix naming conflicts between model projections and function arguments

--- a/plugins/wrapper/test/generated/dune
+++ b/plugins/wrapper/test/generated/dune
@@ -5,6 +5,12 @@
  (instrumentation
   (backend bisect_ppx)))
 
+(cram
+ (package ortac-wrapper)
+ (deps
+  (package ortac-core)
+  (package ortac-wrapper)))
+
 (rule
  (copy lib.mli wrapper.mli))
 

--- a/plugins/wrapper/test/generated/test_error.t
+++ b/plugins/wrapper/test/generated/test_error.t
@@ -1,0 +1,14 @@
+This test file is designed to trigger a failure
+in the `ortac wrapper` plugin by declaring
+Gospel models without providing the required
+projection functions.
+
+We first load the plugin
+  $ export ORTAC_ONLY_PLUGIN=wrapper
+
+  $ cat > missing.mli << EOF
+  > type t
+  > (*@ mutable model m: int
+  >     mutable model n: int *)
+  > EOF
+  $ ortac wrapper -o missing_wrapped.ml missing.mli

--- a/plugins/wrapper/test/generated/test_error.t
+++ b/plugins/wrapper/test/generated/test_error.t
@@ -12,3 +12,12 @@ We first load the plugin
   >     mutable model n: int *)
   > EOF
   $ ortac wrapper -o missing_wrapped.ml missing.mli
+  File "missing.mli", line 1, characters 0-59:
+  1 | type t
+  2 | (*@ mutable model m: int
+  3 |     mutable model n: int *)
+  Error: The model m has no projection function. It was not translated..File "missing.mli", line 1, characters 0-59:
+  1 | type t
+  2 | (*@ mutable model m: int
+  3 |     mutable model n: int *)
+  Error: The model n has no projection function. It was not translated..


### PR DESCRIPTION
This PR addresses issue #318 by emitting a warning in the error output when a model declared in Gospel does not have a corresponding projection function.
Since projection functions are required to support models in the wrapper generation, Ortac should skip code generation in such cases and inform the user through a warning message.