### PR TITLE
[QCheck-STM] Make `ortac_show_cmd` look at functional models

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [QCheck-STM] Make `ortac_show_cmd` look at the models
+  [\#353](https://github.com/ocaml-gospel/ortac/pull/353)
 - [QCheck-STM] Refactor bug report printing
   [\#345](https://github.com/ocaml-gospel/ortac/pull/345)
 - [Dune] Add domain flag to ortac-dune qcheck-stm

--- a/examples/lwt_dllist_spec_tests.ml
+++ b/examples/lwt_dllist_spec_tests.ml
@@ -460,12 +460,12 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__086_ state__087_ last__089_ res__088_ =
+let ortac_show_cmd cmd__086_ models__087_ last__089_ res__088_ =
   let open Spec in
     let open STM in
       match (cmd__086_, res__088_) with
       | (Create (), Res ((SUT, _), s)) ->
-          let lhs = if last__089_ then "r" else SUT.get_name state__087_ 0
+          let lhs = if last__089_ then "r" else Model.get_name models__087_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "create"
             (Util.Pp.pp_unit true) ()
@@ -473,47 +473,49 @@ let ortac_show_cmd cmd__086_ state__087_ last__089_ res__088_ =
           let lhs = if last__089_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "clear"
-            (SUT.get_name state__087_ (0 + shift))
+            (Model.get_name models__087_ (0 + shift))
       | (Is_empty, Res ((Bool, _), _)) ->
           let lhs = if last__089_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "is_empty"
-            (SUT.get_name state__087_ (0 + shift))
+            (Model.get_name models__087_ (0 + shift))
       | (Length, Res ((Int, _), _)) ->
           let lhs = if last__089_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "length"
-            (SUT.get_name state__087_ (0 + shift))
+            (Model.get_name models__087_ (0 + shift))
       | (Add_l a_1, Res ((Node (Int), _), _)) ->
           let lhs = if last__089_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "add_l"
-            (Util.Pp.pp_int true) a_1 (SUT.get_name state__087_ (0 + shift))
+            (Util.Pp.pp_int true) a_1
+            (Model.get_name models__087_ (0 + shift))
       | (Add_r a_2, Res ((Node (Int), _), _)) ->
           let lhs = if last__089_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "add_r"
-            (Util.Pp.pp_int true) a_2 (SUT.get_name state__087_ (0 + shift))
+            (Util.Pp.pp_int true) a_2
+            (Model.get_name models__087_ (0 + shift))
       | (Take_l, Res ((Result (Int, Exn), _), _)) ->
           let lhs = if last__089_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "take_l"
-            (SUT.get_name state__087_ (0 + shift))
+            (Model.get_name models__087_ (0 + shift))
       | (Take_r, Res ((Result (Int, Exn), _), _)) ->
           let lhs = if last__089_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "take_r"
-            (SUT.get_name state__087_ (0 + shift))
+            (Model.get_name models__087_ (0 + shift))
       | (Take_opt_l, Res ((Option (Int), _), _)) ->
           let lhs = if last__089_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "take_opt_l"
-            (SUT.get_name state__087_ (0 + shift))
+            (Model.get_name models__087_ (0 + shift))
       | (Take_opt_r, Res ((Option (Int), _), _)) ->
           let lhs = if last__089_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "take_opt_r"
-            (SUT.get_name state__087_ (0 + shift))
+            (Model.get_name models__087_ (0 + shift))
       | _ -> assert false
 let ortac_postcond cmd__025_ state__026_ res__027_ =
   let open Spec in

--- a/examples/varray_circular_spec_tests.ml
+++ b/examples/varray_circular_spec_tests.ml
@@ -1169,7 +1169,7 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__181_ state__182_ last__184_ res__183_ =
+let ortac_show_cmd cmd__181_ models__182_ last__184_ res__183_ =
   let open Spec in
     let open STM in
       match (cmd__181_, res__183_) with
@@ -1177,72 +1177,73 @@ let ortac_show_cmd cmd__181_ state__182_ last__184_ res__183_ =
           let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "push_back"
-            (SUT.get_name state__182_ (0 + shift))
+            (Model.get_name models__182_ (0 + shift))
             (Util.Pp.pp_elt Util.Pp.pp_char true) x
       | (Pop_back, Res ((Result (Elt (Char), Exn), _), _)) ->
           let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "pop_back"
-            (SUT.get_name state__182_ (0 + shift))
+            (Model.get_name models__182_ (0 + shift))
       | (Push_front x_1, Res ((Unit, _), _)) ->
           let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "push_front"
-            (SUT.get_name state__182_ (0 + shift))
+            (Model.get_name models__182_ (0 + shift))
             (Util.Pp.pp_elt Util.Pp.pp_char true) x_1
       | (Pop_front, Res ((Result (Elt (Char), Exn), _), _)) ->
           let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs
-            "pop_front" (SUT.get_name state__182_ (0 + shift))
+            "pop_front" (Model.get_name models__182_ (0 + shift))
       | (Insert_at (i_1, x_2), Res ((Result (Unit, Exn), _), _)) ->
           let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "insert_at" (SUT.get_name state__182_ (0 + shift))
+            "insert_at" (Model.get_name models__182_ (0 + shift))
             (Util.Pp.pp_int true) i_1 (Util.Pp.pp_elt Util.Pp.pp_char true)
             x_2
       | (Pop_at i_2, Res ((Result (Elt (Char), Exn), _), _)) ->
           let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a)" lhs
-            "pop_at" (SUT.get_name state__182_ (0 + shift))
+            "pop_at" (Model.get_name models__182_ (0 + shift))
             (Util.Pp.pp_int true) i_2
       | (Delete_at i_3, Res ((Result (Unit, Exn), _), _)) ->
           let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a)" lhs
-            "delete_at" (SUT.get_name state__182_ (0 + shift))
+            "delete_at" (Model.get_name models__182_ (0 + shift))
             (Util.Pp.pp_int true) i_3
       | (Get i_4, Res ((Result (Elt (Char), Exn), _), _)) ->
           let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a)" lhs "get"
-            (SUT.get_name state__182_ (0 + shift)) (Util.Pp.pp_int true) i_4
+            (Model.get_name models__182_ (0 + shift)) (Util.Pp.pp_int true)
+            i_4
       | (Set (i_5, v), Res ((Result (Unit, Exn), _), _)) ->
           let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "set" (SUT.get_name state__182_ (0 + shift))
+            "set" (Model.get_name models__182_ (0 + shift))
             (Util.Pp.pp_int true) i_5 (Util.Pp.pp_elt Util.Pp.pp_char true) v
       | (Length, Res ((Int, _), _)) ->
           let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "length"
-            (SUT.get_name state__182_ (0 + shift))
+            (Model.get_name models__182_ (0 + shift))
       | (Make (n, x_3), Res ((Result (SUT, Exn), _), t_11)) ->
           let lhs =
             if last__184_
             then "r"
             else
               (match t_11 with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__182_ 0)
+               | Ok _ -> "Ok " ^ (Model.get_name models__182_ 0)
                | Error _ -> "_")
           and shift = match t_11 with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %a %a)" lhs "make"
             (Util.Pp.pp_int true) n (Util.Pp.pp_elt Util.Pp.pp_char true) x_3
       | (Empty (), Res ((SUT, _), t_12)) ->
-          let lhs = if last__184_ then "r" else SUT.get_name state__182_ 0
+          let lhs = if last__184_ then "r" else Model.get_name models__182_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "empty" (Util.Pp.pp_unit true)
             ()
@@ -1250,44 +1251,44 @@ let ortac_show_cmd cmd__181_ state__182_ last__184_ res__183_ =
           let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "is_empty"
-            (SUT.get_name state__182_ (0 + shift))
+            (Model.get_name models__182_ (0 + shift))
       | (Append, Res ((SUT, _), t_14)) ->
-          let lhs = if last__184_ then "r" else SUT.get_name state__182_ 0
+          let lhs = if last__184_ then "r" else Model.get_name models__182_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s %s" lhs "append"
-            (SUT.get_name state__182_ (0 + shift))
-            (SUT.get_name state__182_ (1 + shift))
+            (Model.get_name models__182_ (0 + shift))
+            (Model.get_name models__182_ (1 + shift))
       | (Sub (i_6, n_1), Res ((Result (SUT, Exn), _), r)) ->
           let lhs =
             if last__184_
             then "r"
             else
               (match r with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__182_ 0)
+               | Ok _ -> "Ok " ^ (Model.get_name models__182_ 0)
                | Error _ -> "_")
           and shift = match r with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "sub" (SUT.get_name state__182_ (0 + shift))
+            "sub" (Model.get_name models__182_ (0 + shift))
             (Util.Pp.pp_int true) i_6 (Util.Pp.pp_int true) n_1
       | (Copy, Res ((SUT, _), r_1)) ->
-          let lhs = if last__184_ then "r" else SUT.get_name state__182_ 0
+          let lhs = if last__184_ then "r" else Model.get_name models__182_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s" lhs "copy"
-            (SUT.get_name state__182_ (0 + shift))
+            (Model.get_name models__182_ (0 + shift))
       | (Fill (pos, len, x_4), Res ((Result (Unit, Exn), _), _)) ->
           let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a %a)" lhs
-            "fill" (SUT.get_name state__182_ (0 + shift))
+            "fill" (Model.get_name models__182_ (0 + shift))
             (Util.Pp.pp_int true) pos (Util.Pp.pp_int true) len
             (Util.Pp.pp_elt Util.Pp.pp_char true) x_4
       | (Blit (src_pos, dst_pos, len_1), Res ((Result (Unit, Exn), _), _)) ->
           let lhs = if last__184_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %s %a %a)"
-            lhs "blit" (SUT.get_name state__182_ (0 + shift))
+            lhs "blit" (Model.get_name models__182_ (0 + shift))
             (Util.Pp.pp_int true) src_pos
-            (SUT.get_name state__182_ (1 + shift)) (Util.Pp.pp_int true)
+            (Model.get_name models__182_ (1 + shift)) (Util.Pp.pp_int true)
             dst_pos (Util.Pp.pp_int true) len_1
       | _ -> assert false
 let ortac_postcond cmd__074_ state__075_ res__076_ =

--- a/plugins/qcheck-stm/src/runtime/ortac_runtime_qcheck_stm_sequential.ml
+++ b/plugins/qcheck-stm/src/runtime/ortac_runtime_qcheck_stm_sequential.ml
@@ -34,13 +34,13 @@ module Make (Spec : Spec) = struct
     | [] -> None
     | c :: cs -> (
         let res = Spec.run c sut in
-        let call = ortac_show_cmd c sut (cs = []) res in
+        let s' = Spec.next_state c s in
+        let call = ortac_show_cmd c s' (cs = []) res in
         (* This functor will be called after a modified postcond has been
            defined, returning a list of 3-plets containing the command, the
            term and the location *)
         match postcond c s res with
         | None -> (
-            let s' = Spec.next_state c s in
             match check_disagree postcond ortac_show_cmd s' sut cs with
             | None -> None
             | Some (rest, report) -> Some ({ call; res } :: rest, report))

--- a/plugins/qcheck-stm/src/runtime/stores.ml
+++ b/plugins/qcheck-stm/src/runtime/stores.ml
@@ -15,6 +15,8 @@ module Model = struct
 
     let get t n =
       try List.nth t n with _ -> failwith ("nth: " ^ string_of_int n)
+
+    let get_name t n = Format.asprintf "sut%d" (size t - n - 1)
   end
 end
 

--- a/plugins/qcheck-stm/src/runtime/stores.mli
+++ b/plugins/qcheck-stm/src/runtime/stores.mli
@@ -26,6 +26,10 @@ module Model : sig
 
     val get : t -> int -> elt
     (** [get t n] returns the [n]th element of the model [t] *)
+
+    val get_name : t -> int -> string
+    (** [get_name t n] returns the name for the [n]th element of the stack [t]
+        of SUTs *)
   end
   with type elt := M.elt
 end

--- a/plugins/qcheck-stm/test/array_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/array_stm_tests.expected.ml
@@ -738,7 +738,7 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__117_ state__118_ last__120_ res__119_ =
+let ortac_show_cmd cmd__117_ models__118_ last__120_ res__119_ =
   let open Spec in
     let open STM in
       match (cmd__117_, res__119_) with
@@ -746,17 +746,17 @@ let ortac_show_cmd cmd__117_ state__118_ last__120_ res__119_ =
           let lhs = if last__120_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "length"
-            (SUT.get_name state__118_ (0 + shift))
+            (Model.get_name models__118_ (0 + shift))
       | (Get i, Res ((Result (Char, Exn), _), _)) ->
           let lhs = if last__120_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a)" lhs "get"
-            (SUT.get_name state__118_ (0 + shift)) (Util.Pp.pp_int true) i
+            (Model.get_name models__118_ (0 + shift)) (Util.Pp.pp_int true) i
       | (Set (i_1, a_1), Res ((Result (Unit, Exn), _), _)) ->
           let lhs = if last__120_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "set" (SUT.get_name state__118_ (0 + shift))
+            "set" (Model.get_name models__118_ (0 + shift))
             (Util.Pp.pp_int true) i_1 (Util.Pp.pp_char true) a_1
       | (Make (i_2, a_2), Res ((Result (SUT, Exn), _), t_4)) ->
           let lhs =
@@ -764,48 +764,48 @@ let ortac_show_cmd cmd__117_ state__118_ last__120_ res__119_ =
             then "r"
             else
               (match t_4 with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__118_ 0)
+               | Ok _ -> "Ok " ^ (Model.get_name models__118_ 0)
                | Error _ -> "_")
           and shift = match t_4 with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %a %a)" lhs "make"
             (Util.Pp.pp_int true) i_2 (Util.Pp.pp_char true) a_2
       | (Append, Res ((SUT, _), t_5)) ->
-          let lhs = if last__120_ then "r" else SUT.get_name state__118_ 0
+          let lhs = if last__120_ then "r" else Model.get_name models__118_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s %s" lhs "append"
-            (SUT.get_name state__118_ (0 + shift))
-            (SUT.get_name state__118_ (1 + shift))
+            (Model.get_name models__118_ (0 + shift))
+            (Model.get_name models__118_ (1 + shift))
       | (Sub (i_3, n), Res ((Result (SUT, Exn), _), r)) ->
           let lhs =
             if last__120_
             then "r"
             else
               (match r with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__118_ 0)
+               | Ok _ -> "Ok " ^ (Model.get_name models__118_ 0)
                | Error _ -> "_")
           and shift = match r with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "sub" (SUT.get_name state__118_ (0 + shift))
+            "sub" (Model.get_name models__118_ (0 + shift))
             (Util.Pp.pp_int true) i_3 (Util.Pp.pp_int true) n
       | (Copy, Res ((SUT, _), r_1)) ->
-          let lhs = if last__120_ then "r" else SUT.get_name state__118_ 0
+          let lhs = if last__120_ then "r" else Model.get_name models__118_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s" lhs "copy"
-            (SUT.get_name state__118_ (0 + shift))
+            (Model.get_name models__118_ (0 + shift))
       | (Fill (pos, len, x), Res ((Result (Unit, Exn), _), _)) ->
           let lhs = if last__120_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a %a)" lhs
-            "fill" (SUT.get_name state__118_ (0 + shift))
+            "fill" (Model.get_name models__118_ (0 + shift))
             (Util.Pp.pp_int true) pos (Util.Pp.pp_int true) len
             (Util.Pp.pp_char true) x
       | (To_list, Res ((List (Char), _), _)) ->
           let lhs = if last__120_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "to_list"
-            (SUT.get_name state__118_ (0 + shift))
+            (Model.get_name models__118_ (0 + shift))
       | (Of_list l, Res ((SUT, _), t_10)) ->
-          let lhs = if last__120_ then "r" else SUT.get_name state__118_ 0
+          let lhs = if last__120_ then "r" else Model.get_name models__118_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "of_list"
             (Util.Pp.pp_list Util.Pp.pp_char true) l
@@ -813,12 +813,14 @@ let ortac_show_cmd cmd__117_ state__118_ last__120_ res__119_ =
           let lhs = if last__120_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "mem"
-            (Util.Pp.pp_char true) a_3 (SUT.get_name state__118_ (0 + shift))
+            (Util.Pp.pp_char true) a_3
+            (Model.get_name models__118_ (0 + shift))
       | (For_all p, Res ((Bool, _), _)) ->
           let lhs = if last__120_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "for_all"
-            (Util.Pp.pp_fun_ true) p (SUT.get_name state__118_ (0 + shift))
+            (Util.Pp.pp_fun_ true) p
+            (Model.get_name models__118_ (0 + shift))
       | _ -> assert false
 let ortac_postcond cmd__046_ state__047_ res__048_ =
   let open Spec in

--- a/plugins/qcheck-stm/test/atomic_tests.expected.ml
+++ b/plugins/qcheck-stm/test/atomic_tests.expected.ml
@@ -385,7 +385,7 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__067_ state__068_ last__070_ res__069_ =
+let ortac_show_cmd cmd__067_ models__068_ last__070_ res__069_ =
   let open Spec in
     let open STM in
       match (cmd__067_, res__069_) with
@@ -397,38 +397,40 @@ let ortac_show_cmd cmd__067_ state__068_ last__070_ res__069_ =
           let lhs = if last__070_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "get"
-            (SUT.get_name state__068_ (0 + shift))
+            (Model.get_name models__068_ (0 + shift))
       | (Set v_1, Res ((Unit, _), _)) ->
           let lhs = if last__070_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "set"
-            (SUT.get_name state__068_ (0 + shift)) (Util.Pp.pp_int true) v_1
+            (Model.get_name models__068_ (0 + shift)) (Util.Pp.pp_int true)
+            v_1
       | (Exchange v_2, Res ((Int, _), _)) ->
           let lhs = if last__070_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "exchange"
-            (SUT.get_name state__068_ (0 + shift)) (Util.Pp.pp_int true) v_2
+            (Model.get_name models__068_ (0 + shift)) (Util.Pp.pp_int true)
+            v_2
       | (Compare_and_set (seen, v_3), Res ((Bool, _), _)) ->
           let lhs = if last__070_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a %a" lhs "compare_and_set"
-            (SUT.get_name state__068_ (0 + shift)) (Util.Pp.pp_int true) seen
-            (Util.Pp.pp_int true) v_3
+            (Model.get_name models__068_ (0 + shift)) (Util.Pp.pp_int true)
+            seen (Util.Pp.pp_int true) v_3
       | (Fetch_and_add n, Res ((Int, _), _)) ->
           let lhs = if last__070_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "fetch_and_add"
-            (SUT.get_name state__068_ (0 + shift)) (Util.Pp.pp_int true) n
+            (Model.get_name models__068_ (0 + shift)) (Util.Pp.pp_int true) n
       | (Incr, Res ((Unit, _), _)) ->
           let lhs = if last__070_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "incr"
-            (SUT.get_name state__068_ (0 + shift))
+            (Model.get_name models__068_ (0 + shift))
       | (Decr, Res ((Unit, _), _)) ->
           let lhs = if last__070_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "decr"
-            (SUT.get_name state__068_ (0 + shift))
+            (Model.get_name models__068_ (0 + shift))
       | _ -> assert false
 let ortac_postcond cmd__020_ state__021_ res__022_ =
   let open Spec in

--- a/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
@@ -191,7 +191,7 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__025_ state__026_ last__028_ res__027_ =
+let ortac_show_cmd cmd__025_ models__026_ last__028_ res__027_ =
   let open Spec in
     let open STM in
       match (cmd__025_, res__027_) with
@@ -201,7 +201,7 @@ let ortac_show_cmd cmd__025_ state__026_ last__028_ res__027_ =
             then "r"
             else
               (match t_1 with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__026_ 0)
+               | Ok _ -> "Ok " ^ (Model.get_name models__026_ 0)
                | Error _ -> "_")
           and shift = match t_1 with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %a %a)" lhs "make"
@@ -210,7 +210,7 @@ let ortac_show_cmd cmd__025_ state__026_ last__028_ res__027_ =
           let lhs = if last__028_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "set" (SUT.get_name state__026_ (0 + shift))
+            "set" (Model.get_name models__026_ (0 + shift))
             (Util.Pp.pp_int true) i_1 (Util.Pp.pp_char true) a_2
       | _ -> assert false
 let ortac_postcond cmd__010_ state__011_ res__012_ =

--- a/plugins/qcheck-stm/test/custom_config_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/custom_config_stm_tests.expected.ml
@@ -206,7 +206,7 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__029_ state__030_ last__032_ res__031_ =
+let ortac_show_cmd cmd__029_ models__030_ last__032_ res__031_ =
   let open Spec in
     let open STM in
       match (cmd__029_, res__031_) with
@@ -216,7 +216,7 @@ let ortac_show_cmd cmd__029_ state__030_ last__032_ res__031_ =
           Format.asprintf "let %s = %s %a" lhs "proj"
             (Util.Pp.pp_elt Util.Pp.pp_char true) __arg0
       | (Empty (), Res ((SUT, _), t_1)) ->
-          let lhs = if last__032_ then "r" else SUT.get_name state__030_ 0
+          let lhs = if last__032_ then "r" else Model.get_name models__030_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "empty" (Util.Pp.pp_unit true)
             ()
@@ -224,13 +224,13 @@ let ortac_show_cmd cmd__029_ state__030_ last__032_ res__031_ =
           let lhs = if last__032_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "push"
-            (SUT.get_name state__030_ (0 + shift))
+            (Model.get_name models__030_ (0 + shift))
             (Util.Pp.pp_elt Util.Pp.pp_int true) e
       | (Top, Res ((Result (Elt (Int), Exn), _), _)) ->
           let lhs = if last__032_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "top"
-            (SUT.get_name state__030_ (0 + shift))
+            (Model.get_name models__030_ (0 + shift))
       | _ -> assert false
 let ortac_postcond cmd__010_ state__011_ res__012_ =
   let open Spec in

--- a/plugins/qcheck-stm/test/function_args_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/function_args_stm_tests.expected.ml
@@ -254,7 +254,7 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__023_ state__024_ last__026_ res__025_ =
+let ortac_show_cmd cmd__023_ models__024_ last__026_ res__025_ =
   let open Spec in
     let open STM in
       match (cmd__023_, res__025_) with
@@ -264,16 +264,17 @@ let ortac_show_cmd cmd__023_ state__024_ last__026_ res__025_ =
             then "r"
             else
               (match t_1 with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__024_ 0)
+               | Ok _ -> "Ok " ^ (Model.get_name models__024_ 0)
                | Error _ -> "_")
           and shift = match t_1 with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %a %a)" lhs "make"
             (Util.Pp.pp_int true) len (Util.Pp.pp_char true) c
       | (Map f, Res ((SUT, _), output)) ->
-          let lhs = if last__026_ then "r" else SUT.get_name state__024_ 0
+          let lhs = if last__026_ then "r" else Model.get_name models__024_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a %s" lhs "map"
-            (Util.Pp.pp_fun_ true) f (SUT.get_name state__024_ (0 + shift))
+            (Util.Pp.pp_fun_ true) f
+            (Model.get_name models__024_ (0 + shift))
       | _ -> assert false
 let ortac_postcond cmd__010_ state__011_ res__012_ =
   let open Spec in

--- a/plugins/qcheck-stm/test/functional_model_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/functional_model_stm_tests.expected.ml
@@ -151,12 +151,12 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__021_ state__022_ last__024_ res__023_ =
+let ortac_show_cmd cmd__021_ models__022_ last__024_ res__023_ =
   let open Spec in
     let open STM in
       match (cmd__021_, res__023_) with
       | (Empty (), Res ((SUT, _), t_1)) ->
-          let lhs = if last__024_ then "r" else SUT.get_name state__022_ 0
+          let lhs = if last__024_ then "r" else Model.get_name models__022_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "empty" (Util.Pp.pp_unit true)
             ()
@@ -164,8 +164,8 @@ let ortac_show_cmd cmd__021_ state__022_ last__024_ res__023_ =
           let lhs = if last__024_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a %a" lhs "add"
-            (SUT.get_name state__022_ (0 + shift)) (Util.Pp.pp_char true) a_1
-            (Util.Pp.pp_int true) b_1
+            (Model.get_name models__022_ (0 + shift)) (Util.Pp.pp_char true)
+            a_1 (Util.Pp.pp_int true) b_1
       | _ -> assert false
 let ortac_postcond cmd__008_ state__009_ res__010_ =
   let open Spec in

--- a/plugins/qcheck-stm/test/ghost_as_model_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/ghost_as_model_stm_tests.expected.ml
@@ -149,12 +149,12 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__021_ state__022_ last__024_ res__023_ =
+let ortac_show_cmd cmd__021_ models__022_ last__024_ res__023_ =
   let open Spec in
     let open STM in
       match (cmd__021_, res__023_) with
       | (Create (), Res ((SUT, _), t_1)) ->
-          let lhs = if last__024_ then "r" else SUT.get_name state__022_ 0
+          let lhs = if last__024_ then "r" else Model.get_name models__022_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "create"
             (Util.Pp.pp_unit true) ()
@@ -162,7 +162,7 @@ let ortac_show_cmd cmd__021_ state__022_ last__024_ res__023_ =
           let lhs = if last__024_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "use"
-            (SUT.get_name state__022_ (0 + shift))
+            (Model.get_name models__022_ (0 + shift))
       | _ -> assert false
 let ortac_postcond cmd__008_ state__009_ res__010_ =
   let open Spec in

--- a/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
@@ -521,12 +521,12 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__096_ state__097_ last__099_ res__098_ =
+let ortac_show_cmd cmd__096_ models__097_ last__099_ res__098_ =
   let open Spec in
     let open STM in
       match (cmd__096_, res__098_) with
       | (Create (random, size), Res ((SUT, _), h)) ->
-          let lhs = if last__099_ then "r" else SUT.get_name state__097_ 0
+          let lhs = if last__099_ then "r" else Model.get_name models__097_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s ~random:%a %a" lhs "create"
             (Util.Pp.pp_bool true) random (Util.Pp.pp_int true) size
@@ -534,64 +534,70 @@ let ortac_show_cmd cmd__096_ state__097_ last__099_ res__098_ =
           let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "clear"
-            (SUT.get_name state__097_ (0 + shift))
+            (Model.get_name models__097_ (0 + shift))
       | (Reset, Res ((Unit, _), _)) ->
           let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "reset"
-            (SUT.get_name state__097_ (0 + shift))
+            (Model.get_name models__097_ (0 + shift))
       | (Copy, Res ((SUT, _), h2)) ->
-          let lhs = if last__099_ then "r" else SUT.get_name state__097_ 0
+          let lhs = if last__099_ then "r" else Model.get_name models__097_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s" lhs "copy"
-            (SUT.get_name state__097_ (0 + shift))
+            (Model.get_name models__097_ (0 + shift))
       | (Add (a_1, b_1), Res ((Unit, _), _)) ->
           let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a %a" lhs "add"
-            (SUT.get_name state__097_ (0 + shift)) (Util.Pp.pp_char true) a_1
-            (Util.Pp.pp_int true) b_1
+            (Model.get_name models__097_ (0 + shift)) (Util.Pp.pp_char true)
+            a_1 (Util.Pp.pp_int true) b_1
       | (Find a_2, Res ((Result (Int, Exn), _), _)) ->
           let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a)" lhs "find"
-            (SUT.get_name state__097_ (0 + shift)) (Util.Pp.pp_char true) a_2
+            (Model.get_name models__097_ (0 + shift)) (Util.Pp.pp_char true)
+            a_2
       | (Find_opt a_3, Res ((Option (Int), _), _)) ->
           let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "find_opt"
-            (SUT.get_name state__097_ (0 + shift)) (Util.Pp.pp_char true) a_3
+            (Model.get_name models__097_ (0 + shift)) (Util.Pp.pp_char true)
+            a_3
       | (Find_all a_4, Res ((List (Int), _), _)) ->
           let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "find_all"
-            (SUT.get_name state__097_ (0 + shift)) (Util.Pp.pp_char true) a_4
+            (Model.get_name models__097_ (0 + shift)) (Util.Pp.pp_char true)
+            a_4
       | (Mem a_5, Res ((Bool, _), _)) ->
           let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "mem"
-            (SUT.get_name state__097_ (0 + shift)) (Util.Pp.pp_char true) a_5
+            (Model.get_name models__097_ (0 + shift)) (Util.Pp.pp_char true)
+            a_5
       | (Remove a_6, Res ((Unit, _), _)) ->
           let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "remove"
-            (SUT.get_name state__097_ (0 + shift)) (Util.Pp.pp_char true) a_6
+            (Model.get_name models__097_ (0 + shift)) (Util.Pp.pp_char true)
+            a_6
       | (Replace (a_7, b_2), Res ((Unit, _), _)) ->
           let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a %a" lhs "replace"
-            (SUT.get_name state__097_ (0 + shift)) (Util.Pp.pp_char true) a_7
-            (Util.Pp.pp_int true) b_2
+            (Model.get_name models__097_ (0 + shift)) (Util.Pp.pp_char true)
+            a_7 (Util.Pp.pp_int true) b_2
       | (Filter_map_inplace f, Res ((Unit, _), _)) ->
           let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "filter_map_inplace"
-            (Util.Pp.pp_fun_ true) f (SUT.get_name state__097_ (0 + shift))
+            (Util.Pp.pp_fun_ true) f
+            (Model.get_name models__097_ (0 + shift))
       | (Length, Res ((Int, _), _)) ->
           let lhs = if last__099_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "length"
-            (SUT.get_name state__097_ (0 + shift))
+            (Model.get_name models__097_ (0 + shift))
       | _ -> assert false
 let ortac_postcond cmd__032_ state__033_ res__034_ =
   let open Spec in

--- a/plugins/qcheck-stm/test/integer_in_model_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/integer_in_model_stm_tests.expected.ml
@@ -145,12 +145,12 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__021_ state__022_ last__024_ res__023_ =
+let ortac_show_cmd cmd__021_ models__022_ last__024_ res__023_ =
   let open Spec in
     let open STM in
       match (cmd__021_, res__023_) with
       | (Create (), Res ((SUT, _), t_1)) ->
-          let lhs = if last__024_ then "r" else SUT.get_name state__022_ 0
+          let lhs = if last__024_ then "r" else Model.get_name models__022_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "create"
             (Util.Pp.pp_unit true) ()
@@ -158,7 +158,7 @@ let ortac_show_cmd cmd__021_ state__022_ last__024_ res__023_ =
           let lhs = if last__024_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "use"
-            (SUT.get_name state__022_ (0 + shift))
+            (Model.get_name models__022_ (0 + shift))
       | _ -> assert false
 let ortac_postcond cmd__008_ state__009_ res__010_ =
   let open Spec in

--- a/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
@@ -394,12 +394,12 @@ let check_init_state () =
                       }
                   })))
   then QCheck.Test.fail_report "INIT_SUT violates type invariants for SUT"
-let ortac_show_cmd cmd__060_ state__061_ last__063_ res__062_ =
+let ortac_show_cmd cmd__060_ models__061_ last__063_ res__062_ =
   let open Spec in
     let open STM in
       match (cmd__060_, res__062_) with
       | (Create a_1, Res ((SUT, _), t_1)) ->
-          let lhs = if last__063_ then "r" else SUT.get_name state__061_ 0
+          let lhs = if last__063_ then "r" else Model.get_name models__061_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "create" (Util.Pp.pp_int true)
             a_1
@@ -407,29 +407,30 @@ let ortac_show_cmd cmd__060_ state__061_ last__063_ res__062_ =
           let lhs = if last__063_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "push"
-            (Util.Pp.pp_int true) a_2 (SUT.get_name state__061_ (0 + shift))
+            (Util.Pp.pp_int true) a_2
+            (Model.get_name models__061_ (0 + shift))
       | (Transfer, Res ((Unit, _), _)) ->
           let lhs = if last__063_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %s" lhs "transfer"
-            (SUT.get_name state__061_ (0 + shift))
-            (SUT.get_name state__061_ (1 + shift))
+            (Model.get_name models__061_ (0 + shift))
+            (Model.get_name models__061_ (1 + shift))
       | (Copy, Res ((SUT, _), r)) ->
-          let lhs = if last__063_ then "r" else SUT.get_name state__061_ 0
+          let lhs = if last__063_ then "r" else Model.get_name models__061_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s" lhs "copy"
-            (SUT.get_name state__061_ (0 + shift))
+            (Model.get_name models__061_ (0 + shift))
       | (Sub (i, n), Res ((Result (SUT, Exn), _), r_1)) ->
           let lhs =
             if last__063_
             then "r"
             else
               (match r_1 with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__061_ 0)
+               | Ok _ -> "Ok " ^ (Model.get_name models__061_ 0)
                | Error _ -> "_")
           and shift = match r_1 with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s %a %a)" lhs
-            "sub" (SUT.get_name state__061_ (0 + shift))
+            "sub" (Model.get_name models__061_ (0 + shift))
             (Util.Pp.pp_int true) i (Util.Pp.pp_int true) n
       | _ -> assert false
 let ortac_postcond cmd__024_ state__025_ res__026_ =

--- a/plugins/qcheck-stm/test/module_prefix_tests.expected.ml
+++ b/plugins/qcheck-stm/test/module_prefix_tests.expected.ml
@@ -107,12 +107,12 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__016_ state__017_ last__019_ res__018_ =
+let ortac_show_cmd cmd__016_ models__017_ last__019_ res__018_ =
   let open Spec in
     let open STM in
       match (cmd__016_, res__018_) with
       | (Make a_1, Res ((SUT, _), t_1)) ->
-          let lhs = if last__019_ then "r" else SUT.get_name state__017_ 0
+          let lhs = if last__019_ then "r" else Model.get_name models__017_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "make" (Util.Pp.pp_int true)
             a_1

--- a/plugins/qcheck-stm/test/queue_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/queue_stm_tests.expected.ml
@@ -565,12 +565,12 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__141_ state__142_ last__144_ res__143_ =
+let ortac_show_cmd cmd__141_ models__142_ last__144_ res__143_ =
   let open Spec in
     let open STM in
       match (cmd__141_, res__143_) with
       | (Create (), Res ((SUT, _), t_1)) ->
-          let lhs = if last__144_ then "r" else SUT.get_name state__142_ 0
+          let lhs = if last__144_ then "r" else Model.get_name models__142_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "create"
             (Util.Pp.pp_unit true) ()
@@ -578,68 +578,69 @@ let ortac_show_cmd cmd__141_ state__142_ last__144_ res__143_ =
           let lhs = if last__144_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "add" (Util.Pp.pp_int true)
-            v (SUT.get_name state__142_ (0 + shift))
+            v (Model.get_name models__142_ (0 + shift))
       | (Push v_1, Res ((Unit, _), _)) ->
           let lhs = if last__144_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "push"
-            (Util.Pp.pp_int true) v_1 (SUT.get_name state__142_ (0 + shift))
+            (Util.Pp.pp_int true) v_1
+            (Model.get_name models__142_ (0 + shift))
       | (Take, Res ((Result (Int, Exn), _), _)) ->
           let lhs = if last__144_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "take"
-            (SUT.get_name state__142_ (0 + shift))
+            (Model.get_name models__142_ (0 + shift))
       | (Take_opt, Res ((Option (Int), _), _)) ->
           let lhs = if last__144_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "take_opt"
-            (SUT.get_name state__142_ (0 + shift))
+            (Model.get_name models__142_ (0 + shift))
       | (Pop, Res ((Result (Int, Exn), _), _)) ->
           let lhs = if last__144_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "pop"
-            (SUT.get_name state__142_ (0 + shift))
+            (Model.get_name models__142_ (0 + shift))
       | (Peek, Res ((Result (Int, Exn), _), _)) ->
           let lhs = if last__144_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "peek"
-            (SUT.get_name state__142_ (0 + shift))
+            (Model.get_name models__142_ (0 + shift))
       | (Top, Res ((Result (Int, Exn), _), _)) ->
           let lhs = if last__144_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "top"
-            (SUT.get_name state__142_ (0 + shift))
+            (Model.get_name models__142_ (0 + shift))
       | (Peek_opt, Res ((Option (Int), _), _)) ->
           let lhs = if last__144_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "peek_opt"
-            (SUT.get_name state__142_ (0 + shift))
+            (Model.get_name models__142_ (0 + shift))
       | (Clear, Res ((Unit, _), _)) ->
           let lhs = if last__144_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "clear"
-            (SUT.get_name state__142_ (0 + shift))
+            (Model.get_name models__142_ (0 + shift))
       | (Copy, Res ((SUT, _), r)) ->
-          let lhs = if last__144_ then "r" else SUT.get_name state__142_ 0
+          let lhs = if last__144_ then "r" else Model.get_name models__142_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s" lhs "copy"
-            (SUT.get_name state__142_ (0 + shift))
+            (Model.get_name models__142_ (0 + shift))
       | (Is_empty, Res ((Bool, _), _)) ->
           let lhs = if last__144_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "is_empty"
-            (SUT.get_name state__142_ (0 + shift))
+            (Model.get_name models__142_ (0 + shift))
       | (Length, Res ((Int, _), _)) ->
           let lhs = if last__144_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "length"
-            (SUT.get_name state__142_ (0 + shift))
+            (Model.get_name models__142_ (0 + shift))
       | (Transfer, Res ((Unit, _), _)) ->
           let lhs = if last__144_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %s" lhs "transfer"
-            (SUT.get_name state__142_ (0 + shift))
-            (SUT.get_name state__142_ (1 + shift))
+            (Model.get_name models__142_ (0 + shift))
+            (Model.get_name models__142_ (1 + shift))
       | _ -> assert false
 let ortac_postcond cmd__038_ state__039_ res__040_ =
   let open Spec in

--- a/plugins/qcheck-stm/test/record_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/record_stm_tests.expected.ml
@@ -161,12 +161,12 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__037_ state__038_ last__040_ res__039_ =
+let ortac_show_cmd cmd__037_ models__038_ last__040_ res__039_ =
   let open Spec in
     let open STM in
       match (cmd__037_, res__039_) with
       | (Make i_1, Res ((SUT, _), r)) ->
-          let lhs = if last__040_ then "r" else SUT.get_name state__038_ 0
+          let lhs = if last__040_ then "r" else Model.get_name models__038_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "make" (Util.Pp.pp_int true)
             i_1
@@ -184,7 +184,7 @@ let ortac_show_cmd cmd__037_ state__038_ last__040_ res__039_ =
           let lhs = if last__040_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "get"
-            (SUT.get_name state__038_ (0 + shift))
+            (Model.get_name models__038_ (0 + shift))
       | _ -> assert false
 let ortac_postcond cmd__008_ state__009_ res__010_ =
   let open Spec in

--- a/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
@@ -205,29 +205,30 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__035_ state__036_ last__038_ res__037_ =
+let ortac_show_cmd cmd__035_ models__036_ last__038_ res__037_ =
   let open Spec in
     let open STM in
       match (cmd__035_, res__037_) with
       | (Make v, Res ((SUT, _), r)) ->
-          let lhs = if last__038_ then "r" else SUT.get_name state__036_ 0
+          let lhs = if last__038_ then "r" else Model.get_name models__036_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "make" (Util.Pp.pp_int true) v
       | (Get, Res ((Int, _), _)) ->
           let lhs = if last__038_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "get"
-            (SUT.get_name state__036_ (0 + shift))
+            (Model.get_name models__036_ (0 + shift))
       | (Set v_1, Res ((Unit, _), _)) ->
           let lhs = if last__038_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "set"
-            (SUT.get_name state__036_ (0 + shift)) (Util.Pp.pp_int true) v_1
+            (Model.get_name models__036_ (0 + shift)) (Util.Pp.pp_int true)
+            v_1
       | (Incr, Res ((Unit, _), _)) ->
           let lhs = if last__038_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "incr"
-            (SUT.get_name state__036_ (0 + shift))
+            (Model.get_name models__036_ (0 + shift))
       | _ -> assert false
 let ortac_postcond cmd__012_ state__013_ res__014_ =
   let open Spec in

--- a/plugins/qcheck-stm/test/sequence_model_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/sequence_model_stm_tests.expected.ml
@@ -272,12 +272,12 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__033_ state__034_ last__036_ res__035_ =
+let ortac_show_cmd cmd__033_ models__034_ last__036_ res__035_ =
   let open Spec in
     let open STM in
       match (cmd__033_, res__035_) with
       | (Create (), Res ((SUT, _), t_1)) ->
-          let lhs = if last__036_ then "r" else SUT.get_name state__034_ 0
+          let lhs = if last__036_ then "r" else Model.get_name models__034_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "create"
             (Util.Pp.pp_unit true) ()
@@ -285,17 +285,18 @@ let ortac_show_cmd cmd__033_ state__034_ last__036_ res__035_ =
           let lhs = if last__036_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "add"
-            (Util.Pp.pp_char true) v (SUT.get_name state__034_ (0 + shift))
+            (Util.Pp.pp_char true) v
+            (Model.get_name models__034_ (0 + shift))
       | (Remove, Res ((Option (Char), _), _)) ->
           let lhs = if last__036_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "remove"
-            (SUT.get_name state__034_ (0 + shift))
+            (Model.get_name models__034_ (0 + shift))
       | (Remove_, Res ((Option (Char), _), _)) ->
           let lhs = if last__036_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "remove_"
-            (SUT.get_name state__034_ (0 + shift))
+            (Model.get_name models__034_ (0 + shift))
       | _ -> assert false
 let ortac_postcond cmd__014_ state__015_ res__016_ =
   let open Spec in

--- a/plugins/qcheck-stm/test/stack_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/stack_stm_tests.expected.ml
@@ -370,12 +370,12 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__088_ state__089_ last__091_ res__090_ =
+let ortac_show_cmd cmd__088_ models__089_ last__091_ res__090_ =
   let open Spec in
     let open STM in
       match (cmd__088_, res__090_) with
       | (Create (), Res ((SUT, _), t_1)) ->
-          let lhs = if last__091_ then "r" else SUT.get_name state__089_ 0
+          let lhs = if last__091_ then "r" else Model.get_name models__089_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "create"
             (Util.Pp.pp_unit true) ()
@@ -383,42 +383,43 @@ let ortac_show_cmd cmd__088_ state__089_ last__091_ res__090_ =
           let lhs = if last__091_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %a %s" lhs "push"
-            (Util.Pp.pp_char true) v (SUT.get_name state__089_ (0 + shift))
+            (Util.Pp.pp_char true) v
+            (Model.get_name models__089_ (0 + shift))
       | (Pop, Res ((Result (Char, Exn), _), _)) ->
           let lhs = if last__091_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "pop"
-            (SUT.get_name state__089_ (0 + shift))
+            (Model.get_name models__089_ (0 + shift))
       | (Pop_opt, Res ((Option (Char), _), _)) ->
           let lhs = if last__091_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "pop_opt"
-            (SUT.get_name state__089_ (0 + shift))
+            (Model.get_name models__089_ (0 + shift))
       | (Top, Res ((Result (Char, Exn), _), _)) ->
           let lhs = if last__091_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = protect (fun () -> %s %s)" lhs "top"
-            (SUT.get_name state__089_ (0 + shift))
+            (Model.get_name models__089_ (0 + shift))
       | (Top_opt, Res ((Option (Char), _), _)) ->
           let lhs = if last__091_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "top_opt"
-            (SUT.get_name state__089_ (0 + shift))
+            (Model.get_name models__089_ (0 + shift))
       | (Clear, Res ((Unit, _), _)) ->
           let lhs = if last__091_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "clear"
-            (SUT.get_name state__089_ (0 + shift))
+            (Model.get_name models__089_ (0 + shift))
       | (Copy, Res ((SUT, _), r)) ->
-          let lhs = if last__091_ then "r" else SUT.get_name state__089_ 0
+          let lhs = if last__091_ then "r" else Model.get_name models__089_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %s" lhs "copy"
-            (SUT.get_name state__089_ (0 + shift))
+            (Model.get_name models__089_ (0 + shift))
       | (Is_empty, Res ((Bool, _), _)) ->
           let lhs = if last__091_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "is_empty"
-            (SUT.get_name state__089_ (0 + shift))
+            (Model.get_name models__089_ (0 + shift))
       | _ -> assert false
 let ortac_postcond cmd__024_ state__025_ res__026_ =
   let open Spec in

--- a/plugins/qcheck-stm/test/submodule_and_prefix_tests.expected.ml
+++ b/plugins/qcheck-stm/test/submodule_and_prefix_tests.expected.ml
@@ -107,12 +107,12 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__016_ state__017_ last__019_ res__018_ =
+let ortac_show_cmd cmd__016_ models__017_ last__019_ res__018_ =
   let open Spec in
     let open STM in
       match (cmd__016_, res__018_) with
       | (Make a_1, Res ((SUT, _), t_1)) ->
-          let lhs = if last__019_ then "r" else SUT.get_name state__017_ 0
+          let lhs = if last__019_ then "r" else Model.get_name models__017_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "make" (Util.Pp.pp_int true)
             a_1

--- a/plugins/qcheck-stm/test/submodule_tests.expected.ml
+++ b/plugins/qcheck-stm/test/submodule_tests.expected.ml
@@ -107,12 +107,12 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__016_ state__017_ last__019_ res__018_ =
+let ortac_show_cmd cmd__016_ models__017_ last__019_ res__018_ =
   let open Spec in
     let open STM in
       match (cmd__016_, res__018_) with
       | (Make a_1, Res ((SUT, _), t_1)) ->
-          let lhs = if last__019_ then "r" else SUT.get_name state__017_ 0
+          let lhs = if last__019_ then "r" else Model.get_name models__017_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "make" (Util.Pp.pp_int true)
             a_1

--- a/plugins/qcheck-stm/test/sut_in_type_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/sut_in_type_stm_tests.expected.ml
@@ -135,7 +135,7 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__016_ state__017_ last__019_ res__018_ =
+let ortac_show_cmd cmd__016_ models__017_ last__019_ res__018_ =
   let open Spec in
     let open STM in
       match (cmd__016_, res__018_) with
@@ -145,7 +145,7 @@ let ortac_show_cmd cmd__016_ state__017_ last__019_ res__018_ =
             then "r"
             else
               (match t_1 with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__017_ 0)
+               | Ok _ -> "Ok " ^ (Model.get_name models__017_ 0)
                | Error _ -> "_")
           and shift = match t_1 with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %a %a)" lhs "make"

--- a/plugins/qcheck-stm/test/test_cleanup_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/test_cleanup_stm_tests.expected.ml
@@ -148,12 +148,12 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__021_ state__022_ last__024_ res__023_ =
+let ortac_show_cmd cmd__021_ models__022_ last__024_ res__023_ =
   let open Spec in
     let open STM in
       match (cmd__021_, res__023_) with
       | (Create (), Res ((SUT, _), t_1)) ->
-          let lhs = if last__024_ then "r" else SUT.get_name state__022_ 0
+          let lhs = if last__024_ then "r" else Model.get_name models__022_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "create"
             (Util.Pp.pp_unit true) ()
@@ -161,7 +161,7 @@ let ortac_show_cmd cmd__021_ state__022_ last__024_ res__023_ =
           let lhs = if last__024_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "use"
-            (SUT.get_name state__022_ (0 + shift))
+            (Model.get_name models__022_ (0 + shift))
       | _ -> assert false
 let ortac_postcond cmd__008_ state__009_ res__010_ =
   let open Spec in

--- a/plugins/qcheck-stm/test/test_without_sut_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/test_without_sut_stm_tests.expected.ml
@@ -142,7 +142,7 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__017_ state__018_ last__020_ res__019_ =
+let ortac_show_cmd cmd__017_ models__018_ last__020_ res__019_ =
   let open Spec in
     let open STM in
       match (cmd__017_, res__019_) with
@@ -152,7 +152,7 @@ let ortac_show_cmd cmd__017_ state__018_ last__020_ res__019_ =
             then "r"
             else
               (match t_1 with
-               | Ok _ -> "Ok " ^ (SUT.get_name state__018_ 0)
+               | Ok _ -> "Ok " ^ (Model.get_name models__018_ 0)
                | Error _ -> "_")
           and shift = match t_1 with | Ok _ -> 1 | Error _ -> 0 in
           Format.asprintf "let %s = protect (fun () -> %s %a %a)" lhs "make"

--- a/plugins/qcheck-stm/test/tuples_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/tuples_stm_tests.expected.ml
@@ -339,12 +339,12 @@ module Spec =
   end
 module STMTests = (Ortac_runtime.Make)(Spec)
 let check_init_state () = ()
-let ortac_show_cmd cmd__056_ state__057_ last__059_ res__058_ =
+let ortac_show_cmd cmd__056_ models__057_ last__059_ res__058_ =
   let open Spec in
     let open STM in
       match (cmd__056_, res__058_) with
       | (Create (), Res ((SUT, _), h)) ->
-          let lhs = if last__059_ then "r" else SUT.get_name state__057_ 0
+          let lhs = if last__059_ then "r" else Model.get_name models__057_ 0
           and shift = 1 in
           Format.asprintf "let %s = %s %a" lhs "create"
             (Util.Pp.pp_unit true) ()
@@ -352,37 +352,37 @@ let ortac_show_cmd cmd__056_ state__057_ last__059_ res__058_ =
           let lhs = if last__059_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "clear"
-            (SUT.get_name state__057_ (0 + shift))
+            (Model.get_name models__057_ (0 + shift))
       | (Add tup, Res ((Unit, _), _)) ->
           let lhs = if last__059_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "add"
-            (SUT.get_name state__057_ (0 + shift))
+            (Model.get_name models__057_ (0 + shift))
             (Util.Pp.pp_tuple2 Util.Pp.pp_char Util.Pp.pp_int true) tup
       | (Add' tup_1, Res ((Unit, _), _)) ->
           let lhs = if last__059_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "add'"
-            (SUT.get_name state__057_ (0 + shift))
+            (Model.get_name models__057_ (0 + shift))
             (Util.Pp.pp_tuple3 Util.Pp.pp_bool Util.Pp.pp_char Util.Pp.pp_int
                true) tup_1
       | (Add'' tup_2, Res ((Unit, _), _)) ->
           let lhs = if last__059_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s %a" lhs "add''"
-            (SUT.get_name state__057_ (0 + shift))
+            (Model.get_name models__057_ (0 + shift))
             (Util.Pp.pp_tuple2 Util.Pp.pp_bool
                (Util.Pp.pp_tuple2 Util.Pp.pp_char Util.Pp.pp_int) true) tup_2
       | (Size_tup, Res ((Tup2 (Int, Int), _), _)) ->
           let lhs = if last__059_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "size_tup"
-            (SUT.get_name state__057_ (0 + shift))
+            (Model.get_name models__057_ (0 + shift))
       | (Size_tup', Res ((Tup3 (Int, Int, Int), _), _)) ->
           let lhs = if last__059_ then "r" else "_"
           and shift = 0 in
           Format.asprintf "let %s = %s %s" lhs "size_tup'"
-            (SUT.get_name state__057_ (0 + shift))
+            (Model.get_name models__057_ (0 + shift))
       | _ -> assert false
 let ortac_postcond cmd__018_ state__019_ res__020_ =
   let open Spec in


### PR DESCRIPTION
This PR proposes to make `ortac_show_cmd` look at the functional models rather than the mutable SUT store in order to compute the name of the SUT-arguments in a function call.

This will allow for an easier way of using the function in a parallel setting.