### PR TITLE
[QCheck-STM+Dune] Add count optional argument

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- [QCheck-STM+Dune] Add count optional argument
+  [\#357](https://github.com/ocaml-gospel/ortac/pull/354)
 - [Dune] Add optional arguments to control aliases
   [\#354](https://github.com/ocaml-gospel/ortac/pull/354)
 - [QCheck-STM] Add domain bug report generation

--- a/examples/dune
+++ b/examples/dune
@@ -112,6 +112,7 @@
      treiber_stack_spec.mli
      --package=ortac-examples
      --domain
+     --count=500
      --run-alias=launchtests)))))
 
 (include dune.treiber_stack.inc)

--- a/examples/dune.lwt_dllist.inc
+++ b/examples/dune.lwt_dllist.inc
@@ -19,7 +19,8 @@
      qcheck-stm
      %{dep:lwt_dllist_spec.mli}
      %{dep:lwt_dllist_spec_config.ml}
-     --quiet)))))
+     --quiet
+     --count=1000)))))
 
 (executable
  (name lwt_dllist_spec_tests)

--- a/examples/dune.treiber_stack.inc
+++ b/examples/dune.treiber_stack.inc
@@ -20,6 +20,7 @@
      %{dep:treiber_stack_spec.mli}
      %{dep:treiber_stack_spec_config.ml}
      --quiet
+     --count=1000
      --domain)))))
 
 (executable

--- a/examples/dune.treiber_stack.inc
+++ b/examples/dune.treiber_stack.inc
@@ -20,7 +20,7 @@
      %{dep:treiber_stack_spec.mli}
      %{dep:treiber_stack_spec_config.ml}
      --quiet
-     --count=1000
+     --count=500
      --domain)))))
 
 (executable

--- a/examples/dune.varray_circular.inc
+++ b/examples/dune.varray_circular.inc
@@ -19,7 +19,8 @@
      qcheck-stm
      %{dep:varray_circular_spec.mli}
      %{dep:varray_circular_spec_config.ml}
-     --quiet)))))
+     --quiet
+     --count=1000)))))
 
 (executable
  (name varray_circular_spec_tests)

--- a/examples/treiber_stack_spec_tests.ml
+++ b/examples/treiber_stack_spec_tests.ml
@@ -598,6 +598,6 @@ let ortac_postcond cmd__020_ state__021_ res__022_ =
       | _ -> None
 let _ =
   QCheck_base_runner.run_tests_main
-    (let count = 1000 in
+    (let count = 500 in
      [STMTests.agree_test ~count ~name:"Treiber_stack_spec STM tests" 1
         check_init_state ortac_show_cmd ortac_postcond])

--- a/plugins/dune-rules/src/dune_rules.ml
+++ b/plugins/dune-rules/src/dune_rules.ml
@@ -106,6 +106,14 @@ end = struct
       Arg.(
         value & flag & info [ "d"; "domain" ] ~doc:"Generate STM_domain tests.")
 
+    let count =
+      let parse i = Ok (int_of_string i) and docv = "COUNT" in
+      Arg.(
+        value
+        & opt (conv ~docv (parse, Fmt.(int))) 1000
+        & info [ "count" ] ~absent:"1000"
+            ~doc:"Build STM tests with COUNT test iterations.")
+
     let fork_timeout =
       Arg.(
         value
@@ -113,7 +121,7 @@ end = struct
         & info [ "t"; "timeout" ] ~doc:"Timeout for each test." ~docv:"TIMEOUT")
 
     let main interface_file config_file ocaml_output library package_name
-        dune_output module_prefix submodule domain fork_timeout gen_alias
+        dune_output module_prefix submodule domain count fork_timeout gen_alias
         run_alias =
       let open Qcheck_stm in
       let config =
@@ -127,6 +135,7 @@ end = struct
           module_prefix;
           submodule;
           domain;
+          count;
           fork_timeout;
           gen_alias;
           run_alias;
@@ -147,6 +156,7 @@ end = struct
         $ module_prefix
         $ submodule
         $ domain
+        $ count
         $ fork_timeout
         $ gen_alias
         $ run_alias)

--- a/plugins/dune-rules/src/qcheck_stm.ml
+++ b/plugins/dune-rules/src/qcheck_stm.ml
@@ -72,6 +72,7 @@ let module_prefix =
 
 let submodule = optional_argument "--submodule" (fun cfg -> cfg.submodule)
 let domain cfg = if cfg.domain then [ (fun ppf _ -> pf ppf "--domain") ] else []
+let count cfg ppf _ = pf ppf "--count=%i" cfg.count
 
 let gen_alias config =
   let alias = Option.value config.gen_alias ~default:"runtest" in
@@ -88,6 +89,7 @@ let gen_ortac_rule ppf config =
     :: dep interface
     :: dep config_file
     :: quiet
+    :: count config
     :: module_prefix config
     @ domain config
     @ submodule config

--- a/plugins/dune-rules/src/qcheck_stm.ml
+++ b/plugins/dune-rules/src/qcheck_stm.ml
@@ -10,6 +10,7 @@ type config = {
   module_prefix : string option;
   submodule : string option;
   domain : bool;
+  count : int;
   fork_timeout : int option;
   gen_alias : string option;
   run_alias : string option;

--- a/plugins/dune-rules/src/qcheck_stm.mli
+++ b/plugins/dune-rules/src/qcheck_stm.mli
@@ -8,6 +8,7 @@ type config = {
   module_prefix : string option;
   submodule : string option;
   domain : bool;
+  count : int;
   fork_timeout : int option;
   gen_alias : string option;
   run_alias : string option;

--- a/plugins/dune-rules/test/test.t
+++ b/plugins/dune-rules/test/test.t
@@ -30,6 +30,7 @@ generated.
        %{dep:intf_spec.mli}
        %{dep:intf_spec_config.ml}
        --quiet
+       --count=1000
        --module-prefix=PrefixLib
        --submodule=M)))))
   
@@ -78,7 +79,8 @@ When the optional output argument is set, rules will be written in the file.
        qcheck-stm
        %{dep:intf_spec.mli}
        %{dep:intf_spec_config.ml}
-       --quiet)))))
+       --quiet
+       --count=1000)))))
   
   (executable
    (name intf_spec_tests)
@@ -124,7 +126,8 @@ Specifying a timeout causes ORTAC_QCHECK_STM_TIMEOUT to be set before running th
        qcheck-stm
        %{dep:intf_spec.mli}
        %{dep:intf_spec_config.ml}
-       --quiet)))))
+       --quiet
+       --count=1000)))))
   
   (executable
    (name intf_spec_tests)
@@ -171,6 +174,7 @@ Specifying a timeout causes ORTAC_QCHECK_STM_TIMEOUT to be set before running th
        %{dep:intf_spec.mli}
        %{dep:intf_spec_config.ml}
        --quiet
+       --count=1000
        --domain)))))
   
   (executable
@@ -259,6 +263,7 @@ The following Dune files are tested to ensure it produces correct files.
        %{dep:intf_spec.mli}
        %{dep:intf_spec_config.ml}
        --quiet
+       --count=1000
        --domain)))))
   
   (executable

--- a/plugins/qcheck-stm/src/config.ml
+++ b/plugins/qcheck-stm/src/config.ml
@@ -33,6 +33,7 @@ type t = {
   module_prefix : string option;
   submodule : string option;
   domain : bool;
+  count : int;
 }
 
 let mk_config context module_prefix submodule domain cfg_uc =
@@ -64,6 +65,7 @@ let mk_config context module_prefix submodule domain cfg_uc =
       module_prefix;
       submodule;
       domain;
+      count = 1000;
     }
 
 let get_sut_type_name config =

--- a/plugins/qcheck-stm/src/config.ml
+++ b/plugins/qcheck-stm/src/config.ml
@@ -36,7 +36,7 @@ type t = {
   count : int;
 }
 
-let mk_config context module_prefix submodule domain cfg_uc =
+let mk_config context module_prefix submodule domain count cfg_uc =
   let open Reserr in
   let* sut_core_type =
     of_option
@@ -65,7 +65,7 @@ let mk_config context module_prefix submodule domain cfg_uc =
       module_prefix;
       submodule;
       domain;
-      count = 1000;
+      count;
     }
 
 let get_sut_type_name config =
@@ -234,7 +234,7 @@ let scan_config cfg_uc config_mod =
   in
   fold_left aux cfg_uc ast
 
-let init gospel config_module module_prefix submodule domain =
+let init gospel config_module module_prefix submodule domain count =
   let open Reserr in
   try
     let module_name = Utils.module_name_of_path gospel in
@@ -257,7 +257,7 @@ let init gospel config_module module_prefix submodule domain =
     let context = List.fold_left add context sigs in
     let* config =
       scan_config config_under_construction config_module
-      >>= mk_config context module_prefix submodule domain
+      >>= mk_config context module_prefix submodule domain count
     in
     ok (sigs, config)
   with Gospel.Warnings.Error (l, k) ->

--- a/plugins/qcheck-stm/src/ortac_qcheck_stm.ml
+++ b/plugins/qcheck-stm/src/ortac_qcheck_stm.ml
@@ -4,13 +4,13 @@ module Ir_of_gospel = Ir_of_gospel
 module Reserr = Reserr
 module Stm_of_ir = Stm_of_ir
 
-let main path config output module_prefix submodule domain quiet () =
+let main path config output module_prefix submodule domain quiet count () =
   let open Reserr in
   let fmt = Registration.get_out_formatter output in
   let pp = pp quiet Ppxlib_ast.Pprintast.structure fmt in
   pp
     (let* sigs, config =
-       Config.init path config module_prefix submodule domain
+       Config.init path config module_prefix submodule domain count
      in
      let* ir = Ir_of_gospel.run sigs config in
      Stm_of_ir.stm config ir)
@@ -56,6 +56,14 @@ end = struct
     Arg.(
       value & flag & info [ "d"; "domain" ] ~doc:"Generate STM_domain tests.")
 
+  let count =
+    let parse i = Ok (int_of_string i) and docv = "COUNT" in
+    Arg.(
+      value
+      & opt (conv ~docv (parse, Fmt.(int))) 1000
+      & info [ "count" ] ~absent:"1000"
+          ~doc:"Build STM tests with COUNT test iterations.")
+
   let term =
     let open Registration in
     Term.(
@@ -67,6 +75,7 @@ end = struct
       $ submodule
       $ domain
       $ quiet
+      $ count
       $ setup_log)
 
   let cmd = Cmd.v info term

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -1765,7 +1765,7 @@ let stm config ir =
     [%stri
       let _ =
         QCheck_base_runner.run_tests_main
-          (let count = 1000 in
+          (let count = [%e eint config.count] in
            [
              STMTests.agree_test ~count ~name:[%e descr] [%e eint max_suts]
                check_init_state ortac_show_cmd ortac_postcond;


### PR DESCRIPTION
This PR proposes to add a `--count` optional argument to the `ortac qcheck-stm` and the `ortac dune qcheck-stm` sub-commands.

The default value is set to 1000, which is the value that was hard-coded before.

There is one UX decision that could be argued against: in the absence of the `--count` argument in the `ortac dune qcheck-stm` sub-command, the default value is explicitly given to the `ortac qcheck-stm` sub-command in the generated dune rules.
