### PR TITLE
[QCheck-STM] Allow for user defined frequencies in generated `arb_cmd`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
 # Unreleased
 
+- [QCheck-STM] Allow for user defined frequencies in generated `arb_cmd`
+  [\#358](https://github.com/ocaml-gospel/ortac/pull/358)
 - [QCheck-STM+Dune] Add count optional argument
-  [\#357](https://github.com/ocaml-gospel/ortac/pull/354)
+  [\#357](https://github.com/ocaml-gospel/ortac/pull/357)
 - [Dune] Add optional arguments to control aliases
   [\#354](https://github.com/ocaml-gospel/ortac/pull/354)
 - [QCheck-STM] Add domain bug report generation

--- a/examples/lwt_dllist_spec_tests.ml
+++ b/examples/lwt_dllist_spec_tests.ml
@@ -88,17 +88,17 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [(pure (fun () -> Create ())) <*> unit;
-               pure Clear;
-               pure Is_empty;
-               pure Length;
-               (pure (fun a_1 -> Add_l a_1)) <*> int;
-               (pure (fun a_2 -> Add_r a_2)) <*> int;
-               pure Take_l;
-               pure Take_r;
-               pure Take_opt_l;
-               pure Take_opt_r])
+             frequency
+               [(1, ((pure (fun () -> Create ())) <*> unit));
+               (1, (pure Clear));
+               (1, (pure Is_empty));
+               (1, (pure Length));
+               (1, ((pure (fun a_1 -> Add_l a_1)) <*> int));
+               (1, ((pure (fun a_2 -> Add_r a_2)) <*> int));
+               (1, (pure Take_l));
+               (1, (pure Take_r));
+               (1, (pure Take_opt_l));
+               (1, (pure Take_opt_r))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Create () ->

--- a/examples/treiber_stack_spec_tests.ml
+++ b/examples/treiber_stack_spec_tests.ml
@@ -112,15 +112,16 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [(pure (fun () -> Create ())) <*> unit;
-               (pure (fun xs -> Of_list xs)) <*> (list small_signed_int);
-               pure Is_empty;
-               pure Peek_opt;
-               pure Pop_opt;
-               pure Pop_all;
-               (pure (fun x -> Push x)) <*> int;
-               (pure (fun xs_1 -> Push_all xs_1)) <*> (list int)])
+             frequency
+               [(1, ((pure (fun () -> Create ())) <*> unit));
+               (1,
+                 ((pure (fun xs -> Of_list xs)) <*> (list small_signed_int)));
+               (1, (pure Is_empty));
+               (1, (pure Peek_opt));
+               (1, (pure Pop_opt));
+               (1, (pure Pop_all));
+               (1, ((pure (fun x -> Push x)) <*> int));
+               (1, ((pure (fun xs_1 -> Push_all xs_1)) <*> (list int)))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Create () ->

--- a/examples/varray_circular_spec_tests.ml
+++ b/examples/varray_circular_spec_tests.ml
@@ -200,40 +200,47 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [(pure (fun x -> Push_back x)) <*> (elt char);
-               pure Pop_back;
-               (pure (fun x_1 -> Push_front x_1)) <*> (elt char);
-               pure Pop_front;
-               ((pure (fun i_1 -> fun x_2 -> Insert_at (i_1, x_2))) <*> int)
-                 <*> (elt char);
-               (pure (fun i_2 -> Pop_at i_2)) <*> int;
-               (pure (fun i_3 -> Delete_at i_3)) <*> int;
-               (pure (fun i_4 -> Get i_4)) <*> int;
-               ((pure (fun i_5 -> fun v -> Set (i_5, v))) <*> int) <*>
-                 (elt char);
-               pure Length;
-               ((pure (fun n -> fun x_3 -> Make (n, x_3))) <*>
-                  small_signed_int)
-                 <*> (elt char);
-               (pure (fun () -> Empty ())) <*> unit;
-               pure Is_empty;
-               pure Append;
-               ((pure (fun i_6 -> fun n_1 -> Sub (i_6, n_1))) <*> int) <*>
-                 int;
-               pure Copy;
-               (((pure
-                    (fun pos -> fun len -> fun x_4 -> Fill (pos, len, x_4)))
-                   <*> int)
-                  <*> int)
-                 <*> (elt char);
-               (((pure
-                    (fun src_pos ->
-                       fun dst_pos ->
-                         fun len_1 -> Blit (src_pos, dst_pos, len_1)))
-                   <*> int)
-                  <*> int)
-                 <*> int])
+             frequency
+               [(1, ((pure (fun x -> Push_back x)) <*> (elt char)));
+               (1, (pure Pop_back));
+               (1, ((pure (fun x_1 -> Push_front x_1)) <*> (elt char)));
+               (1, (pure Pop_front));
+               (1,
+                 (((pure (fun i_1 -> fun x_2 -> Insert_at (i_1, x_2))) <*>
+                     int)
+                    <*> (elt char)));
+               (1, ((pure (fun i_2 -> Pop_at i_2)) <*> int));
+               (1, ((pure (fun i_3 -> Delete_at i_3)) <*> int));
+               (1, ((pure (fun i_4 -> Get i_4)) <*> int));
+               (1,
+                 (((pure (fun i_5 -> fun v -> Set (i_5, v))) <*> int) <*>
+                    (elt char)));
+               (1, (pure Length));
+               (1,
+                 (((pure (fun n -> fun x_3 -> Make (n, x_3))) <*>
+                     small_signed_int)
+                    <*> (elt char)));
+               (1, ((pure (fun () -> Empty ())) <*> unit));
+               (1, (pure Is_empty));
+               (1, (pure Append));
+               (1,
+                 (((pure (fun i_6 -> fun n_1 -> Sub (i_6, n_1))) <*> int) <*>
+                    int));
+               (1, (pure Copy));
+               (1,
+                 ((((pure
+                       (fun pos -> fun len -> fun x_4 -> Fill (pos, len, x_4)))
+                      <*> int)
+                     <*> int)
+                    <*> (elt char)));
+               (1,
+                 ((((pure
+                       (fun src_pos ->
+                          fun dst_pos ->
+                            fun len_1 -> Blit (src_pos, dst_pos, len_1)))
+                      <*> int)
+                     <*> int)
+                    <*> int))])
     let next_state cmd__004_ state__005_ =
       match cmd__004_ with
       | Push_back x ->

--- a/plugins/qcheck-stm/doc/index.mld
+++ b/plugins/qcheck-stm/doc/index.mld
@@ -173,7 +173,8 @@ The other information we can put in the configuration file are:
 {ul {li custom [QCheck] generators in a [Gen] module}
     {li custom [STM] printers in a [Pp] module}
     {li custom [STM.ty] extensions and its functional constructors in a [Ty]
-    module}}
+    module}
+    {li custom frequencies to be used by [QCheck] in a [Frequencies] module}}
 
 These additional information are mostly necessary when the tested library
 exposes other types than the one used as SUT.
@@ -196,6 +197,10 @@ https://ocaml-multicore.github.io/multicoretests/dev/qcheck-multicoretests-util/
 The [Ty] module should contain an [STM.ty] extension and a corresponding
 [STM.ty_show] smart constructor for each of these types. An ['a STM.ty_show] is
 a pair of an ['a ty] value and an ['a -> string] function.
+
+The [Frequencies] module should contain value declarations of the form [let
+<value_name> = <int literal>] where [<value_name>] is the name of a function
+from the interface file we want to test.
 
 Apart from the OCaml file, the configuration file and the output file, the other
 cli arguments available are:

--- a/plugins/qcheck-stm/src/config.ml
+++ b/plugins/qcheck-stm/src/config.ml
@@ -1,6 +1,7 @@
 open Gospel
 open Ortac_core
 open Ppxlib
+module FrequenciesMap = Map.Make (String)
 
 type config_under_construction = {
   sut_core_type' : Ppxlib.core_type option;
@@ -9,6 +10,7 @@ type config_under_construction = {
   pp_mod' : Ppxlib.structure option;
   ty_mod' : Ppxlib.structure option;
   cleanup' : Ppxlib.structure_item option;
+  frequencies' : int FrequenciesMap.t;
 }
 
 let config_under_construction =
@@ -18,6 +20,7 @@ let config_under_construction =
     gen_mod' = None;
     pp_mod' = None;
     ty_mod' = None;
+    frequencies' = FrequenciesMap.empty;
     cleanup' = None;
   }
 
@@ -30,6 +33,7 @@ type t = {
   pp_mod : Ppxlib.structure option; (* Containing custom pretty printers *)
   ty_mod : Ppxlib.structure option; (* Containing custom STM.ty extensions *)
   cleanup : Ppxlib.structure_item option;
+  frequencies : int FrequenciesMap.t;
   module_prefix : string option;
   submodule : string option;
   domain : bool;
@@ -51,6 +55,7 @@ let mk_config context module_prefix submodule domain count cfg_uc =
   and gen_mod = cfg_uc.gen_mod'
   and pp_mod = cfg_uc.pp_mod'
   and ty_mod = cfg_uc.ty_mod'
+  and frequencies = cfg_uc.frequencies'
   and cleanup = cfg_uc.cleanup' in
   ok
     {
@@ -61,6 +66,7 @@ let mk_config context module_prefix submodule domain count cfg_uc =
       gen_mod;
       pp_mod;
       ty_mod;
+      frequencies;
       cleanup;
       module_prefix;
       submodule;

--- a/plugins/qcheck-stm/src/config.ml
+++ b/plugins/qcheck-stm/src/config.ml
@@ -220,16 +220,22 @@ let module_binding cfg_uc (mb : Ppxlib.module_binding) =
       let destruct =
         pstr_value drop
           (value_binding ~pat:(ppat_var __') ~expr:(eint __) ^:: nil)
+      and error stri =
+        let loc = stri.pstr_loc in
+        error (Ill_formed_frequency, loc)
       in
       let aux acc stri =
-        parse destruct Location.none ~on_error:(Fun.const acc) stri
+        parse destruct Location.none
+          ~on_error:(Fun.const @@ error stri)
+          stri
           (fun name freq ->
-            {
-              acc with
-              frequencies' = FrequenciesMap.add name freq acc.frequencies';
-            })
+            ok
+              {
+                acc with
+                frequencies' = FrequenciesMap.add name freq acc.frequencies';
+              })
       in
-      ok @@ List.fold_left aux cfg_uc content
+      fold_left aux cfg_uc content
   | _ -> ok cfg_uc
 
 let scan_config cfg_uc config_mod =

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -313,6 +313,16 @@ let promote_map f =
   in
   aux
 
+let promote_map_ f =
+  let rec aux = function
+    | [] -> ok ()
+    | x :: xs -> (
+        match f x with
+        | Ok _, _ -> aux xs
+        | Error errs, ws -> warns ws >> filter_errs errs >> aux xs)
+  in
+  aux
+
 let promote_mapi f =
   let rec aux i = function
     | [] -> ok []

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -41,6 +41,7 @@ type W.kind +=
   | Type_not_supported of string
   | Type_not_supported_for_sut_parameter of string
   | Type_parameter_not_instantiated of string
+  | Unused_frequency of string
 
 let level kind =
   match kind with
@@ -49,7 +50,7 @@ let level kind =
   | Ghost_values _ | Impossible_term_substitution _ | Incompatible_type _
   | Incomplete_ret_val_computation _ | No_spec _ | Returning_nested_sut _
   | Sut_as_type_inst _ | Sut_in_tuple _ | Third_order_function_argument _
-  | Tuple_arity _ | Type_not_supported _ ->
+  | Tuple_arity _ | Type_not_supported _ | Unused_frequency _ ->
       W.Warning
   | Impossible_init_state_generation _ | Incompatible_sut _
   | Incomplete_configuration_module _ | No_configuration_file _
@@ -134,6 +135,8 @@ let pp_kind ppf kind =
      but in fact we support all the types that the Gospel type-checker supports,
      so that error message should never get reported to the end user *)
   | Type_not_supported ty -> pf ppf "Type %s not supported" ty
+  | Unused_frequency frequency ->
+      pf ppf "Unused frequency from configuration file: %s" frequency
   (* Errors *)
   | Impossible_init_state_generation (Mismatch_number_of_arguments fct) ->
       pf ppf "Error in INIT expression %s:@ %a" fct text

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -16,6 +16,7 @@ type W.kind +=
   | Function_arity of string
   | Functional_argument of string
   | Ghost_values of (string * [ `Arg | `Ret ])
+  | Ill_formed_frequency
   | Impossible_init_state_generation of init_state_error
   | Impossible_term_substitution of
       [ `Never | `New | `Old | `NotModel | `OutOfScope ]
@@ -47,10 +48,11 @@ let level kind =
   match kind with
   | Constant_value _ | Ensures_not_found_for_next_state _
   | Ensures_not_found_for_ret_sut _ | Function_arity _ | Functional_argument _
-  | Ghost_values _ | Impossible_term_substitution _ | Incompatible_type _
-  | Incomplete_ret_val_computation _ | No_spec _ | Returning_nested_sut _
-  | Sut_as_type_inst _ | Sut_in_tuple _ | Third_order_function_argument _
-  | Tuple_arity _ | Type_not_supported _ | Unused_frequency _ ->
+  | Ghost_values _ | Ill_formed_frequency | Impossible_term_substitution _
+  | Incompatible_type _ | Incomplete_ret_val_computation _ | No_spec _
+  | Returning_nested_sut _ | Sut_as_type_inst _ | Sut_in_tuple _
+  | Third_order_function_argument _ | Tuple_arity _ | Type_not_supported _
+  | Unused_frequency _ ->
       W.Warning
   | Impossible_init_state_generation _ | Incompatible_sut _
   | Incomplete_configuration_module _ | No_configuration_file _
@@ -93,6 +95,11 @@ let pp_kind ppf kind =
       pf ppf "Skipping %s:@ %a%a%a" id text "functions with a ghost " text
         (match k with `Arg -> "argument" | `Ret -> "returned value")
         text " are not supported"
+  | Ill_formed_frequency ->
+      pf ppf
+        "Ill formed frequency configuration is ignored.@\n\
+         Frequencies should be configured as follow:@\n\
+         @ @ let <function_name> = int litteral>"
   | Incompatible_type (v, t) ->
       pf ppf "Skipping %s:@ %a%s" v text
         "the type of its SUT-type argument is incompatible with the configured \

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -245,6 +245,8 @@ let ( let* ) x f =
   | (Error _, _) as x -> x
 
 let ( >>= ) = ( let* )
+let ( =<< ) f x = x >>= f
+let ( >> ) x f = x >>= Fun.const f
 
 let ( and* ) (a, aw) (b, bw) =
   let r =
@@ -344,6 +346,14 @@ let rec fold_left f acc = function
       | Error errs, ws ->
           let* _ = warns ws and* _ = filter_errs errs in
           fold_left f acc xs)
+
+let rec fold_right f xs acc =
+  match xs with
+  | [] -> ok acc
+  | x :: xs -> (
+      match fold_right f xs acc with
+      | (Ok _, _) as acc -> f x =<< acc
+      | Error errs, ws -> warns ws >> filter_errs errs >> f x acc)
 
 let of_option ~default = Option.fold ~none:(error default) ~some:ok
 let to_option = function Ok x, _ -> Some x | _ -> None

--- a/plugins/qcheck-stm/src/reserr.ml
+++ b/plugins/qcheck-stm/src/reserr.ml
@@ -343,9 +343,7 @@ let rec fold_left f acc = function
       | (Ok _, _) as acc ->
           let* acc = acc in
           fold_left f acc xs
-      | Error errs, ws ->
-          let* _ = warns ws and* _ = filter_errs errs in
-          fold_left f acc xs)
+      | Error errs, ws -> warns ws >> filter_errs errs >> fold_left f acc xs)
 
 let rec fold_right f xs acc =
   match xs with

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -76,6 +76,9 @@ val promote : 'a reserr list -> 'a list reserr
 val promote_map : ('a -> 'b reserr) -> 'a list -> 'b list reserr
 (** [promote_map f xs] is [List.map f xs |> promote] with only one traversal *)
 
+val promote_map_ : ('a -> 'b reserr) -> 'a list -> unit reserr
+(** [promote_map_ f xs] is [promote_map f xs] ignoring its result. *)
+
 val promote_mapi : (int -> 'a -> 'b reserr) -> 'a list -> 'b list reserr
 (** [promote_mapi f xs] is [List.mapi f xs |> promote] with only one traversal
 *)

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -16,6 +16,7 @@ type W.kind +=
   | Function_arity of string
   | Functional_argument of string
   | Ghost_values of (string * [ `Arg | `Ret ])
+  | Ill_formed_frequency
   | Impossible_init_state_generation of init_state_error
   | Impossible_term_substitution of
       [ `Never | `New | `Old | `NotModel | `OutOfScope ]

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -84,7 +84,13 @@ val promote_opt : 'a reserr -> 'a option reserr
 (** [promote_opt r] is [promote] for a unique value *)
 
 val fold_left : ('a -> 'b -> 'a reserr) -> 'a -> 'b list -> 'a reserr
+(** [fold_left f acc xs] is the monadic fold left. It works in a similar way
+    than [promote] wrt errors and warnins. *)
+
 val fold_right : ('b -> 'a -> 'a reserr) -> 'b list -> 'a -> 'a reserr
+(** [fold_right f xs acc] is the monadic fold right. It works in a similar way
+    than [promote] wrt errors and warnins. *)
+
 val of_option : default:W.t -> 'a option -> 'a reserr
 val to_option : 'a reserr -> 'a option
 val fmap : ('a -> 'b) -> 'a reserr -> 'b reserr

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -41,6 +41,7 @@ type W.kind +=
   | Type_not_supported of string
   | Type_not_supported_for_sut_parameter of string
   | Type_parameter_not_instantiated of string
+  | Unused_frequency of string
 
 type 'a reserr
 

--- a/plugins/qcheck-stm/src/reserr.mli
+++ b/plugins/qcheck-stm/src/reserr.mli
@@ -84,6 +84,7 @@ val promote_opt : 'a reserr -> 'a option reserr
 (** [promote_opt r] is [promote] for a unique value *)
 
 val fold_left : ('a -> 'b -> 'a reserr) -> 'a -> 'b list -> 'a reserr
+val fold_right : ('b -> 'a -> 'a reserr) -> 'b list -> 'a -> 'a reserr
 val of_option : default:W.t -> 'a option -> 'a reserr
 val to_option : 'a reserr -> 'a option
 val fmap : ('a -> 'b) -> 'a reserr -> 'b reserr

--- a/plugins/qcheck-stm/src/stm_of_ir.ml
+++ b/plugins/qcheck-stm/src/stm_of_ir.ml
@@ -416,8 +416,12 @@ let arb_cmd config ir =
     in
     ok @@ (freq_map, pexp_tuple [ eint freq; gen ] :: acc)
   in
-  let* _unused_freq, generators =
+  let* unused_freq, generators =
     fold_right aux ir.values (config.frequencies, [])
+  in
+  let* _ =
+    promote_map (fun (name, loc) -> error (Unused_frequency name, loc))
+    @@ Cfg.FrequenciesMap.unused unused_freq
   in
   let cmds = elist generators in
   let let_open str e =

--- a/plugins/qcheck-stm/test/all_warnings_config.ml
+++ b/plugins/qcheck-stm/test/all_warnings_config.ml
@@ -3,3 +3,9 @@ open All_warnings
 let init_sut = make 16 'a'
 
 type sut = char t
+
+module Frequencies = struct
+  let bob = 42
+  let lenght = bob
+  let constant = 42
+end

--- a/plugins/qcheck-stm/test/all_warnings_errors.expected
+++ b/plugins/qcheck-stm/test/all_warnings_errors.expected
@@ -1,3 +1,9 @@
+File "all_warnings_config.ml", line 9, characters 2-18:
+9 |   let lenght = bob
+      ^^^^^^^^^^^^^^^^
+Warning: Ill formed frequency configuration is ignored.
+         Frequencies should be configured as follow:
+           let <function_name> = int litteral>.
 File "all_warnings.mli", line 12, characters 0-52:
 12 | val constant : unit
 13 | (*@ constant
@@ -94,3 +100,11 @@ File "all_warnings.mli", line 59, characters 26-29:
                                ^^^
 Warning: Skipping clause: occurrences of the SUT in clauses are only
          supported to access its model fields.
+File "all_warnings_config.ml", line 8, characters 6-9:
+8 |   let bob = 42
+          ^^^
+Warning: Unused frequency from configuration file: bob.
+File "all_warnings_config.ml", line 10, characters 6-14:
+10 |   let constant = 42
+           ^^^^^^^^
+Warning: Unused frequency from configuration file: constant.

--- a/plugins/qcheck-stm/test/array_config.ml
+++ b/plugins/qcheck-stm/test/array_config.ml
@@ -7,3 +7,7 @@ type sut = char t
 module Gen = struct
   let int = small_signed_int
 end
+
+module Frequencies = struct
+  let make = 0
+end

--- a/plugins/qcheck-stm/test/array_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/array_stm_tests.expected.ml
@@ -141,7 +141,7 @@ module Spec =
                (1,
                  (((pure (fun i_1 -> fun a_1 -> Set (i_1, a_1))) <*> int) <*>
                     char));
-               (1,
+               (0,
                  (((pure (fun i_2 -> fun a_2 -> Make (i_2, a_2))) <*>
                      small_signed_int)
                     <*> char));

--- a/plugins/qcheck-stm/test/array_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/array_stm_tests.expected.ml
@@ -135,26 +135,31 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [pure Length;
-               (pure (fun i -> Get i)) <*> int;
-               ((pure (fun i_1 -> fun a_1 -> Set (i_1, a_1))) <*> int) <*>
-                 char;
-               ((pure (fun i_2 -> fun a_2 -> Make (i_2, a_2))) <*>
-                  small_signed_int)
-                 <*> char;
-               pure Append;
-               ((pure (fun i_3 -> fun n -> Sub (i_3, n))) <*> int) <*> int;
-               pure Copy;
-               (((pure (fun pos -> fun len -> fun x -> Fill (pos, len, x)))
-                   <*> int)
-                  <*> int)
-                 <*> char;
-               pure To_list;
-               (pure (fun l -> Of_list l)) <*> (list char);
-               (pure (fun a_3 -> Mem a_3)) <*> char;
-               (pure (fun p -> For_all p)) <*>
-                 (fun1 Observable.char QCheck.bool).gen])
+             frequency
+               [(1, (pure Length));
+               (1, ((pure (fun i -> Get i)) <*> int));
+               (1,
+                 (((pure (fun i_1 -> fun a_1 -> Set (i_1, a_1))) <*> int) <*>
+                    char));
+               (1,
+                 (((pure (fun i_2 -> fun a_2 -> Make (i_2, a_2))) <*>
+                     small_signed_int)
+                    <*> char));
+               (1, (pure Append));
+               (1,
+                 (((pure (fun i_3 -> fun n -> Sub (i_3, n))) <*> int) <*> int));
+               (1, (pure Copy));
+               (1,
+                 ((((pure (fun pos -> fun len -> fun x -> Fill (pos, len, x)))
+                      <*> int)
+                     <*> int)
+                    <*> char));
+               (1, (pure To_list));
+               (1, ((pure (fun l -> Of_list l)) <*> (list char)));
+               (1, ((pure (fun a_3 -> Mem a_3)) <*> char));
+               (1,
+                 ((pure (fun p -> For_all p)) <*>
+                    (fun1 Observable.char QCheck.bool).gen))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Length ->

--- a/plugins/qcheck-stm/test/atomic_tests.expected.ml
+++ b/plugins/qcheck-stm/test/atomic_tests.expected.ml
@@ -88,17 +88,18 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [(pure (fun v -> Make v)) <*> small_signed_int;
-               pure Get;
-               (pure (fun v_1 -> Set v_1)) <*> int;
-               (pure (fun v_2 -> Exchange v_2)) <*> int;
-               ((pure (fun seen -> fun v_3 -> Compare_and_set (seen, v_3)))
-                  <*> int)
-                 <*> int;
-               (pure (fun n -> Fetch_and_add n)) <*> int;
-               pure Incr;
-               pure Decr])
+             frequency
+               [(1, ((pure (fun v -> Make v)) <*> small_signed_int));
+               (1, (pure Get));
+               (1, ((pure (fun v_1 -> Set v_1)) <*> int));
+               (1, ((pure (fun v_2 -> Exchange v_2)) <*> int));
+               (1,
+                 (((pure (fun seen -> fun v_3 -> Compare_and_set (seen, v_3)))
+                     <*> int)
+                    <*> int));
+               (1, ((pure (fun n -> Fetch_and_add n)) <*> int));
+               (1, (pure Incr));
+               (1, (pure Decr))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Make v ->

--- a/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/conjunctive_clauses_stm_tests.expected.ml
@@ -73,12 +73,14 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [((pure (fun i -> fun a_1 -> Make (i, a_1))) <*>
-                   small_signed_int)
-                  <*> char;
-               ((pure (fun i_1 -> fun a_2 -> Set (i_1, a_2))) <*> int) <*>
-                 char])
+             frequency
+               [(1,
+                  (((pure (fun i -> fun a_1 -> Make (i, a_1))) <*>
+                      small_signed_int)
+                     <*> char));
+               (1,
+                 (((pure (fun i_1 -> fun a_2 -> Set (i_1, a_2))) <*> int) <*>
+                    char))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Make (i, a_1) ->

--- a/plugins/qcheck-stm/test/custom_config_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/custom_config_stm_tests.expected.ml
@@ -96,11 +96,11 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [(pure (fun __arg0 -> Proj __arg0)) <*> (elt char);
-               (pure (fun () -> Empty ())) <*> unit;
-               (pure (fun e -> Push e)) <*> (elt int);
-               pure Top])
+             frequency
+               [(1, ((pure (fun __arg0 -> Proj __arg0)) <*> (elt char)));
+               (1, ((pure (fun () -> Empty ())) <*> unit));
+               (1, ((pure (fun e -> Push e)) <*> (elt int)));
+               (1, (pure Top))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Proj __arg0 -> state__003_

--- a/plugins/qcheck-stm/test/function_args_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/function_args_stm_tests.expected.ml
@@ -100,12 +100,14 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [((pure (fun len -> fun c -> Make (len, c))) <*>
-                   small_signed_int)
-                  <*> char;
-               (pure (fun f -> Map f)) <*>
-                 (fun1 Observable.char QCheck.char).gen])
+             frequency
+               [(1,
+                  (((pure (fun len -> fun c -> Make (len, c))) <*>
+                      small_signed_int)
+                     <*> char));
+               (1,
+                 ((pure (fun f -> Map f)) <*>
+                    (fun1 Observable.char QCheck.char).gen))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Make (len, c) ->

--- a/plugins/qcheck-stm/test/functional_model_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/functional_model_stm_tests.expected.ml
@@ -68,10 +68,11 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [(pure (fun () -> Empty ())) <*> unit;
-               ((pure (fun a_1 -> fun b_1 -> Add (a_1, b_1))) <*> char) <*>
-                 int])
+             frequency
+               [(1, ((pure (fun () -> Empty ())) <*> unit));
+               (1,
+                 (((pure (fun a_1 -> fun b_1 -> Add (a_1, b_1))) <*> char)
+                    <*> int))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Empty () ->

--- a/plugins/qcheck-stm/test/ghost_as_model_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/ghost_as_model_stm_tests.expected.ml
@@ -67,7 +67,9 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof [(pure (fun () -> Create ())) <*> unit; pure Use])
+             frequency
+               [(1, ((pure (fun () -> Create ())) <*> unit));
+               (1, (pure Use))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Create () ->

--- a/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/hashtbl_stm_tests.expected.ml
@@ -139,26 +139,30 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [((pure (fun random -> fun size -> Create (random, size))) <*>
-                   bool)
-                  <*> small_signed_int;
-               pure Clear;
-               pure Reset;
-               pure Copy;
-               ((pure (fun a_1 -> fun b_1 -> Add (a_1, b_1))) <*> char) <*>
-                 int;
-               (pure (fun a_2 -> Find a_2)) <*> char;
-               (pure (fun a_3 -> Find_opt a_3)) <*> char;
-               (pure (fun a_4 -> Find_all a_4)) <*> char;
-               (pure (fun a_5 -> Mem a_5)) <*> char;
-               (pure (fun a_6 -> Remove a_6)) <*> char;
-               ((pure (fun a_7 -> fun b_2 -> Replace (a_7, b_2))) <*> char)
-                 <*> int;
-               (pure (fun f -> Filter_map_inplace f)) <*>
-                 (fun2 Observable.char Observable.int
-                    (QCheck.option QCheck.int)).gen;
-               pure Length])
+             frequency
+               [(1,
+                  (((pure (fun random -> fun size -> Create (random, size)))
+                      <*> bool)
+                     <*> small_signed_int));
+               (1, (pure Clear));
+               (1, (pure Reset));
+               (1, (pure Copy));
+               (1,
+                 (((pure (fun a_1 -> fun b_1 -> Add (a_1, b_1))) <*> char)
+                    <*> int));
+               (1, ((pure (fun a_2 -> Find a_2)) <*> char));
+               (1, ((pure (fun a_3 -> Find_opt a_3)) <*> char));
+               (1, ((pure (fun a_4 -> Find_all a_4)) <*> char));
+               (1, ((pure (fun a_5 -> Mem a_5)) <*> char));
+               (1, ((pure (fun a_6 -> Remove a_6)) <*> char));
+               (1,
+                 (((pure (fun a_7 -> fun b_2 -> Replace (a_7, b_2))) <*> char)
+                    <*> int));
+               (1,
+                 ((pure (fun f -> Filter_map_inplace f)) <*>
+                    (fun2 Observable.char Observable.int
+                       (QCheck.option QCheck.int)).gen));
+               (1, (pure Length))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Create (random, size) ->

--- a/plugins/qcheck-stm/test/integer_in_model_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/integer_in_model_stm_tests.expected.ml
@@ -65,7 +65,9 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof [(pure (fun () -> Create ())) <*> unit; pure Use])
+             frequency
+               [(1, ((pure (fun () -> Create ())) <*> unit));
+               (1, (pure Use))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Create () ->

--- a/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/invariants_stm_tests.expected.ml
@@ -74,12 +74,12 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [(pure (fun a_1 -> Create a_1)) <*> small_signed_int;
-               (pure (fun a_2 -> Push a_2)) <*> int;
-               pure Transfer;
-               pure Copy;
-               ((pure (fun i -> fun n -> Sub (i, n))) <*> int) <*> int])
+             frequency
+               [(1, ((pure (fun a_1 -> Create a_1)) <*> small_signed_int));
+               (1, ((pure (fun a_2 -> Push a_2)) <*> int));
+               (1, (pure Transfer));
+               (1, (pure Copy));
+               (1, (((pure (fun i -> fun n -> Sub (i, n))) <*> int) <*> int))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Create a_1 ->

--- a/plugins/qcheck-stm/test/module_prefix_tests.expected.ml
+++ b/plugins/qcheck-stm/test/module_prefix_tests.expected.ml
@@ -62,7 +62,8 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof [(pure (fun a_1 -> Make a_1)) <*> small_signed_int])
+             frequency
+               [(1, ((pure (fun a_1 -> Make a_1)) <*> small_signed_int))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Make a_1 ->

--- a/plugins/qcheck-stm/test/queue_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/queue_stm_tests.expected.ml
@@ -96,21 +96,21 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [(pure (fun () -> Create ())) <*> unit;
-               (pure (fun v -> Add v)) <*> int;
-               (pure (fun v_1 -> Push v_1)) <*> int;
-               pure Take;
-               pure Take_opt;
-               pure Pop;
-               pure Peek;
-               pure Top;
-               pure Peek_opt;
-               pure Clear;
-               pure Copy;
-               pure Is_empty;
-               pure Length;
-               pure Transfer])
+             frequency
+               [(1, ((pure (fun () -> Create ())) <*> unit));
+               (1, ((pure (fun v -> Add v)) <*> int));
+               (1, ((pure (fun v_1 -> Push v_1)) <*> int));
+               (1, (pure Take));
+               (1, (pure Take_opt));
+               (1, (pure Pop));
+               (1, (pure Peek));
+               (1, (pure Top));
+               (1, (pure Peek_opt));
+               (1, (pure Clear));
+               (1, (pure Copy));
+               (1, (pure Is_empty));
+               (1, (pure Length));
+               (1, (pure Transfer))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Create () ->

--- a/plugins/qcheck-stm/test/record_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/record_stm_tests.expected.ml
@@ -95,11 +95,11 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [(pure (fun i_1 -> Make i_1)) <*> small_signed_int;
-               (pure (fun i_2 -> Plus1 i_2)) <*> int;
-               (pure (fun i_3 -> Plus2 i_3)) <*> int;
-               pure Get])
+             frequency
+               [(1, ((pure (fun i_1 -> Make i_1)) <*> small_signed_int));
+               (1, ((pure (fun i_2 -> Plus1 i_2)) <*> int));
+               (1, ((pure (fun i_3 -> Plus2 i_3)) <*> int));
+               (1, (pure Get))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Make i_1 ->

--- a/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/ref_stm_tests.expected.ml
@@ -69,11 +69,11 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [(pure (fun v -> Make v)) <*> small_signed_int;
-               pure Get;
-               (pure (fun v_1 -> Set v_1)) <*> int;
-               pure Incr])
+             frequency
+               [(1, ((pure (fun v -> Make v)) <*> small_signed_int));
+               (1, (pure Get));
+               (1, ((pure (fun v_1 -> Set v_1)) <*> int));
+               (1, (pure Incr))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Make v ->

--- a/plugins/qcheck-stm/test/sequence_model_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/sequence_model_stm_tests.expected.ml
@@ -94,11 +94,11 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [(pure (fun () -> Create ())) <*> unit;
-               (pure (fun v -> Add v)) <*> char;
-               pure Remove;
-               pure Remove_])
+             frequency
+               [(1, ((pure (fun () -> Create ())) <*> unit));
+               (1, ((pure (fun v -> Add v)) <*> char));
+               (1, (pure Remove));
+               (1, (pure Remove_))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Create () ->

--- a/plugins/qcheck-stm/test/stack_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/stack_stm_tests.expected.ml
@@ -82,16 +82,16 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [(pure (fun () -> Create ())) <*> unit;
-               (pure (fun v -> Push v)) <*> char;
-               pure Pop;
-               pure Pop_opt;
-               pure Top;
-               pure Top_opt;
-               pure Clear;
-               pure Copy;
-               pure Is_empty])
+             frequency
+               [(1, ((pure (fun () -> Create ())) <*> unit));
+               (1, ((pure (fun v -> Push v)) <*> char));
+               (1, (pure Pop));
+               (1, (pure Pop_opt));
+               (1, (pure Top));
+               (1, (pure Top_opt));
+               (1, (pure Clear));
+               (1, (pure Copy));
+               (1, (pure Is_empty))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Create () ->

--- a/plugins/qcheck-stm/test/submodule_and_prefix_tests.expected.ml
+++ b/plugins/qcheck-stm/test/submodule_and_prefix_tests.expected.ml
@@ -62,7 +62,8 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof [(pure (fun a_1 -> Make a_1)) <*> small_signed_int])
+             frequency
+               [(1, ((pure (fun a_1 -> Make a_1)) <*> small_signed_int))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Make a_1 ->

--- a/plugins/qcheck-stm/test/submodule_tests.expected.ml
+++ b/plugins/qcheck-stm/test/submodule_tests.expected.ml
@@ -62,7 +62,8 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof [(pure (fun a_1 -> Make a_1)) <*> small_signed_int])
+             frequency
+               [(1, ((pure (fun a_1 -> Make a_1)) <*> small_signed_int))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Make a_1 ->

--- a/plugins/qcheck-stm/test/sut_in_type_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/sut_in_type_stm_tests.expected.ml
@@ -73,10 +73,11 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [((pure (fun i -> fun a_1 -> Make (i, a_1))) <*>
-                   small_signed_int)
-                  <*> small_signed_int])
+             frequency
+               [(1,
+                  (((pure (fun i -> fun a_1 -> Make (i, a_1))) <*>
+                      small_signed_int)
+                     <*> small_signed_int))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Make (i, a_1) ->

--- a/plugins/qcheck-stm/test/test_cleanup_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/test_cleanup_stm_tests.expected.ml
@@ -65,7 +65,9 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof [(pure (fun () -> Create ())) <*> unit; pure Use])
+             frequency
+               [(1, ((pure (fun () -> Create ())) <*> unit));
+               (1, (pure Use))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Create () ->

--- a/plugins/qcheck-stm/test/test_without_sut_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/test_without_sut_stm_tests.expected.ml
@@ -77,11 +77,13 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [((pure (fun i -> fun a_1 -> Make (i, a_1))) <*>
-                   small_signed_int)
-                  <*> small_signed_int;
-               ((pure (fun a_2 -> fun b -> Add (a_2, b))) <*> int) <*> int])
+             frequency
+               [(1,
+                  (((pure (fun i -> fun a_1 -> Make (i, a_1))) <*>
+                      small_signed_int)
+                     <*> small_signed_int));
+               (1,
+                 (((pure (fun a_2 -> fun b -> Add (a_2, b))) <*> int) <*> int))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Make (i, a_1) ->

--- a/plugins/qcheck-stm/test/tuples_stm_tests.expected.ml
+++ b/plugins/qcheck-stm/test/tuples_stm_tests.expected.ml
@@ -103,15 +103,17 @@ module Spec =
       let open QCheck in
         make ~print:show_cmd
           (let open Gen in
-             oneof
-               [(pure (fun () -> Create ())) <*> unit;
-               pure Clear;
-               (pure (fun tup -> Add tup)) <*> (tup2 char int);
-               (pure (fun tup_1 -> Add' tup_1)) <*> (tup3 bool char int);
-               (pure (fun tup_2 -> Add'' tup_2)) <*>
-                 (tup2 bool (tup2 char int));
-               pure Size_tup;
-               pure Size_tup'])
+             frequency
+               [(1, ((pure (fun () -> Create ())) <*> unit));
+               (1, (pure Clear));
+               (1, ((pure (fun tup -> Add tup)) <*> (tup2 char int)));
+               (1,
+                 ((pure (fun tup_1 -> Add' tup_1)) <*> (tup3 bool char int)));
+               (1,
+                 ((pure (fun tup_2 -> Add'' tup_2)) <*>
+                    (tup2 bool (tup2 char int))));
+               (1, (pure Size_tup));
+               (1, (pure Size_tup'))])
     let next_state cmd__002_ state__003_ =
       match cmd__002_ with
       | Create () ->


### PR DESCRIPTION
This PR proposes to allow the user to provide fequencies to be used in the generated `arb_cmd` function.

Closes #347

The user can define custom frequencies in a `Frequencies` module inside the configuration file.
The form of such definition is a value declaration of the form:

```ocaml
let of_list = 42
```

In the absence of a declared frequency, the default value is `1`.

We enforce that the value is an `int` **literal**, as we process the Parsertree of the configuration file.
A warning is emitted for every ill-formed frequency declaration.

A warning is also raised for every unused declared frequency (caused by a typo or the function being skipped for another reason).
